### PR TITLE
Integrate with HTML, part 1 of n

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,55 +1,319 @@
 <!doctype html><html lang="en">
  <head>
   <meta content="text/html; charset=utf-8" http-equiv="Content-Type">
+  <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport">
   <title>Referrer Policy</title>
-<style data-fill-with="stylesheet">/* This section copied from the W3C's ED styles. */
+<style data-fill-with="stylesheet">/******************************************************************************
+ *                   Style sheet for the W3C specifications                   *
+ *
+ * Special classes handled by this style sheet include:
+ *
+ * Indices
+ *   - .toc for the Table of Contents (<ol class="toc">)
+ *     + <span class="secno"> for the section numbers
+ *   - #toc for the Table of Contents (<nav id="toc">)
+ *   - ul.index for Indices (<a href="#ref">term</a><span>, in §N.M</span>)
+ *   - table.index for Index Tables (e.g. for properties or elements)
+ *
+ * Structural Markup
+ *   - table.data for general data tables
+ *     -> use 'scope' attribute, <colgroup>, <thead>, and <tbody> for best results !
+ *     -> use <table class='complex data'> for extra-complex tables
+ *     -> use <td class='long'> for paragraph-length cell content
+ *     -> use <td class='pre'> when manual line breaks/indentation would help readability
+ *   - dl.switch for switch statements
+ *   - ol.algorithm for algorithms (helps to visualize nesting)
+ *   - .figure and .caption (HTML4) and figure and figcaption (HTML5)
+ *     -> .sidefigure for right-floated figures
+ *   - ins/del
+ *
+ * Code
+ *   - pre and code
+ *
+ * Special Sections
+ *   - .note       for informative notes             (div, p, span, aside, details)
+ *   - .example    for informative examples          (div, p, pre, span)
+ *   - .issue      for issues                        (div, p, span)
+ *   - .advisement for loud normative statements     (div, p, strong)
+ *   - .annoying-warning for spec obsoletion notices (div, aside, details)
+ *
+ * Definition Boxes
+ *   - pre.def   for WebIDL definitions
+ *   - table.def for tables that define other entities (e.g. CSS properties)
+ *   - dl.def    for definition lists that define other entitles (e.g. HTML elements)
+ *
+ * Numbering
+ *   - .secno for section numbers in .toc and headings (<span class='secno'>3.2</span>)
+ *   - .marker for source-inserted example/figure/issue numbers (<span class='marker'>Issue 4</span>)
+ *   - ::before styled for CSS-generated issue/example/figure numbers:
+ *     -> Documents wishing to use this only need to add
+ *        figcaption::before,
+ *        .caption::before { content: "Figure "  counter(figure);  }
+ *        .example::before { content: "Example " counter(example); }
+ *        .issue::before   { content: "Issue "   counter(issue);   }
+ *
+ * Header Stuff (ignore, just don't conflict with these classes)
+ *   - .head for the header
+ *   - .copyright for the copyright
+ *
+ * Miscellaneous
+ *   - .overlarge for things that should be as wide as possible, even if
+ *     that overflows the body text area. This can be used on an item or
+ *     on its container, depending on the effect desired.
+ *     Note that this styling basically doesn't help at all when printing,
+ *     since A4 paper isn't much wider than the max-width here.
+ *     It's better to design things to fit into a narrower measure if possible.
+ *   - js-added ToC jump links (see fixup.js)
+ *
+ ******************************************************************************/
+
+/******************************************************************************/
+/*                                   Body                                     */
+/******************************************************************************/
 
 	body {
-		color: black;
+		counter-reset: example figure issue;
+
+		/* Layout */
+		max-width: 50em;               /* limit line length to 50em for readability   */
+		margin: 0 auto;                /* center text within page                     */
+		padding: 1.6em 1.5em 2em 50px; /* assume 16px font size for downlevel clients */
+		padding: 1.6em 1.5em 2em calc(26px + 1.5em); /* leave space for status flag     */
+
+		/* Typography */
+		line-height: 1.5;
 		font-family: sans-serif;
-		margin: 0 auto;
-		max-width: 50em;
-		padding: 2em 1em 2em 70px;
+		widows: 2;
+		orphans: 2;
+		word-wrap: break-word;
+		overflow-wrap: break-word;
+		hyphens: auto;
+
+		/* Colors */
+		color: black;
+		background: white top left fixed no-repeat;
+		background-size: 25px auto;
 	}
-	:link { color: #00C; background: transparent }
-	:visited { color: #609; background: transparent }
-	a[href]:active { color: #C00; background: transparent }
-	a[href]:hover { background: #ffa }
 
-	a[href] img { border-style: none }
 
-	h1, h2, h3, h4, h5, h6 { text-align: left }
-	h1, h2, h3 { color: #005A9C; }
-	h1 { font: 170% sans-serif }
-	h2 { font: 140% sans-serif }
-	h3 { font: 120% sans-serif }
-	h4 { font: bold 100% sans-serif }
-	h5 { font: italic 100% sans-serif }
-	h6 { font: small-caps 100% sans-serif }
+/******************************************************************************/
+/*                         Front Matter & Navigation                          */
+/******************************************************************************/
 
-	.hide { display: none }
+/** Header ********************************************************************/
 
 	div.head { margin-bottom: 1em }
-	div.head h1 { margin-top: 2em; clear: both }
-	div.head table { margin-left: 2em; margin-top: 2em }
+	div.head hr { border-style: solid; }
 
-	p.copyright { font-size: small }
-	p.copyright small { font-size: small }
-
-	pre { margin-left: 2em }
-	dt { font-weight: bold }
-
-	ul.toc, ol.toc {
-		list-style: none;
+	div.head h1 {
+		font-weight: bold;
+		margin: 0 0 .1em;
+		font-size: 220%;
 	}
 
-/* The rest copied from the CSSWG's default.css */
+	div.head h2 { margin-bottom: 1.5em;}
 
-	body {
-		counter-reset: exampleno figure issue;
-		max-width: 50em;
-		margin: 0 auto !important;
-		line-height: 1.5;
+/** W3C Logo ******************************************************************/
+
+	.head .logo {
+		float: right;
+		margin: 0.4rem 0 0.2rem .4rem;
+	}
+
+	.head img[src*="logos/W3C"] {
+		display: block;
+		border: solid #1a5e9a;
+		border-width: .65rem .7rem .6rem;
+		border-radius: .4rem;
+		background: #1a5e9a;
+		color: white;
+		font-weight: bold;
+	}
+
+	.head a:hover > img[src*="logos/W3C"],
+	.head a:focus > img[src*="logos/W3C"] {
+		opacity: .8;
+	}
+
+	.head a:active > img[src*="logos/W3C"] {
+		background: #c00;
+		border-color: #c00;
+	}
+
+	/* see also additional rules in Link Styling section */
+
+/** Copyright *****************************************************************/
+
+	p.copyright,
+	p.copyright small { font-size: small }
+
+/** Back to Top / ToC Toggle **************************************************/
+
+	@media print {
+		#toc-nav {
+			display: none;
+		}
+	}
+	@media not print {
+		#toc-nav {
+			position: fixed;
+			z-index: 2;
+			bottom: 0; left: 0;
+			margin: 0;
+			min-width: 1.33em;
+			border-top-right-radius: 2rem;
+			box-shadow: 0 0 2px;
+			font-size: 1.5em;
+			color: black;
+		}
+		#toc-nav > a {
+			display: block;
+			white-space: nowrap;
+
+			height: 1.33em;
+			padding: .1em 0.3em;
+			margin: 0;
+
+			background: white;
+			box-shadow: 0 0 2px;
+			border: none;
+			border-top-right-radius: 1.33em;
+			background: white;
+		}
+		#toc-nav > #toc-jump {
+			padding-bottom: 2em;
+			margin-bottom: -1.9em;
+		}
+
+		#toc-nav > a:hover,
+		#toc-nav > a:focus {
+			background: #f8f8f8;
+		}
+		#toc-nav > a:not(:hover):not(:focus) {
+			color: #707070;
+		}
+
+		/* statusbar gets in the way on keyboard focus; remove once browsers fix */
+		#toc-nav > a[href="#toc"]:not(:hover):focus:last-child {
+			padding-bottom: 1.5rem;
+		}
+
+		#toc-nav:not(:hover) > a:not(:focus) > span + span {
+			/* Ideally this uses :focus-within on #toc-nav */
+			display: none;
+		}
+		#toc-nav > a > span + span {
+			padding-right: 0.2em;
+		}
+
+		#toc-toggle-inline {
+			vertical-align: 0.05em;
+			font-size: 80%;
+			color: gray;
+			color: hsla(203,20%,40%,.7);
+			border-style: none;
+			background: transparent;
+			position: relative;
+		}
+		#toc-toggle-inline:hover:not(:active),
+		#toc-toggle-inline:focus:not(:active) {
+			text-shadow: 1px 1px silver;
+			top: -1px;
+			left: -1px;
+		}
+
+		#toc-nav :active {
+			color: #C00;
+		}
+	}
+
+/** ToC Sidebar ***************************************************************/
+
+	/* Floating sidebar */
+	@media screen {
+		body.toc-sidebar #toc {
+			position: fixed;
+			top: 0; bottom: 0;
+			left: 0;
+			width: 23.5em;
+			max-width: 80%;
+			max-width: calc(100% - 2em - 26px);
+			overflow: auto;
+			padding: 0 1em;
+			padding-left: 42px;
+			padding-left: calc(1em + 26px);
+			background: inherit;
+			background-color: #f7f8f9;
+			z-index: 1;
+			box-shadow: -.1em 0 .25em rgba(0,0,0,.1) inset;
+		}
+		body.toc-sidebar #toc h2 {
+			margin-top: .8rem;
+			font-variant: small-caps;
+			font-variant: all-small-caps;
+			text-transform: lowercase;
+			font-weight: bold;
+			color: gray;
+			color: hsla(203,20%,40%,.7);
+		}
+		body.toc-sidebar #toc-jump:not(:focus) {
+			width: 0;
+			height: 0;
+			padding: 0;
+			position: absolute;
+			overflow: hidden;
+		}
+	}
+	/* Hide main scroller when only the ToC is visible anyway */
+	@media screen and (max-width: 28em) {
+		body.toc-sidebar {
+			overflow: hidden;
+		}
+	}
+
+	/* Sidebar with its own space */
+	@media screen and (min-width: 78em) {
+		body:not(.toc-inline) #toc {
+			position: fixed;
+			top: 0; bottom: 0;
+			left: 0;
+			width: 23.5em;
+			overflow: auto;
+			padding: 0 1em;
+			padding-left: 42px;
+			padding-left: calc(1em + 26px);
+			background: inherit;
+			background-color: #f7f8f9;
+			z-index: 1;
+			box-shadow: -.1em 0 .25em rgba(0,0,0,.1) inset;
+		}
+		body:not(.toc-inline) #toc h2 {
+			margin-top: .8rem;
+			font-variant: small-caps;
+			font-variant: all-small-caps;
+			text-transform: lowercase;
+			font-weight: bold;
+			color: gray;
+			color: hsla(203,20%,40%,.7);
+		}
+
+		body:not(.toc-inline) {
+			padding-left: 29em;
+		}
+		/* See also Overflow section at the bottom */
+
+		body:not(.toc-inline) #toc-jump:not(:focus) {
+			width: 0;
+			height: 0;
+			padding: 0;
+			position: absolute;
+			overflow: hidden;
+		}
+	}
+	@media screen and (min-width: 90em) {
+		body:not(.toc-inline) {
+			margin: 0 4em;
+		}
 	}
 
 /******************************************************************************/
@@ -60,19 +324,34 @@
 
 	h1, h2, h3, h4, h5, h6, dt {
 		page-break-after: avoid;
+		page-break-inside: avoid;
+		font: 100% sans-serif;   /* Reset all font styling to clear out UA styles */
+		font-family: inherit;    /* Inherit the font family. */
+		line-height: 1.2;        /* Keep wrapped headings compact */
+		hyphens: manual;         /* Hyphenated headings look weird */
 	}
 
-	h2, h3, h5, h6 {
-		margin-top: 3em;
+	h2, h3, h4, h5, h6 {
+		margin-top: 3rem;
 	}
-	h4 {
-		 margin-top: 4em;
+
+	h1, h2, h3 {
+		color: #005A9C;
+		background: transparent;
 	}
+
+	h1 { font-size: 170%; }
+	h2 { font-size: 140%; }
+	h3 { font-size: 120%; }
+	h4 { font-weight: bold; }
+	h5 { font-style: italic; }
+	h6 { font-variant: small-caps; }
+	dt { font-weight: bold; }
 
 /** Subheadings ***************************************************************/
 
 	h1 + h2,
-	#subtitle + h2 {
+	#subtitle {
 		/* #subtitle is a subtitle in an H2 under the H1 */
 		margin-top: 0;
 	}
@@ -84,8 +363,8 @@
 	}
 
 /** Section divider ***********************************************************/
-	/* <hr> used to separate TMI into the second half of a section              */
-	hr:not([title]) {
+
+	:not(.head) > hr {
 		font-size: 1.5em;
 		text-align: center;
 		margin: 1em auto;
@@ -93,10 +372,9 @@
 		border: transparent solid 0;
 		background: transparent;
 	}
-	hr:not([title])::before {
-		content: "\1F411\2003\2003\1F411\2003\2003\1F411";
+	:not(.head) > hr::before {
+		content: "\2727\2003\2003\2727\2003\2003\2727";
 	}
-	/* note: <hr> with title separates document header from contents */
 
 /******************************************************************************/
 /*                            Paragraphs and Lists                            */
@@ -105,8 +383,9 @@
 	p {
 		margin: 1em 0;
 	}
-	dd     > p:first-child,
-	li     > p:first-child {
+
+	dd > p:first-child,
+	li > p:first-child {
 		margin-top: 0;
 	}
 
@@ -114,26 +393,23 @@
 		margin-left: 0;
 		padding-left: 2em;
 	}
+
 	li {
-		margin: 0.25em 2em 0.5em 0;
-		padding-left: 0;
+		margin: 0.25em 0 0.5em;
+		padding: 0;
 	}
 
 	dl dd {
-		margin: 0 0 1em 2em;
+		margin: 0 0 .5em 2em;
 	}
-	.head dd {
-		margin-bottom: 0;
+
+	.head dd + dd { /* compact for header */
+		margin-top: -.5em;
 	}
 
 	/* Style for algorithms */
-	ol.algorithm ol {
-	 border-left: 1px solid #90b8de;
-	 margin-left: 1em;
-	}
-	ol.algorithm ol.algorithm {
-	 border-left: none;
-	 margin-left: 0;
+	ol.algorithm ol:not(.algorithm) {
+	 border-left: 0.5em solid #DEF;
 	}
 
 	/* Style for switch/case <dl>s */
@@ -160,32 +436,6 @@
 	 width: 1em;
 	 text-align: right;
 	 line-height: 0.5em;
-	}
-
-	/* Style for paragraphs I know are in MD-genned lists */
-	[data-md] > :first-child {
-		margin-top: 0;
-	}
-	[data-md] > :last-child {
-		margin-bottom: 0;
-	}
-
-/** Inline Lists **************************************************************/
-	/* This is mostly to make the list inside the CR exit criteria more compact. */
-
-	ol.inline, ol.inline li {
-		display: inline;
-		padding: 0; margin: 0;
-	}
-	ol.inline {
-		counter-reset: list-item;
-	}
-	ol.inline li {
-		counter-increment: list-item;
-	}
-	ol.inline li::before {
-		content: "(" counter(list-item) ") ";
-		font-weight: bold;
 	}
 
 /** Terminology Markup ********************************************************/
@@ -227,129 +477,27 @@
 
 /** General monospace/pre rules ***********************************************/
 
-	pre, code {
-		font-family: Menlo, Consolas, "DejaVu Sans Mono", monospace;
+	pre, code, samp {
+		font-family: Menlo, Consolas, "DejaVu Sans Mono", Monaco, monospace;
 		font-size: .9em;
 		page-break-inside: avoid;
+		hyphens: none;
+		text-transform: none;
 	}
+	pre code,
+	code code {
+		font-size: 100%;
+	}
+
 	pre {
 		margin-top: 1em;
 		margin-bottom: 1em;
 		overflow: auto;
 	}
 
-/** Syntax-Highlighted Code ***************************************************/
+/** Inline Code fragments *****************************************************/
 
-	.example pre[class*="language-"],
-	.example [class*="language-"] pre,
-	.example pre[class*="lang-"],
-	.example [class*="lang-"] pre {
-		background: transparent; /* Prism applies a gray background that doesn't work well in the template. */
-	}
-
-/** Example Code **************************************************************/
-
-	div.html, div.xml,
-	pre.html, pre.xml {
-		padding: 0.5em;
-		margin: 1em 0;
-		position: relative;
-		clear: both;
-		color: #600;
-	}
-	pre.example,
-	pre.html,
-	pre.xml {
-		padding-top: 1.5em;
-	}
-
-	pre.illegal, .illegal pre
-	pre.deprecated, .deprecated pre {
-		color: red;
-	}
-
-/** IDL fragments *************************************************************/
-
-	pre.idl {
-		/* Match blue propdef boxes */
-		padding: .5em 1em;
-		background: #DEF;
-		margin: 1.2em 0;
-		border-left: 0.5em solid #8CCBF2;
-	}
-	pre.idl :link, pre.idl :visited {
-		color:inherit;
-		background:transparent;
-	}
-
-/** Inline CSS fragments ******************************************************/
-
-	.css.css, .property.property, .descriptor.descriptor {
-		color: #005a9c;
-		font-size: inherit;
-		font-family: inherit;
-	}
-	.css::before, .property::before, .descriptor::before {
-		content: "‘";
-	}
-	.css::after, .property::after, .descriptor::after {
-		content: "’";
-	}
-	.property, .descriptor {
-		/* Don't wrap property and descriptor names */
-		white-space: nowrap;
-	}
-	.type { /* CSS value <type> */
-	font-style: italic;
-	}
-	pre .property::before, pre .property::after {
-		content: "";
-	}
-
-/** Inline markup fragments ***************************************************/
-
-	code.html, code.xml {
-		color: #660000;
-	}
-
-/** Autolinks produced using Bikeshed *****************************************/
-
-	[data-link-type="property"]::before,
-	[data-link-type="propdesc"]::before,
-	[data-link-type="descriptor"]::before,
-	[data-link-type="value"]::before,
-	[data-link-type="function"]::before,
-	[data-link-type="at-rule"]::before,
-	[data-link-type="selector"]::before,
-	[data-link-type="maybe"]::before {
-		content: "‘";
-	}
-	[data-link-type="property"]::after,
-	[data-link-type="propdesc"]::after,
-	[data-link-type="descriptor"]::after,
-	[data-link-type="value"]::after,
-	[data-link-type="function"]::after,
-	[data-link-type="at-rule"]::after,
-	[data-link-type="selector"]::after,
-	[data-link-type="maybe"]::after {
-		content: "’";
-	}
-
-	[data-link-type].production::before,
-	[data-link-type].production::after,
-	.prod [data-link-type]::before,
-	.prod [data-link-type]::after {
-		content: "";
-	}
-
-	[data-link-type=element]         { font-family: monospace; }
-	[data-link-type=element]::before { content: "<" }
-	[data-link-type=element]::after  { content: ">" }
-
-	[data-link-type=biblio] {
-		white-space: pre;
-	}
-
+  /* Do something nice. */
 
 /******************************************************************************/
 /*                                    Links                                   */
@@ -358,75 +506,38 @@
 /** General Hyperlinks ********************************************************/
 
 	/* We hyperlink a lot, so make it less intrusive */
-	a:link, a:visited {
-		color: inherit;
+	a[href] {
+		color: #034575;
 		text-decoration: none;
-		border-bottom: 1px solid silver;
+		border-bottom: 1px solid #707070;
+		/* Need a bit of extending for it to look okay */
+		padding: 0 1px 0;
+		margin: 0 -1px 0;
 	}
-	@supports (text-decoration-color: silver) {
-		a:link, a:visited {
-			border-bottom: none;
-			text-decoration: underline;
-			text-decoration-color: silver;
-		}
-		a:visited {
-			text-decoration-style: dotted;
-		}
+	a:visited {
+		border-bottom-color: #BBB;
 	}
 
-	a.logo:link, a.logo:visited { /* backout above styling for W3C logo */
-		padding: 0;
+	/* Use distinguishing colors when user is interacting with the link */
+	a[href]:focus,
+	a[href]:hover {
+		background: #f8f8f8;
+		background: rgba(75%, 75%, 75%, .25);
+		border-bottom-width: 3px;
+		margin-bottom: -2px;
+	}
+	a[href]:active {
+		color: #C00;
+		border-color: #C00;
+	}
+
+	/* Backout above styling for W3C logo */
+	.head .logo,
+	.head .logo a {
 		border: none;
 		text-decoration: none;
+		background: transparent;
 	}
-
-/** Self-Links ****************************************************************/
-	/* Auto-generated links from an element to its own anchor, for usability */
-
-	.heading, .issue, .note, .example, li, dt {
-		position: relative;
-	}
-	a.self-link {
-		position: absolute;
-		top: 0;
-		left: -2.5em;
-		width: 2em;
-		height: 2em;
-		text-align: center;
-		border: none;
-		transition: opacity .2s;
-		opacity: .5;
-	}
-	a.self-link:hover {
-		opacity: 1;
-	}
-	.heading > a.self-link {
-		font-size: 83%;
-	}
-	li > a.self-link {
-		left: -3.5em;
-	}
-	dfn > a.self-link {
-		top: auto;
-		left: auto;
-		opacity: 0;
-		width: 1.5em;
-		height: 1.5em;
-		background: gray;
-		color: white;
-		font-style: normal;
-		transition: opacity .2s, background-color .2s, color .2s;
-	}
-	dfn:hover > a.self-link {
-		opacity: 1;
-	}
-	dfn > a.self-link:hover {
-		color: black;
-	}
-
-	a.self-link::before            { content: "¶"; }
-	.heading > a.self-link::before { content: "§"; }
-	dfn > a.self-link::before      { content: "#"; }
 
 /******************************************************************************/
 /*                                    Images                                  */
@@ -436,15 +547,21 @@
 		border-style: none;
 	}
 
-	figure, div.figure, div.sidefigure {
-		page-break-inside: avoid;
-	}
+	/* For autogen numbers, add
+	   .caption::before, figcaption::before { content: "Figure " counter(figure) ". "; }
+	*/
 
-	div.figure, p.figure, div.sidefigure, figure {
+	figure, .figure, .sidefigure {
+		page-break-inside: avoid;
 		text-align: center;
 		margin: 2.5em 0;
 	}
-	div.figure pre, div.sidefigure pre, figure pre {
+	.figure img,    .sidefigure img,    figure img,
+	.figure object, .sidefigure object, figure object {
+		max-width: 100%;
+		margin: auto;
+	}
+	.figure pre, .sidefigure pre, figure pre {
 		text-align: left;
 		display: table;
 		margin: 1em auto;
@@ -452,55 +569,32 @@
 	.figure table, figure table {
 		margin: auto;
 	}
-	div.sidefigure, figure.sidefigure {
-		float: right;
-		width: 50%;
-		margin: 0 0 0.5em 0.5em
+	@media screen and (min-width: 20em) {
+		.sidefigure {
+			float: right;
+			width: 50%;
+			margin: 0 0 0.5em 0.5em
+		}
 	}
-	div.figure img, div.sidefigure img, figure img,
-	div.figure object, div.sidefigure object, figure object {
-		display: block;
-		margin: auto;
-		max-width: 100%
-	}
-	p.caption, figcaption, caption {
-		text-align: center;
+	.caption, figcaption, caption {
 		font-style: italic;
 		font-size: 90%;
 	}
-	p.caption:not(.no-marker)::before, figcaption:not(.no-marker)::before {
-		content: "Figure " counter(figure) ". ";
-	}
-	p.caption::before, figcaption::before, figcaption > .marker {
+	.caption::before, figcaption::before, figcaption > .marker {
 		font-weight: bold;
 	}
-	p.caption, figcaption {
+	.caption, figcaption {
 		counter-increment: figure;
 	}
 
 	/* DL list is indented 2em, but figure inside it is not */
-	dd > div.figure, dd > figure { margin-left: -2em }
-
-	pre.ascii-art {
-		display: table; /* shrinkwrap */
-		margin: 1em auto;
-	}
-
-	/* Displaying the output of text layout, particularly when
-		 line-breaking is being invoked, and thus having a
-		 visible width is good. */
-	pre.output {
-		margin: 1em;
-		border: solid thin silver;
-		padding: 0.25em;
-		display: table;
-	}
+	dd > .figure, dd > figure { margin-left: -2em }
 
 /******************************************************************************/
 /*                             Colored Boxes                                  */
 /******************************************************************************/
 
-	.issue, .note, .example, .why, .advisement, blockquote {
+	.issue, .note, .example, .advisement, blockquote {
 		padding: .5em;
 		border: .5em;
 		border-left-style: solid;
@@ -511,10 +605,10 @@
 		border-right-style: solid;
 	}
 
-	div.issue,
-	div.note,
-	div.example,
-	details.why,
+	.issue,
+	.note,
+	.example,
+	.advisement,
 	blockquote {
 		margin: 1em auto;
 	}
@@ -534,7 +628,6 @@
 	}
 
 /** Open issue ****************************************************************/
-	/* not intended for CR+ publication */
 
 	.issue {
 		border-color: #E05252;
@@ -542,53 +635,57 @@
 		counter-increment: issue;
 		overflow: auto;
 	}
-	.issue:not(.no-marker)::before {
-		content: "ISSUE " counter(issue);
-		padding-right: 1em;
-	}
 	.issue::before, .issue > .marker {
+		text-transform: uppercase;
 		color: #AE1E1E;
+		padding-right: 1em;
+		text-transform: uppercase;
 	}
+	/* Add .issue::before { content: "Issue " counter(issue); } for autogen numbers,
+	   or use class="marker" to mark up the issue number in source. */
 
 /** Example *******************************************************************/
 
 	.example {
 		border-color: #E0CB52;
 		background: #FCFAEE;
-		counter-increment: exampleno;
+		counter-increment: example;
 		overflow: auto;
 		clear: both;
 	}
 	.example::before, .example > .marker {
+		text-transform: uppercase;
 		color: #827017;
-		font-family: sans-serif;
 		min-width: 7.5em;
 		display: block;
 	}
-	.example:not(.no-marker)::before {
-		content: "EXAMPLE";
-		content: "EXAMPLE " counter(exampleno);
-	}
-	.invalid.example::before, .invalid.example > .marker,
-	.illegal.example::before, .illegal.example > .marker {
-		color: red;
-	}
-	.invalid.example:not(.no-marker)::before,
-	.illegal.example:not(.no-marker)::before {
-		content: "INVALID EXAMPLE";
-		content: "INVALID EXAMPLE" counter(exampleno);
-	}
+	/* Add .example::before { content: "Example " counter(example); } for autogen numbers,
+	   or use class="marker" to mark up the example number in source. */
 
 /** Non-normative Note ********************************************************/
 
-	.note, .why {
+	.note {
 		border-color: #52E052;
 		background: #E9FBE9;
 		overflow: auto;
 	}
-	.note::before, .note > .marker {
+
+	.note::before, .note > .marker,
+	details.note > summary::before,
+	details.note > summary > .marker {
+		text-transform: uppercase;
 		display: block;
 		color: hsl(120, 70%, 30%);
+	}
+	/* Add .note::before { content: "Note"; } for autogen label,
+	   or use class="marker" to mark up the label in source. */
+
+	details.note > summary {
+		display: block;
+		color: hsl(120, 70%, 30%);
+	}
+	details.note[open] > summary {
+		border-bottom: 1px silver solid;
 	}
 
 /** Advisement Box ************************************************************/
@@ -598,46 +695,40 @@
 		border-color: orange;
 		border-style: none solid;
 		background: #FFEECC;
-		text-align: center;
 	}
 	strong.advisement {
 		display: block;
+		text-align: center;
 	}
-	/*.advisement::before { color: #FF8800; } */
-
-/** ??? ***********************************************************************/
-
-	details.why {
-		border-color: #52E052;
-		background: #E9FBE9;
-		display: block;
-	}
-
-	details.why > summary {
-		font-style: italic;
-		display: block;
-	}
-
-	details.why[open] > summary {
-		border-bottom: 1px silver solid;
+	.advisement > .marker {
+		color: #B35F00;
 	}
 
 /** Spec Obsoletion Notice ****************************************************/
 	/* obnoxious obsoletion notice for older/abandoned specs. */
 
-	details.annoying-warning {
+	details {
 		display: block;
 	}
+	summary {
+		font-weight: bolder;
+	}
 
+	.annoying-warning:not(details),
+	details.annoying-warning:not([open]) > summary,
 	details.annoying-warning[open] {
 		background: #fdd;
 		color: red;
 		font-weight: bold;
-		text-align: center;
-		padding: .5em;
-		border: thick solid red;
+		padding: .75em 1em;
+		border: thick red;
+		border-style: solid;
 		border-radius: 1em;
 	}
+	.annoying-warning :last-child {
+		margin-bottom: 0;
+	}
+
 @media not print {
 	details.annoying-warning[open] {
 		position: fixed;
@@ -649,57 +740,52 @@
 }
 
 	details.annoying-warning:not([open]) > summary {
-		background: #fdd;
-		color: red;
-		font-weight: bold;
 		text-align: center;
-		padding: .5em;
+	}
+
+/** Entity Definition Boxes ***************************************************/
+
+	.def {
+		padding: .5em 1em;
+		background: #DEF;
+		margin: 1.2em 0;
+		border-left: 0.5em solid #8CCBF2;
 	}
 
 /******************************************************************************/
 /*                                    Tables                                  */
 /******************************************************************************/
 
+	th, td {
+		text-align: left;
+		text-align: start;
+	}
+
 /** Property/Descriptor Definition Tables *************************************/
 
-	table.propdef, table.propdef-extra,
-	table.descdef, table.definition-table {
-		page-break-inside: avoid;
+	table.def {
+		/* inherits .def box styling, see above */
 		width: 100%;
-		margin: 1.2em 0;
-		border-left: 0.5em solid #8CCBF2;
-		padding: 0.5em 1em;
-		background: #DEF;
 		border-spacing: 0;
 	}
 
-	table.propdef td, table.propdef-extra td,
-	table.descdef td, table.definition-table td,
-	table.propdef th, table.propdef-extra th,
-	table.descdef th, table.definition-table th {
+	table.def td,
+	table.def th {
 		padding: 0.5em;
 		vertical-align: baseline;
 		border-bottom: 1px solid #bbd7e9;
 	}
-	table.propdef > tbody > tr:last-child th,
-	table.propdef-extra > tbody > tr:last-child th,
-	table.descdef > tbody > tr:last-child th,
-	table.definition-table > tbody > tr:last-child th,
-	table.propdef > tbody > tr:last-child td,
-	table.propdef-extra > tbody > tr:last-child td,
-	table.descdef > tbody > tr:last-child td,
-	table.definition-table > tbody > tr:last-child td {
+
+	table.def > tbody > tr:last-child th,
+	table.def > tbody > tr:last-child td {
 		border-bottom: 0;
 	}
 
-	table.propdef th,
-	table.propdef-extra th,
-	table.descdef th,
-	table.definition-table th {
+	table.def th {
 		font-style: italic;
 		font-weight: normal;
-		width: 8.3em;
 		padding-left: 1em;
+		width: 3em;
 	}
 
 	/* For when values are extra-complex and need formatting for readability */
@@ -707,17 +793,11 @@
 		white-space: pre-wrap;
 	}
 
-	/* A footnote at the bottom of a propdef */
-	table.propdef td.footnote,
-	table.propdef-extra td.footnote,
-	table.descdef td.footnote,
-	table.definition-table td.footnote {
+	/* A footnote at the bottom of a def table */
+	table.def           td.footnote {
 		padding-top: 0.6em;
 	}
-	table.propdef td.footnote::before,
-	table.propdef-extra td.footnote::before,
-	table.descdef td.footnote::before,
-	table.definition-table td.footnote::before {
+	table.def           td.footnote::before {
 		content: " ";
 		display: block;
 		height: 0.6em;
@@ -725,22 +805,7 @@
 		border-top: thin solid;
 	}
 
-/** Profile Tables ************************************************************/
-	/* table of required features in a CSS profile */
-
-	table.features th {
-		background: #00589f;
-		color: #fff;
-		text-align: left;
-		padding: 0.2em 0.2em 0.2em 0.5em;
-	}
-	table.features td {
-		vertical-align: top;
-		border-bottom: 1px solid #ccc;
-		padding: 0.3em 0.3em 0.3em 0.7em;
-	}
-
-/** Data tables (and properly marked-up proptables) ***************************/
+/** Data tables (and properly marked-up index tables) *************************/
 	/*
 		 <table class="data"> highlights structural relationships in a table
 		 when correct markup is used (e.g. thead/tbody, th vs. td, scope attribute)
@@ -750,89 +815,117 @@
 
 		 Use class="long" on table cells with paragraph-like contents
 		 (This will adjust text alignment accordingly.)
+		 Alternately use class="longlastcol" on tables, to have the last column assume "long".
 	*/
 
-	.data, .proptable {
-		margin: 1em auto;
-		border-collapse: collapse;
-		width: 100%;
-		border: hidden;
-	}
-	.data {
-		text-align: center;
-		width: auto;
-	}
-	.data caption {
-		width: 100%;
+	table {
+		word-wrap: normal;
+		overflow-wrap: normal;
+		hyphens: manual;
 	}
 
-	.data td, .data th,
-	.proptable td, .proptable th {
-		padding: 0.5em;
+	table.data,
+	table.index {
+		margin: 1em auto;
+		border-collapse: collapse;
+		border: hidden;
+		width: 100%;
+	}
+	table.data caption,
+	table.index caption {
+		max-width: 50em;
+		margin: 0 auto 1em;
+	}
+
+	table.data td,  table.data th,
+	table.index td, table.index th {
+		padding: 0.5em 1em;
 		border-width: 1px;
 		border-color: silver;
 		border-top-style: solid;
 	}
 
-	.data thead td:empty {
+	table.data thead td:empty {
 		padding: 0;
 		border: 0;
 	}
 
-	.data thead th[scope="row"],
-	.proptable thead th[scope="row"] {
-		text-align: right;
-		color: inherit;
-	}
-
-	.data thead,
-	.proptable thead,
-	.data tbody,
-	.proptable tbody {
-		color: inherit;
+	table.data  thead,
+	table.index thead,
+	table.data  tbody,
+	table.index tbody {
 		border-bottom: 2px solid;
 	}
 
-	.data colgroup {
+	table.data colgroup,
+	table.index colgroup {
 		border-left: 2px solid;
 	}
 
-	.data tbody th:first-child,
-	.proptable tbody th:first-child ,
-	.data tbody td[scope="row"]:first-child,
-	.proptable tbody td[scope="row"]:first-child {
-		text-align: right;
-		color: inherit;
+	table.data  tbody th:first-child,
+	table.index tbody th:first-child  {
 		border-right: 2px solid;
 		border-top: 1px solid silver;
 		padding-right: 1em;
 	}
-	.data.define td:last-child {
-		text-align: left;
+
+	table.data th[colspan],
+	table.data td[colspan] {
+		text-align: center;
 	}
 
-	.data tbody th[rowspan],
-	.proptable tbody th[rowspan],
-	.data tbody td[rowspan],
-	.proptable tbody td[rowspan]{
-		border-left:  1px solid silver;
-		border-right: 1px solid silver;
-	}
-
-	.complex.data th,
-	.complex.data td {
+	table.complex.data th,
+	table.complex.data td {
 		border: 1px solid silver;
+		text-align: center;
 	}
 
-	.data td.long {
+	table.data.longlastcol td:last-child,
+	table.data td.long {
 	 vertical-align: baseline;
 	 text-align: left;
 	}
 
-	.data img {
+	table.data img {
 		vertical-align: middle;
 	}
 
+
+/*
+Alternate table alignment rules
+
+	table.data,
+	table.index {
+		text-align: center;
+	}
+
+	table.data  thead th[scope="row"],
+	table.index thead th[scope="row"] {
+		text-align: right;
+	}
+
+	table.data  tbody th:first-child,
+	table.index tbody th:first-child  {
+		text-align: right;
+	}
+
+Possible extra rowspan handling
+
+	table.data  tbody th[rowspan]:not([rowspan='1']),
+	table.index tbody th[rowspan]:not([rowspan='1']),
+	table.data  tbody td[rowspan]:not([rowspan='1']),
+	table.index tbody td[rowspan]:not([rowspan='1']) {
+		border-left: 1px solid silver;
+	}
+
+	table.data  tbody th[rowspan]:first-child,
+	table.index tbody th[rowspan]:first-child,
+	table.data  tbody td[rowspan]:first-child,
+	table.index tbody td[rowspan]:first-child{
+		border-left: 0;
+		border-right: 1px solid silver;
+	}
+*/
 
 /******************************************************************************/
 /*                                  Indices                                   */
@@ -841,97 +934,117 @@
 
 /** Table of Contents *********************************************************/
 
-	/* ToC not indented, but font style shows hierarchy */
-	ul.toc           { margin: 1em 0;     font-weight: bold; /*text-transform: uppercase;*/ }
-	ul.toc ul        { margin: 0;        font-weight: normal; text-transform: none; }
-	ul.toc ul ul     { margin: 0 0 0 2em; font-style: italic; }
-	ul.toc ul ul ul  { margin: 0; }
-	ul.toc > li      { margin: 1.5em 0; }
-	ul.toc ul.toc li { margin: 0.3em 0 0 0; }
-
-	ul.toc, ul.toc ul, ul.toc li { padding: 0; line-height: 1.3; }
-	ul.toc a { text-decoration: none; border-bottom-style: none; }
-	ul.toc a:hover, ul.toc a:focus  { border-bottom-style: solid; }
-	@supports (text-decoration-style: solid) {
-		ul.toc a:hover, ul.toc a:focus  {
-			border-bottom-style: none;
-			text-decoration-style: solid;
-		}
+	.toc a {
+		/* More spacing; use padding to make it part of the click target. */
+		padding-top: 0.1rem;
+		/* Larger, more consistently-sized click target */
+		display: block;
+		/* Reverse color scheme */
+		color: black;
+		border-color: #3980B5;
 	}
-	/*
-	ul.toc li li li, ul.toc li li li ul {margin-left: 0; display: inline}
-	ul.toc li li li ul, ul.toc li li li ul li {margin-left: 0; display: inline}
-	*/
+	.toc a:visited {
+		border-color: #054572;
+	}
+	.toc a:not(:focus):not(:hover) {
+		/* Allow colors to cascade through from link styling */
+		border-bottom-color: transparent;
+	}
+
+	.toc, .toc ol, .toc ul, .toc li {
+		list-style: none; /* Numbers must be inlined into source */
+		/* because generated content isn't search/selectable and markers can't do multilevel yet */
+		margin:  0;
+		padding: 0;
+		line-height: 1.1rem; /* consistent spacing */
+	}
+
+	/* ToC not indented until third level, but font style & margins show hierarchy */
+	.toc > li             { font-weight: bold;   }
+	.toc > li li          { font-weight: normal; }
+	.toc > li li li       { font-style:  italic; }
+	.toc > li li li li    { font-style:  normal; }
+	.toc > li li li li li { font-style:  italic;
+	                        font-size:   85%;    }
+
+	.toc > li             { margin: 1.5rem 0;    }
+	.toc > li li          { margin: 0.3rem 0;    }
+	.toc > li li li       { margin-left: 2rem;   }
 
 	/* Section numbers in a column of their own */
-	ul.toc {
-		margin-left: 5em
-	}
-	ul.toc span.secno {
+	.toc .secno {
 		float: left;
-		width: 4em;
-		margin-left: -5em;
+		width: 4rem;
+		white-space: nowrap;
 	}
-	ul.toc ul ul span.secno {
-		margin-left: -7em;
+	.toc > li li li li .secno {
+		font-size: 85%;
 	}
-	/*ul.toc span.secno {text-align: right}*/
-	ul.toc li {
+	.toc > li li li li li .secno {
+		font-size: 100%;
+	}
+
+	:not(li) > .toc              { margin-left:  5rem; }
+	.toc .secno                  { margin-left: -5rem; }
+	.toc > li li li .secno       { margin-left: -7rem; }
+	.toc > li li li li .secno    { margin-left: -9rem; }
+	.toc > li li li li li .secno { margin-left: -11rem; }
+
+	/* Tighten up indentation in narrow ToCs */
+	@media (max-width: 30em) {
+		:not(li) > .toc              { margin-left:  4rem; }
+		.toc .secno                  { margin-left: -4rem; }
+		.toc > li li li              { margin-left:  1rem; }
+		.toc > li li li .secno       { margin-left: -5rem; }
+		.toc > li li li li .secno    { margin-left: -6rem; }
+		.toc > li li li li li .secno { margin-left: -7rem; }
+	}
+	@media screen and (min-width: 78em) {
+		body:not(.toc-inline) :not(li) > .toc              { margin-left:  4rem; }
+		body:not(.toc-inline) .toc .secno                  { margin-left: -4rem; }
+		body:not(.toc-inline) .toc > li li li              { margin-left:  1rem; }
+		body:not(.toc-inline) .toc > li li li .secno       { margin-left: -5rem; }
+		body:not(.toc-inline) .toc > li li li li .secno    { margin-left: -6rem; }
+		body:not(.toc-inline) .toc > li li li li li .secno { margin-left: -7rem; }
+	}
+	body.toc-sidebar #toc :not(li) > .toc              { margin-left:  4rem; }
+	body.toc-sidebar #toc .toc .secno                  { margin-left: -4rem; }
+	body.toc-sidebar #toc .toc > li li li              { margin-left:  1rem; }
+	body.toc-sidebar #toc .toc > li li li .secno       { margin-left: -5rem; }
+	body.toc-sidebar #toc .toc > li li li li .secno    { margin-left: -6rem; }
+	body.toc-sidebar #toc .toc > li li li li li .secno { margin-left: -7rem; }
+
+	.toc li {
 		clear: both;
 	}
-	/* If we had 'tab', floats would not be needed here:
-		 ul.toc span.secno {tab: 5em right; margin-right: 1em}
-		 ul.toc li {text-indent: 5em hanging}
-	 The second line in case items wrap
-	*/
 
-/** At-risk List **************************************************************/
-	/* Style for At Risk features (intended as editorial aid, not intended for publishing) */
-
-	.atrisk::before {
-	 float: right;
-	 margin-top: -0.25em;
-	 padding: 0.5em 1em 0.5em 0;
-	 text-indent: -0.9em;
-	 border: 1px solid;
-	 content: '\25C0    Not yet widely implemented';
-	 white-space: pre;
-	 font-size: small;
-	 background-color: white;
-	 color: gray;
-	 text-align: center;
-	}
-
-	.toc .atrisk::before { content:none }
 
 /** Index *********************************************************************/
 
 	/* Index Lists: Layout */
-	ul.indexlist       { margin-left: 0; columns: 15em; -webkit-columns: 15em; text-indent: 1em hanging; }
-	ul.indexlist li    { margin-left: 0; list-style: none; break-inside: avoid; word-break: break-word; }
-	ul.indexlist li li { margin-left: 1em }
-	ul.indexlist dl    { margin-top: 0; }
-	ul.indexlist dt    { margin: .2em 0 .2em 20px;}
-	ul.indexlist dd    { margin: .2em 0 .2em 40px;}
+	ul.index       { margin-left: 0; columns: 15em; text-indent: 1em hanging; }
+	ul.index li    { margin-left: 0; list-style: none; break-inside: avoid; }
+	ul.index li li { margin-left: 1em }
+	ul.index dl    { margin-top: 0; }
+	ul.index dt    { margin: .2em 0 .2em 20px;}
+	ul.index dd    { margin: .2em 0 .2em 40px;}
 	/* Index Lists: Typography */
-	ul.indexlist ul,
-	ul.indexlist dl { font-size: smaller; }
-	ul.indexlist li span {
-		white-space: nowrap;
-		position: absolute;
-		color: transparent; }
-	ul.indexlist li a:hover + span,
-	ul.indexlist li a:focus + span {
-		color: gray;
-	}
-	@media print {
-		ul.indexlist li span { color: gray; }
+	ul.index ul,
+	ul.index dl { font-size: smaller; }
+	@media not print {
+		ul.index li span {
+			white-space: nowrap;
+			color: transparent; }
+		ul.index li a:hover + span,
+		ul.index li a:focus + span {
+			color: #707070;
+		}
 	}
 
-/** Property Index Tables *****************************************************/
+/** Index Tables *****************************************************/
 	/* See also the data table styling section, which this effectively subclasses */
 
-	table.proptable {
+	table.index {
 		font-size: small;
 		border-collapse: collapse;
 		border-spacing: 0;
@@ -939,34 +1052,19 @@
 		margin: 1em 0;
 	}
 
-	table.proptable td,
-	table.proptable th {
+	table.index td,
+	table.index th {
 		padding: 0.4em;
-		text-align: center;
 	}
 
-	table.proptable tr:hover td {
-		background: #DEF;
+	table.index tr:hover td:not([rowspan]),
+	table.index tr:hover th:not([rowspan]) {
+		background: #f7f8f9;
 	}
-	.propdef th {
-		font-style: italic;
-		font-weight: normal;
-		text-align: left;
-		width: 3em;
-	}
+
 	/* The link in the first column in the property table (formerly a TD) */
-	table.proptable td .property,
-	table.proptable th .property {
-		display: block;
-		text-align: left;
+	table.index th:first-child a {
 		font-weight: bold;
-	}
-
-/** Extra-large Elements ******************************************************/
-
-	.big-element-wrapper {
-		max-width: 50em;
-		overflow-x: auto;
 	}
 
 /******************************************************************************/
@@ -974,38 +1072,263 @@
 /******************************************************************************/
 
 	@media print {
+		/* Pages have their own margins. */
 		html {
-			margin: 0 !important; }
+			margin: 0;
+		}
+		/* Serif for print. */
 		body {
-			font-family: serif; }
-		th, td {
-			font-family: inherit; }
-		a {
-			color: inherit !important; }
-
-		a:link, a:visited {
-			text-decoration: none !important }
-		a:link::after, a:visited::after { /* create a cross-ref "see..." */ }
-		.example::before {
-			font-family: serif !important; }
+			font-family: serif;
+		}
 	}
 	@page {
 		margin: 1.5cm 1.1cm;
 	}
 
+/******************************************************************************/
+/*                                    Legacy                                  */
+/******************************************************************************/
+
+	/* This rule is inherited from past style sheets. No idea what it's for. */
+	.hide { display: none }
+
+
+
+/******************************************************************************/
+/*                             Overflow Control                               */
+/******************************************************************************/
+
+	.figure .caption, .sidefigure .caption, figcaption {
+		/* in case figure is overlarge, limit caption to 50em */
+		max-width: 50rem;
+		margin-left: auto;
+		margin-right: auto;
+	}
+	.overlarge > table {
+		/* limit preferred width of table */
+		max-width: 50em;
+		margin-left: auto;
+		margin-right: auto;
+	}
+
+	@media (min-width: 55em) {
+		.overlarge {
+			margin-left: calc(13px + 26.5rem - 50vw);
+			margin-right: calc(13px + 26.5rem - 50vw);
+			max-width: none;
+		}
+	}
+	@media screen and (min-width: 78em) {
+		body:not(.toc-inline) .overlarge {
+			/* 30.5em body padding 50em content area */
+			margin-left: calc(40em - 50vw) !important;
+			margin-right: calc(40em - 50vw) !important;
+		}
+	}
+	@media screen and (min-width: 90em) {
+		body:not(.toc-inline) .overlarge {
+			/* 4em html margin 30.5em body padding 50em content area */
+			margin-left: 0 !important;
+			margin-right: calc(84.5em - 100vw) !important;
+		}
+	}
+
+	@media not print {
+		.overlarge {
+			overflow-x: auto;
+			/* See Lea Verou's explanation background-attachment:
+			 * http://lea.verou.me/2012/04/background-attachment-local/
+			 *
+			background: top left  / 4em 100% linear-gradient(to right,  #ffffff, rgba(255, 255, 255, 0)) local,
+			            top right / 4em 100% linear-gradient(to left, #ffffff, rgba(255, 255, 255, 0)) local,
+			            top left  / 1em 100% linear-gradient(to right,  #c3c3c5, rgba(195, 195, 197, 0)) scroll,
+			            top right / 1em 100% linear-gradient(to left, #c3c3c5, rgba(195, 195, 197, 0)) scroll,
+			            white;
+			background-repeat: no-repeat;
+			*/
+		}
+	}
 </style>
   <meta content="Bikeshed 1.0.0" name="generator">
- </head>
+<style>/* style-md-lists */
+
+            /* This is a weird hack for me not yet following the commonmark spec
+               regarding paragraph and lists. */
+            [data-md] > :first-child {
+                margin-top: 0;
+            }
+            [data-md] > :last-child {
+                margin-bottom: 0;
+            }</style>
+<style>/* style-counters */
+
+            .issue:not(.no-marker)::before {
+                content: "Issue " counter(issue);
+            }
+
+            .example:not(.no-marker)::before {
+                content: "Example";
+                content: "Example " counter(example);
+            }
+            .invalid.example:not(.no-marker)::before,
+            .illegal.example:not(.no-marker)::before {
+                content: "Invalid Example";
+                content: "Invalid Example" counter(example);
+            }</style>
+<style>/* style-dfn-panel */
+
+        .dfn-panel {
+            display: inline-block;
+            position: absolute;
+            z-index: 35;
+            height: auto;
+            width: -webkit-fit-content;
+            max-width: 300px;
+            max-height: 500px;
+            overflow: auto;
+            padding: 0.5em 0.75em;
+            font: small Helvetica Neue, sans-serif, Droid Sans Fallback;
+            background: #DDDDDD;
+            color: black;
+            border: outset 0.2em;
+        }
+        .dfn-panel:not(.on) { display: none; }
+        .dfn-panel * { margin: 0; padding: 0; text-indent: 0; }
+        .dfn-panel > b { display: block; }
+        .dfn-panel a { color: black; }
+        .dfn-panel a:not(:hover) { text-decoration: none !important; border-bottom: none !important; }
+        .dfn-panel > b + b { margin-top: 0.25em; }
+        .dfn-panel > span { display: list-item; list-style: inside; }
+        .dfn-panel.activated {
+            display: inline-block;
+            position: fixed;
+            left: .5em;
+            bottom: .5em;
+            margin: 0 auto;
+            max-width: calc(100vw - 1.5em - .4em - .5em);
+            max-height: 30vh;
+        }
+
+        .dfn-paneled { cursor: pointer; }
+        </style>
+<style>/* style-selflinks */
+
+            .heading, .issue, .note, .example, li, dt {
+                position: relative;
+            }
+            a.self-link {
+                position: absolute;
+                top: 0;
+                left: calc(-1 * (3.5rem - 26px));
+                width: calc(3.5rem - 26px);
+                height: 2em;
+                text-align: center;
+                border: none;
+                transition: opacity .2s;
+                opacity: .5;
+            }
+            a.self-link:hover {
+                opacity: 1;
+            }
+            .heading > a.self-link {
+                font-size: 83%;
+            }
+            li > a.self-link {
+                left: calc(-1 * (3.5rem - 26px) - 2em);
+            }
+            dfn > a.self-link {
+                top: auto;
+                left: auto;
+                opacity: 0;
+                width: 1.5em;
+                height: 1.5em;
+                background: gray;
+                color: white;
+                font-style: normal;
+                transition: opacity .2s, background-color .2s, color .2s;
+            }
+            dfn:hover > a.self-link {
+                opacity: 1;
+            }
+            dfn > a.self-link:hover {
+                color: black;
+            }
+
+            a.self-link::before            { content: "¶"; }
+            .heading > a.self-link::before { content: "§"; }
+            dfn > a.self-link::before      { content: "#"; }</style>
+<style>/* style-autolinks */
+
+            .css.css, .property.property, .descriptor.descriptor {
+                color: #005a9c;
+                font-size: inherit;
+                font-family: inherit;
+            }
+            .css::before, .property::before, .descriptor::before {
+                content: "‘";
+            }
+            .css::after, .property::after, .descriptor::after {
+                content: "’";
+            }
+            .property, .descriptor {
+                /* Don't wrap property and descriptor names */
+                white-space: nowrap;
+            }
+            .type { /* CSS value <type> */
+                font-style: italic;
+            }
+            pre .property::before, pre .property::after {
+                content: "";
+            }
+            [data-link-type="property"]::before,
+            [data-link-type="propdesc"]::before,
+            [data-link-type="descriptor"]::before,
+            [data-link-type="value"]::before,
+            [data-link-type="function"]::before,
+            [data-link-type="at-rule"]::before,
+            [data-link-type="selector"]::before,
+            [data-link-type="maybe"]::before {
+                content: "‘";
+            }
+            [data-link-type="property"]::after,
+            [data-link-type="propdesc"]::after,
+            [data-link-type="descriptor"]::after,
+            [data-link-type="value"]::after,
+            [data-link-type="function"]::after,
+            [data-link-type="at-rule"]::after,
+            [data-link-type="selector"]::after,
+            [data-link-type="maybe"]::after {
+                content: "’";
+            }
+
+            [data-link-type].production::before,
+            [data-link-type].production::after,
+            .prod [data-link-type]::before,
+            .prod [data-link-type]::after {
+                content: "";
+            }
+
+            [data-link-type=element],
+            [data-link-type=element-attr] {
+                font-family: Menlo, Consolas, "DejaVu Sans Mono", monospace;
+                font-size: .9em;
+            }
+            [data-link-type=element]::before { content: "<" }
+            [data-link-type=element]::after  { content: ">" }
+
+            [data-link-type=biblio] {
+                white-space: pre;
+            }</style>
  <body class="h-entry">
   <div class="head">
-   <p data-fill-with="logo"><a class="logo" href="http://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/Icons/w3c_home" width="72"> </a> </p>
+   <p data-fill-with="logo"><a class="logo" href="http://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Referrer Policy</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2016-04-28">28 April 2016</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2016-05-02">2 May 2016</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
      <dd><a class="u-url" href="https://w3c.github.io/webappsec-referrer-policy/">https://w3c.github.io/webappsec-referrer-policy/</a>
-     <dt>Latest version:
+     <dt>Latest published version:
      <dd><a href="http://www.w3.org/TR/referrer-policy/">http://www.w3.org/TR/referrer-policy/</a>
      <dt>Version History:
      <dd><a href="https://github.com/w3c/webappsec-referrer-policy/commits/master/index.src.html">https://github.com/w3c/webappsec-referrer-policy/commits/master/index.src.html</a>
@@ -1013,6 +1336,7 @@
      <dd><span><a href="mailto:public-webappsec@w3.org?subject=%5BREFERRER%5D%20YOUR%20TOPIC%20HERE">public-webappsec@w3.org</a> with subject line “<kbd>[REFERRER] <i data-lt="">… message topic …</i></kbd>” (<a href="http://lists.w3.org/Archives/Public/public-webappsec/" rel="discussion">archives</a>)</span>
      <dt>Issue Tracking:
      <dd><a href="https://github.com/w3c/webappsec-referrer-policy/issues/">GitHub</a>
+     <dd><a href="#issues-index">Inline In Spec</a>
      <dt class="editor">Editors:
      <dd class="editor p-author h-card vcard"><a class="p-name fn u-email email" href="mailto:eisinger@google.com">Jochen Eisinger</a> (<span class="p-org org">Google Inc.</span>)
      <dd class="editor p-author h-card vcard"><a class="p-name fn u-email email" href="mailto:estark@google.com">Emily Stark</a> (<span class="p-org org">Google Inc.</span>)
@@ -1049,131 +1373,101 @@
    <p></p>
   </div>
   <div data-fill-with="at-risk"></div>
-  <h2 class="no-num no-toc no-ref heading settled" id="contents"><span class="content">Table of Contents</span></h2>
-  <div data-fill-with="table-of-contents" role="navigation">
-   <ul class="toc" role="directory">
+  <nav data-fill-with="table-of-contents" id="toc">
+   <h2 class="no-num no-toc no-ref" id="contents">Table of Contents</h2>
+   <ol class="toc" role="directory">
     <li>
      <a href="#intro"><span class="secno">1</span> <span class="content">Introduction</span></a>
-     <ul class="toc">
+     <ol class="toc">
       <li><a href="#intro-privacy"><span class="secno">1.1</span> <span class="content">Privacy</span></a>
       <li><a href="#intro-security"><span class="secno">1.2</span> <span class="content">Security</span></a>
       <li><a href="#intro-trackback"><span class="secno">1.3</span> <span class="content">Trackback</span></a>
-     </ul>
+     </ol>
     <li><a href="#terms"><span class="secno">2</span> <span class="content">Key Concepts and Terminology</span></a>
     <li>
      <a href="#referrer-policy-states"><span class="secno">3</span> <span class="content">Referrer Policy States</span></a>
-     <ul class="toc">
+     <ol class="toc">
       <li><a href="#referrer-policy-state-no-referrer"><span class="secno">3.1</span> <span class="content">No Referrer</span></a>
       <li><a href="#referrer-policy-state-no-referrer-when-downgrade"><span class="secno">3.2</span> <span class="content">No Referrer When Downgrade</span></a>
       <li><a href="#referrer-policy-state-origin"><span class="secno">3.3</span> <span class="content">Origin Only</span></a>
       <li><a href="#referrer-policy-state-origin-when-cross-origin"><span class="secno">3.4</span> <span class="content">Origin When Cross-Origin</span></a>
       <li><a href="#referrer-policy-state-unsafe-url"><span class="secno">3.5</span> <span class="content">Unsafe URL</span></a>
-     </ul>
+     </ol>
     <li>
      <a href="#referrer-policy-delivery"><span class="secno">4</span> <span class="content">Referrer Policy Delivery</span></a>
-     <ul class="toc">
+     <ol class="toc">
       <li>
        <a href="#referrer-policy-header"><span class="secno">4.1</span> <span class="content">Delivery via Referrer-Policy header</span></a>
-       <ul class="toc">
+       <ol class="toc">
         <li><a href="#referrer-usage"><span class="secno">4.1.1</span> <span class="content">Usage</span></a>
-       </ul>
+       </ol>
       <li><a href="#referrer-policy-delivery-meta"><span class="secno">4.2</span> <span class="content">Delivery via <code><span>meta</span></code></span></a>
       <li><a href="#referrer-policy-delivery-referrer-attribute"><span class="secno">4.3</span> <span class="content">Delivery
   via a <code>referrerpolicy</code> content attribute</span></a>
       <li>
        <a href="#referrer-policy-delivery-implicit"><span class="secno">4.4</span> <span class="content">Implicit Delivery</span></a>
-       <ul class="toc">
+       <ol class="toc">
         <li><a href="#referrer-policy-delivery-implicit-nested"><span class="secno">4.4.1</span> <span class="content"> Nested Browsing Contexts </span></a>
         <li><a href="#referrer-policy-delivery-implicit-workers"><span class="secno">4.4.2</span> <span class="content"> Workers </span></a>
-       </ul>
-     </ul>
+       </ol>
+     </ol>
+    <li><a href="#integration-with-fetch"><span class="secno">5</span> <span class="content">Integration with Fetch</span></a>
+    <li><a href="#integration-with-html"><span class="secno">6</span> <span class="content">Integration with HTML</span></a>
     <li>
-     <a href="#element-interface-extensions"><span class="secno">5</span> <span class="content">Element interface extensions</span></a>
-     <ul class="toc">
-      <li>
-       <a href="#html-anchor-element"><span class="secno">5.1</span> <span class="content">HTMLAnchorElement</span></a>
-       <ul class="toc">
-        <li><a href="#html-anchor-element-attributes"><span class="secno">5.1.1</span> <span class="content">Attributes</span></a>
-       </ul>
-      <li>
-       <a href="#html-area-element"><span class="secno">5.2</span> <span class="content">HTMLAreaElement</span></a>
-       <ul class="toc">
-        <li><a href="#html-area-element-attributes"><span class="secno">5.2.1</span> <span class="content">Attributes</span></a>
-       </ul>
-      <li>
-       <a href="#html-image-element"><span class="secno">5.3</span> <span class="content">HTMLImageElement</span></a>
-       <ul class="toc">
-        <li><a href="#html-image-element-attributes"><span class="secno">5.3.1</span> <span class="content">Attributes</span></a>
-       </ul>
-      <li>
-       <a href="#html-iframe-element"><span class="secno">5.4</span> <span class="content">HTMLIFrameElement</span></a>
-       <ul class="toc">
-        <li><a href="#html-iframe-element-attributes"><span class="secno">5.4.1</span> <span class="content">Attributes</span></a>
-       </ul>
-      <li>
-       <a href="#html-link-element"><span class="secno">5.5</span> <span class="content">HTMLLinkElement</span></a>
-       <ul class="toc">
-        <li><a href="#html-link-element-attributes"><span class="secno">5.5.1</span> <span class="content">Attributes</span></a>
-       </ul>
-     </ul>
-    <li><a href="#integration-with-fetch"><span class="secno">6</span> <span class="content">Integration with Fetch</span></a>
-    <li><a href="#integration-with-html"><span class="secno">7</span> <span class="content">Integration with HTML</span></a>
+     <a href="#algorithms"><span class="secno">7</span> <span class="content">Algorithms</span></a>
+     <ol class="toc">
+      <li><a href="#parse-referrer-policy-from-header"><span class="secno">7.1</span> <span class="content"> Parse a referrer policy from a <span><code>Referrer-Policy</code></span> header </span></a>
+      <li><a href="#set-referrer-policy"><span class="secno">7.2</span> <span class="content"> Set <var>environment</var>’s referrer policy to <var>policy</var> </span></a>
+      <li><a href="#set-requests-referrer-policy-on-redirect"><span class="secno">7.3</span> <span class="content"> Set <var>request</var>’s referrer policy on redirect </span></a>
+      <li><a href="#determine-requests-referrer"><span class="secno">7.4</span> <span class="content"> Determine <var>request</var>’s Referrer </span></a>
+      <li><a href="#strip-url"><span class="secno">7.5</span> <span class="content"> Strip <var>url</var> for use as a referrer </span></a>
+      <li><a href="#determine-policy-for-token"><span class="secno">7.6</span> <span class="content"> Determine <var>token</var>’s Policy </span></a>
+     </ol>
     <li>
-     <a href="#algorithms"><span class="secno">8</span> <span class="content">Algorithms</span></a>
-     <ul class="toc">
-      <li><a href="#parse-referrer-policy-from-header"><span class="secno">8.1</span> <span class="content"> Parse a referrer policy from a <span><code>Referrer-Policy</code></span> header </span></a>
-      <li><a href="#set-referrer-policy"><span class="secno">8.2</span> <span class="content"> Set <var>environment</var>’s referrer policy to <var>policy</var> </span></a>
-      <li><a href="#set-requests-referrer-policy-on-redirect"><span class="secno">8.3</span> <span class="content"> Set <var>request</var>’s referrer policy on redirect </span></a>
-      <li><a href="#determine-requests-referrer"><span class="secno">8.4</span> <span class="content"> Determine <var>request</var>’s Referrer </span></a>
-      <li><a href="#strip-url"><span class="secno">8.5</span> <span class="content"> Strip <var>url</var> for use as a referrer </span></a>
-      <li><a href="#determine-policy-for-token"><span class="secno">8.6</span> <span class="content"> Determine <var>token</var>’s Policy </span></a>
-     </ul>
+     <a href="#privacy"><span class="secno">8</span> <span class="content">Privacy Considerations</span></a>
+     <ol class="toc">
+      <li><a href="#user-controls"><span class="secno">8.1</span> <span class="content">User Controls</span></a>
+     </ol>
     <li>
-     <a href="#privacy"><span class="secno">9</span> <span class="content">Privacy Considerations</span></a>
-     <ul class="toc">
-      <li><a href="#user-controls"><span class="secno">9.1</span> <span class="content">User Controls</span></a>
-     </ul>
+     <a href="#security"><span class="secno">9</span> <span class="content">Security Considerations</span></a>
+     <ol class="toc">
+      <li><a href="#information-leakage"><span class="secno">9.1</span> <span class="content">Information Leakage</span></a>
+      <li><a href="#downgrade"><span class="secno">9.2</span> <span class="content">Downgrade to less strict policies</span></a>
+     </ol>
     <li>
-     <a href="#security"><span class="secno">10</span> <span class="content">Security Considerations</span></a>
-     <ul class="toc">
-      <li><a href="#information-leakage"><span class="secno">10.1</span> <span class="content">Information Leakage</span></a>
-      <li><a href="#downgrade"><span class="secno">10.2</span> <span class="content">Downgrade to less strict policies</span></a>
-     </ul>
-    <li>
-     <a href="#authoring"><span class="secno">11</span> <span class="content">Authoring Considerations</span></a>
-     <ul class="toc">
-      <li><a href="#unknown-policy-values"><span class="secno">11.1</span> <span class="content">Unknown Policy Values</span></a>
-     </ul>
-    <li><a href="#acknowledgements"><span class="secno">12</span> <span class="content">Acknowledgements</span></a>
+     <a href="#authoring"><span class="secno">10</span> <span class="content">Authoring Considerations</span></a>
+     <ol class="toc">
+      <li><a href="#unknown-policy-values"><span class="secno">10.1</span> <span class="content">Unknown Policy Values</span></a>
+     </ol>
+    <li><a href="#acknowledgements"><span class="secno">11</span> <span class="content">Acknowledgements</span></a>
     <li>
      <a href="#conformance"><span class="secno"></span> <span class="content">Conformance</span></a>
-     <ul class="toc">
+     <ol class="toc">
       <li><a href="#conventions"><span class="secno"></span> <span class="content">Document conventions</span></a>
       <li><a href="#conformant-algorithms"><span class="secno"></span> <span class="content">Conformant Algorithms</span></a>
-     </ul>
+     </ol>
     <li>
      <a href="#index"><span class="secno"></span> <span class="content">Index</span></a>
-     <ul class="toc">
+     <ol class="toc">
       <li><a href="#index-defined-here"><span class="secno"></span> <span class="content">Terms defined by this specification</span></a>
       <li><a href="#index-defined-elsewhere"><span class="secno"></span> <span class="content">Terms defined by reference</span></a>
-     </ul>
+     </ol>
     <li>
      <a href="#references"><span class="secno"></span> <span class="content">References</span></a>
-     <ul class="toc">
+     <ol class="toc">
       <li><a href="#normative"><span class="secno"></span> <span class="content">Normative References</span></a>
       <li><a href="#informative"><span class="secno"></span> <span class="content">Informative References</span></a>
-     </ul>
-    <li><a href="#idl-index"><span class="secno"></span> <span class="content">IDL Index</span></a>
+     </ol>
     <li><a href="#issues-index"><span class="secno"></span> <span class="content">Issues Index</span></a>
-   </ul>
-  </div>
+   </ol>
+  </nav>
   <main>
    <section>
     <h2 class="heading settled" data-level="1" id="intro"><span class="secno">1. </span><span class="content">Introduction</span><a class="self-link" href="#intro"></a></h2>
     <p><em>This section is not normative.</em></p>
     <p>Requests made from a document, and for navigations away from that document
   are associated with a <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc7231#section-5.5.2"><code>Referer</code></a> header. While the header
-  can be suppressed for links with the <a data-link-type="dfn" href="http://www.w3.org/TR/html5/links.html#link-type-noreferrer"><code>noreferrer</code></a> link
+  can be suppressed for links with the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/semantics.html#link-type-noreferrer"><code>noreferrer</code></a> link
   type, authors might wish to control the <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc7231#section-5.5.2"><code>Referer</code></a> header
   more directly for a number of reasons:</p>
     <h3 class="heading settled" data-level="1.1" id="intro-privacy"><span class="secno">1.1. </span><span class="content">Privacy</span><a class="self-link" href="#intro-privacy"></a></h3>
@@ -1201,42 +1495,55 @@
    <section>
     <h2 class="heading settled" data-level="2" id="terms"><span class="secno">2. </span><span class="content">Key Concepts and Terminology</span><a class="self-link" href="#terms"></a></h2>
     <dl>
-     <dt> <dfn data-dfn-type="dfn" data-export="" data-local-lt="policy" id="referrer-policy">referrer policy<a class="self-link" href="#referrer-policy"></a></dfn> 
+     <dt> <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" data-local-lt="policy" data-lt="referrer policy" id="referrer-policy">referrer policy<span class="dfn-panel" data-deco=""><b><a href="#referrer-policy">#referrer-policy</a></b><b>Referenced in:</b><span><a href="#ref-for-referrer-policy-1">3. Referrer Policy States</a> <a href="#ref-for-referrer-policy-2">(2)</a></span><span><a href="#ref-for-referrer-policy-3">4. Referrer Policy Delivery</a></span><span><a href="#ref-for-referrer-policy-4">4.2. Delivery via meta</a></span><span><a href="#ref-for-referrer-policy-5">4.4. Implicit Delivery</a></span><span><a href="#ref-for-referrer-policy-6">4.4.1. 
+     Nested Browsing Contexts </a></span><span><a href="#ref-for-referrer-policy-7">7.1. 
+    Parse a referrer policy from a Referrer-Policy header </a></span><span><a href="#ref-for-referrer-policy-8">7.2. 
+    Set environment’s referrer policy to policy </a></span><span><a href="#ref-for-referrer-policy-9">7.3. 
+    Set request’s referrer policy on redirect </a></span><span><a href="#ref-for-referrer-policy-10">7.4. 
+    Determine request’s Referrer </a> <a href="#ref-for-referrer-policy-11">(2)</a></span><span><a href="#ref-for-referrer-policy-12">7.6. 
+    Determine token’s Policy </a></span><span><a href="#ref-for-referrer-policy-13">8.1. User Controls</a></span></span></dfn> 
      <dd>
-       A <strong>referrer policy</strong> is a property of a <a data-link-type="dfn" href="http://www.w3.org/TR/html5/webappapis.html#settings-object">settings
+       A <strong>referrer policy</strong> is a property of a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#settings-object">settings
       object</a> that defines the algorithm used to populate the <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc7231#section-5.5.2"><code>Referer</code></a> header when <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#fetching">fetching</a> subresources,
       prefetching, or performing navigations. 
-      <p>If no referrer policy is explicitly set for a <a data-link-type="dfn" href="http://www.w3.org/TR/html5/webappapis.html#settings-object">settings object</a>,
+      <p>If no referrer policy is explicitly set for a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#settings-object">settings object</a>,
       then the value of the property is the empty string. Otherwise, the value
-      is whatever has been explicitly set, as explained in the <a href="#set-referrer-policy">§8.2 Set environment’s referrer policy to policy</a> algorithm.</p>
-     <dt><dfn data-dfn-type="dfn" data-local-lt="same-origin" data-noexport="" id="same-origin-request">same-origin request<a class="self-link" href="#same-origin-request"></a></dfn>
+      is whatever has been explicitly set, as explained in the <a href="#set-referrer-policy">§7.2 Set environment’s referrer policy to policy</a> algorithm.</p>
+     <dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-local-lt="same-origin" data-lt="same-origin request" data-noexport="" id="same-origin-request">same-origin request<span class="dfn-panel" data-deco=""><b><a href="#same-origin-request">#same-origin-request</a></b><b>Referenced in:</b><span><a href="#ref-for-same-origin-request-1">2. Key Concepts and Terminology</a></span><span><a href="#ref-for-same-origin-request-2">3.3. Origin Only</a></span><span><a href="#ref-for-same-origin-request-3">3.4. Origin When Cross-Origin</a></span><span><a href="#ref-for-same-origin-request-4">3.5. Unsafe URL</a></span></span></dfn>
      <dd> A <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#request">Request</a></code> <var>request</var> is a <strong>same-origin request</strong> if <var>request</var>’s <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#concept-request-origin">origin</a></code> and the <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc6454#section-3.2">origin</a> of <var>request</var>’s <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#concept-request-url">url</a></code> are <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc6454#section-5"><code>the same</code></a>. 
-     <dt><dfn data-dfn-type="dfn" data-local-lt="cross-origin" data-noexport="" id="cross-origin-request">cross-origin request<a class="self-link" href="#cross-origin-request"></a></dfn>
-     <dd> A <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#request">Request</a></code> is a <strong>cross-origin request</strong> if it is <em>not</em> <a data-link-type="dfn" href="#same-origin-request">same-origin</a>. 
+     <dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-local-lt="cross-origin" data-lt="cross-origin request" data-noexport="" id="cross-origin-request">cross-origin request<span class="dfn-panel" data-deco=""><b><a href="#cross-origin-request">#cross-origin-request</a></b><b>Referenced in:</b><span><a href="#ref-for-cross-origin-request-1">3.3. Origin Only</a></span><span><a href="#ref-for-cross-origin-request-2">3.4. Origin When Cross-Origin</a> <a href="#ref-for-cross-origin-request-3">(2)</a></span><span><a href="#ref-for-cross-origin-request-4">3.5. Unsafe URL</a></span><span><a href="#ref-for-cross-origin-request-5">7.4. 
+    Determine request’s Referrer </a></span></span></dfn>
+     <dd> A <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#request">Request</a></code> is a <strong>cross-origin request</strong> if it is <em>not</em> <a data-link-type="dfn" href="#same-origin-request" id="ref-for-same-origin-request-1">same-origin</a>. 
     </dl>
    </section>
    <section>
     <h2 class="heading settled" data-level="3" id="referrer-policy-states"><span class="secno">3. </span><span class="content">Referrer Policy States</span><a class="self-link" href="#referrer-policy-states"></a></h2>
-    <p>Every <a data-link-type="dfn" href="http://www.w3.org/TR/html5/webappapis.html#settings-object">settings object</a> has a <a data-link-type="dfn" href="#referrer-policy">referrer policy</a> which governs
+    <p>Every <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#settings-object">settings object</a> has a <a data-link-type="dfn" href="#referrer-policy" id="ref-for-referrer-policy-1">referrer policy</a> which governs
   the referrer information sent along with requests made for subresources, and
-  for navigations. The <a data-link-type="dfn" href="#referrer-policy">policy</a> will be the empty string if no policy has
-  been set, otherwise it will be one of the following five values: <code><a data-link-type="dfn" href="#no-referrer">No Referrer</a></code>, <code><a data-link-type="dfn" href="#no-referrer-when-downgrade">No Referrer When
-  Downgrade</a></code>, <code><a data-link-type="dfn" href="#origin-only">Origin Only</a></code>, <code><a data-link-type="dfn" href="#origin-when-cross-origin">Origin When
-  Cross-origin</a></code>, and <code><a data-link-type="dfn" href="#unsafe-url">Unsafe URL</a></code>. Each is explained
-  below, and a detailed algorithm for evaluating their effect is given in the <a href="#integration-with-fetch">§6 Integration with Fetch</a> and <a href="#algorithms">§8 Algorithms</a> sections:</p>
-    <p class="note" role="note">Note: The referrer policy for a <a data-link-type="dfn" href="http://www.w3.org/TR/html5/webappapis.html#settings-object">settings object</a> provides a default
+  for navigations. The <a data-link-type="dfn" href="#referrer-policy" id="ref-for-referrer-policy-2">policy</a> will be the empty string if no policy has
+  been set, otherwise it will be one of the following five values: <code><a data-link-type="dfn" href="#no-referrer" id="ref-for-no-referrer-1">No Referrer</a></code>, <code><a data-link-type="dfn" href="#no-referrer-when-downgrade" id="ref-for-no-referrer-when-downgrade-1">No Referrer When
+  Downgrade</a></code>, <code><a data-link-type="dfn" href="#origin-only" id="ref-for-origin-only-1">Origin Only</a></code>, <code><a data-link-type="dfn" href="#origin-when-cross-origin" id="ref-for-origin-when-cross-origin-1">Origin When
+  Cross-origin</a></code>, and <code><a data-link-type="dfn" href="#unsafe-url" id="ref-for-unsafe-url-1">Unsafe URL</a></code>. Each is explained
+  below, and a detailed algorithm for evaluating their effect is given in the <a href="#integration-with-fetch">§5 Integration with Fetch</a> and <a href="#algorithms">§7 Algorithms</a> sections:</p>
+    <p class="note" role="note">Note: The referrer policy for a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#settings-object">settings object</a> provides a default
   baseline policy for requests. This policy may be tightened for specific
-  requests via mechanisms like the <code><a data-link-type="dfn" href="http://www.w3.org/TR/html5/links.html#link-type-noreferrer">noreferrer</a></code> link type.</p>
+  requests via mechanisms like the <code><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/semantics.html#link-type-noreferrer">noreferrer</a></code> link type.</p>
     <h3 class="heading settled" data-level="3.1" id="referrer-policy-state-no-referrer"><span class="secno">3.1. </span><span class="content">No Referrer</span><a class="self-link" href="#referrer-policy-state-no-referrer"></a></h3>
-    <p>The simplest policy is <dfn data-dfn-type="dfn" data-noexport="" id="no-referrer">No Referrer<a class="self-link" href="#no-referrer"></a></dfn>, which specifies that no
-  referrer information is to be sent along with requests made from a particular <a data-link-type="dfn" href="http://www.w3.org/TR/html5/webappapis.html#settings-object">settings object</a> to any <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc6454#section-3.2">origin</a>. The header will be omitted
+    <p>The simplest policy is <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="No Referrer" data-noexport="" id="no-referrer">No Referrer<span class="dfn-panel" data-deco=""><b><a href="#no-referrer">#no-referrer</a></b><b>Referenced in:</b><span><a href="#ref-for-no-referrer-1">3. Referrer Policy States</a></span><span><a href="#ref-for-no-referrer-2">7.2. 
+    Set environment’s referrer policy to policy </a></span><span><a href="#ref-for-no-referrer-3">7.4. 
+    Determine request’s Referrer </a></span><span><a href="#ref-for-no-referrer-4">7.6. 
+    Determine token’s Policy </a> <a href="#ref-for-no-referrer-5">(2)</a></span></span></dfn>, which specifies that no
+  referrer information is to be sent along with requests made from a particular <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#settings-object">settings object</a> to any <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc6454#section-3.2">origin</a>. The header will be omitted
   entirely.</p>
     <div class="example" id="example-27d86a4b"><a class="self-link" href="#example-27d86a4b"></a> If a document at <code>https://example.com/page.html</code> sets a policy of <code>No Referrer</code>, then navigations to <code>https://example.com/</code> (or any other URL) would send no <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc7231#section-5.5.2"><code>Referer</code></a> header. </div>
     <h3 class="heading settled" data-level="3.2" id="referrer-policy-state-no-referrer-when-downgrade"><span class="secno">3.2. </span><span class="content">No Referrer When Downgrade</span><a class="self-link" href="#referrer-policy-state-no-referrer-when-downgrade"></a></h3>
-    <p>The <dfn data-dfn-type="dfn" data-noexport="" id="no-referrer-when-downgrade">No Referrer When Downgrade<a class="self-link" href="#no-referrer-when-downgrade"></a></dfn> policy sends a full URL along with
-  requests from <a data-link-type="dfn" href="http://www.w3.org/TR/2010/REC-wsc-ui-20100812/#typesoftls">TLS-protected</a> <a data-link-type="dfn" href="http://www.w3.org/TR/html5/webappapis.html#settings-object">settings object</a> to a <a data-link-type="dfn" href="https://w3c.github.io/webappsec/specs/mixedcontent/#a-priori-authenticated-url"><em>a priori</em> authenticated URL</a>, and requests from <a data-link-type="dfn" href="http://www.w3.org/TR/html5/webappapis.html#settings-object">settings
+    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="No Referrer When Downgrade" data-noexport="" id="no-referrer-when-downgrade">No Referrer When Downgrade<span class="dfn-panel" data-deco=""><b><a href="#no-referrer-when-downgrade">#no-referrer-when-downgrade</a></b><b>Referenced in:</b><span><a href="#ref-for-no-referrer-when-downgrade-1">3. Referrer Policy States</a></span><span><a href="#ref-for-no-referrer-when-downgrade-2">7.2. 
+    Set environment’s referrer policy to policy </a></span><span><a href="#ref-for-no-referrer-when-downgrade-3">7.4. 
+    Determine request’s Referrer </a></span><span><a href="#ref-for-no-referrer-when-downgrade-4">7.6. 
+    Determine token’s Policy </a></span></span></dfn> policy sends a full URL along with
+  requests from <a data-link-type="dfn" href="http://www.w3.org/TR/2010/REC-wsc-ui-20100812/#typesoftls">TLS-protected</a> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#settings-object">settings object</a> to a <a data-link-type="dfn" href="https://w3c.github.io/webappsec/specs/mixedcontent/#a-priori-authenticated-url"><em>a priori</em> authenticated URL</a>, and requests from <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#settings-object">settings
   objects</a> which are <em>not</em> <a data-link-type="dfn" href="http://www.w3.org/TR/2010/REC-wsc-ui-20100812/#typesoftls">TLS-protected</a> to any <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc6454#section-3.2">origin</a>.</p>
-    <p>Requests from <a data-link-type="dfn" href="http://www.w3.org/TR/2010/REC-wsc-ui-20100812/#typesoftls">TLS-protected</a> <a data-link-type="dfn" href="http://www.w3.org/TR/html5/webappapis.html#settings-object">settings objects</a> to not-<a data-link-type="dfn" href="https://w3c.github.io/webappsec/specs/mixedcontent/#a-priori-authenticated-url"><em>a
+    <p>Requests from <a data-link-type="dfn" href="http://www.w3.org/TR/2010/REC-wsc-ui-20100812/#typesoftls">TLS-protected</a> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#settings-object">settings objects</a> to not-<a data-link-type="dfn" href="https://w3c.github.io/webappsec/specs/mixedcontent/#a-priori-authenticated-url"><em>a
   priori</em> authenticated URL</a>, on the other hand, will contain no referrer
   information. A <code><a data-link-type="dfn" href="https://tools.ietf.org/html/rfc7231#section-5.5.2">Referer</a></code> HTTP header will not be sent.</p>
     <div class="example" id="example-506cf3f7">
@@ -1246,9 +1553,12 @@
     </div>
     <p>This is a user agent’s default behavior, if no policy is otherwise specified.</p>
     <h3 class="heading settled" data-level="3.3" id="referrer-policy-state-origin"><span class="secno">3.3. </span><span class="content">Origin Only</span><a class="self-link" href="#referrer-policy-state-origin"></a></h3>
-    <p>The <dfn data-dfn-type="dfn" data-noexport="" id="origin-only">Origin Only<a class="self-link" href="#origin-only"></a></dfn> policy specifies that only the <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc6454#section-6.2">ASCII serialization</a> of the <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc6454#section-3.2">origin</a> of the <a data-link-type="dfn" href="http://www.w3.org/TR/html5/webappapis.html#settings-object">settings object</a> from which a request is
-  made is sent as referrer information when making both <a data-link-type="dfn" href="#same-origin-request">same-origin
-  requests</a> and <a data-link-type="dfn" href="#cross-origin-request">cross-origin requests</a> from a particular <a data-link-type="dfn" href="http://www.w3.org/TR/html5/webappapis.html#settings-object">settings object</a>.</p>
+    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="Origin Only" data-noexport="" id="origin-only">Origin Only<span class="dfn-panel" data-deco=""><b><a href="#origin-only">#origin-only</a></b><b>Referenced in:</b><span><a href="#ref-for-origin-only-1">3. Referrer Policy States</a></span><span><a href="#ref-for-origin-only-2">7.2. 
+    Set environment’s referrer policy to policy </a></span><span><a href="#ref-for-origin-only-3">7.4. 
+    Determine request’s Referrer </a></span><span><a href="#ref-for-origin-only-4">7.6. 
+    Determine token’s Policy </a></span></span></dfn> policy specifies that only the <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc6454#section-6.2">ASCII serialization</a> of the <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc6454#section-3.2">origin</a> of the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#settings-object">settings object</a> from which a request is
+  made is sent as referrer information when making both <a data-link-type="dfn" href="#same-origin-request" id="ref-for-same-origin-request-2">same-origin
+  requests</a> and <a data-link-type="dfn" href="#cross-origin-request" id="ref-for-cross-origin-request-1">cross-origin requests</a> from a particular <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#settings-object">settings object</a>.</p>
     <p class="note" role="note">Note: The serialization of an origin looks like <code>https://example.com</code>. To ensure that a valid URL is sent in the
   `<code>Referer</code>` header, user agents will append a U+002F SOLIDUS
   ("<code>/</code>") character to the origin (e.g. <code>https://example.com/</code>).</p>
@@ -1257,11 +1567,14 @@
     <div class="example" id="example-6fbea3ba"><a class="self-link" href="#example-6fbea3ba"></a> If a document at <code>https://example.com/page.html</code> sets a policy of <code>Origin Only</code>, then navigations to any <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc6454#section-3.2">origin</a> would send a <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc7231#section-5.5.2"><code>Referer</code></a> header with a value of <code>https://example.com/</code>, even to URLs that are not <a data-link-type="dfn" href="https://w3c.github.io/webappsec/specs/mixedcontent/#a-priori-authenticated-url"><em>a
     priori</em> authenticated URLs</a>. </div>
     <h3 class="heading settled" data-level="3.4" id="referrer-policy-state-origin-when-cross-origin"><span class="secno">3.4. </span><span class="content">Origin When Cross-Origin</span><a class="self-link" href="#referrer-policy-state-origin-when-cross-origin"></a></h3>
-    <p>The <dfn data-dfn-type="dfn" data-noexport="" id="origin-when-cross-origin">Origin When Cross-Origin<a class="self-link" href="#origin-when-cross-origin"></a></dfn> policy specifies that a full URL, <a href="#strip-url">stripped for use as a referrer</a>, is sent as referrer
-  information when making <a data-link-type="dfn" href="#same-origin-request">same-origin requests</a> from a particular <a data-link-type="dfn" href="http://www.w3.org/TR/html5/webappapis.html#settings-object">settings object</a>, and only the <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc6454#section-6.2">ASCII serialization</a> of the <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc6454#section-3.2">origin</a> of the <a data-link-type="dfn" href="http://www.w3.org/TR/html5/webappapis.html#settings-object">settings object</a> from which a request is
-  made is sent as referrer information when making <a data-link-type="dfn" href="#cross-origin-request">cross-origin requests</a> from a particular <a data-link-type="dfn" href="http://www.w3.org/TR/html5/webappapis.html#settings-object">settings object</a>.</p>
+    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="Origin When Cross-Origin" data-noexport="" id="origin-when-cross-origin">Origin When Cross-Origin<span class="dfn-panel" data-deco=""><b><a href="#origin-when-cross-origin">#origin-when-cross-origin</a></b><b>Referenced in:</b><span><a href="#ref-for-origin-when-cross-origin-1">3. Referrer Policy States</a></span><span><a href="#ref-for-origin-when-cross-origin-2">7.2. 
+    Set environment’s referrer policy to policy </a></span><span><a href="#ref-for-origin-when-cross-origin-3">7.4. 
+    Determine request’s Referrer </a></span><span><a href="#ref-for-origin-when-cross-origin-4">7.6. 
+    Determine token’s Policy </a></span></span></dfn> policy specifies that a full URL, <a href="#strip-url">stripped for use as a referrer</a>, is sent as referrer
+  information when making <a data-link-type="dfn" href="#same-origin-request" id="ref-for-same-origin-request-3">same-origin requests</a> from a particular <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#settings-object">settings object</a>, and only the <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc6454#section-6.2">ASCII serialization</a> of the <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc6454#section-3.2">origin</a> of the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#settings-object">settings object</a> from which a request is
+  made is sent as referrer information when making <a data-link-type="dfn" href="#cross-origin-request" id="ref-for-cross-origin-request-2">cross-origin requests</a> from a particular <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#settings-object">settings object</a>.</p>
     <p class="note" role="note">Note: For the <code>Origin When Cross-Origin</code> policy, we also consider
-  protocol upgrades, e.g. requests from <code>http://example.com/</code> to <code>https://example.com/</code> to be <a data-link-type="dfn" href="#cross-origin-request">cross-origin requests</a>.</p>
+  protocol upgrades, e.g. requests from <code>http://example.com/</code> to <code>https://example.com/</code> to be <a data-link-type="dfn" href="#cross-origin-request" id="ref-for-cross-origin-request-3">cross-origin requests</a>.</p>
     <p class="note" role="note">Note: The <code>Origin When Cross-Origin</code> policy causes the origin of
   HTTPS referrers to be sent over the network as part of unencrypted HTTP
   requests.</p>
@@ -1271,9 +1584,12 @@
     priori</em> authenticated URLs</a>.</p>
     </div>
     <h3 class="heading settled" data-level="3.5" id="referrer-policy-state-unsafe-url"><span class="secno">3.5. </span><span class="content">Unsafe URL</span><a class="self-link" href="#referrer-policy-state-unsafe-url"></a></h3>
-    <p>The <dfn data-dfn-type="dfn" data-noexport="" id="unsafe-url">Unsafe URL<a class="self-link" href="#unsafe-url"></a></dfn> policy specifies that a full URL, <a href="#strip-url">stripped for use as a referrer</a>, is sent along with
-  both <a data-link-type="dfn" href="#cross-origin-request">cross-origin requests</a> and <a data-link-type="dfn" href="#same-origin-request">same-origin requests</a> made from
-  a particular <a data-link-type="dfn" href="http://www.w3.org/TR/html5/webappapis.html#settings-object">settings object</a>.</p>
+    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="Unsafe URL" data-noexport="" id="unsafe-url">Unsafe URL<span class="dfn-panel" data-deco=""><b><a href="#unsafe-url">#unsafe-url</a></b><b>Referenced in:</b><span><a href="#ref-for-unsafe-url-1">3. Referrer Policy States</a></span><span><a href="#ref-for-unsafe-url-2">7.2. 
+    Set environment’s referrer policy to policy </a></span><span><a href="#ref-for-unsafe-url-3">7.4. 
+    Determine request’s Referrer </a></span><span><a href="#ref-for-unsafe-url-4">7.6. 
+    Determine token’s Policy </a></span></span></dfn> policy specifies that a full URL, <a href="#strip-url">stripped for use as a referrer</a>, is sent along with
+  both <a data-link-type="dfn" href="#cross-origin-request" id="ref-for-cross-origin-request-4">cross-origin requests</a> and <a data-link-type="dfn" href="#same-origin-request" id="ref-for-same-origin-request-4">same-origin requests</a> made from
+  a particular <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#settings-object">settings object</a>.</p>
     <div class="example" id="example-ed289e46"><a class="self-link" href="#example-ed289e46"></a> If a document at <code>https://example.com/sekrit.html</code> sets a policy
     of <code>Unsafe URL</code>, then navigations to <code>http://not.example.com/</code> (and every other origin) would send a <code><a data-link-type="dfn" href="https://tools.ietf.org/html/rfc7231#section-5.5.2">Referer</a></code> HTTP header with a value of <code>https://example.com/sekrit.html</code>. </div>
     <p class="note" role="note">Note: The policy’s name doesn’t lie; it is unsafe. This policy will leak
@@ -1283,28 +1599,30 @@
    </section>
    <section>
     <h2 class="heading settled" data-level="4" id="referrer-policy-delivery"><span class="secno">4. </span><span class="content">Referrer Policy Delivery</span><a class="self-link" href="#referrer-policy-delivery"></a></h2>
-    <p>A <a data-link-type="dfn" href="http://www.w3.org/TR/html5/webappapis.html#settings-object">settings object</a>’s <a data-link-type="dfn" href="#referrer-policy">referrer policy</a> is delivered in one of four
+    <p>A <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#settings-object">settings object</a>’s <a data-link-type="dfn" href="#referrer-policy" id="ref-for-referrer-policy-3">referrer policy</a> is delivered in one of four
   ways:</p>
     <ul>
      <li> Via the <code>Referrer-Policy</code> HTTP header (defined
       in <a href="#referrer-policy-header">§4.1 Delivery via Referrer-Policy header</a>). 
-     <li> Via a <code><a data-link-type="element" href="http://www.w3.org/TR/html5/document-metadata.html#the-meta-element">meta</a></code> element with a <code><a data-link-type="element-attr" href="http://www.w3.org/TR/html5/document-metadata.html#attr-meta-name">name</a></code> of <code>referrer</code>. 
-     <li> Via a <code>referrerpolicy</code> content attribute on an <code><a data-link-type="element" href="http://www.w3.org/TR/html5/text-level-semantics.html#the-a-element">a</a></code>, <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-area-element">area</a></code>, <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element">img</a></code>, <code><a data-link-type="element" href="http://www.w3.org/TR/html5/embedded-content-0.html#the-iframe-element">iframe</a></code>, or <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-link-element">link</a></code> element. 
+     <li> Via a <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#meta">meta</a></code> element with a <code><a data-link-type="element-sub" href="https://html.spec.whatwg.org/multipage/semantics.html#attr-meta-name">name</a></code> of <code>referrer</code>. 
+     <li> Via a <code>referrerpolicy</code> content attribute on an <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/#the-a-element">a</a></code>, <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-area-element">area</a></code>, <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element">img</a></code>, <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-iframe-element">iframe</a></code>, or <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-link-element">link</a></code> element. 
      <li> Implicitly, via inheritance. 
     </ul>
     <h3 class="heading settled" data-level="4.1" id="referrer-policy-header"><span class="secno">4.1. </span><span class="content">Delivery via Referrer-Policy header</span><a class="self-link" href="#referrer-policy-header"></a></h3>
-    <p>The <code><dfn data-dfn-type="dfn" data-local-lt="referrer-policy header" data-noexport="" id="referrer-policy-header-dfn">Referrer-Policy<a class="self-link" href="#referrer-policy-header-dfn"></a></dfn></code> HTTP
+    <p>The <code><dfn class="dfn-paneled" data-dfn-type="dfn" data-local-lt="referrer-policy header" data-lt="Referrer-Policy" data-noexport="" id="referrer-policy-header-dfn">Referrer-Policy<span class="dfn-panel" data-deco=""><b><a href="#referrer-policy-header-dfn">#referrer-policy-header-dfn</a></b><b>Referenced in:</b><span><a href="#ref-for-referrer-policy-header-dfn-1">7.1. 
+    Parse a referrer policy from a Referrer-Policy header </a></span><span><a href="#ref-for-referrer-policy-header-dfn-2">7.6. 
+    Determine token’s Policy </a></span></span></dfn></code> HTTP
   header specifies the referrer policy that the user agent applies when
   determining what referrer information should be included with requests
-  made, and with <a data-link-type="dfn" href="http://www.w3.org/TR/html5/browsers.html#browsing-context">browsing contexts</a> created from the context of the protected resource.
+  made, and with <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context">browsing contexts</a> created from the context of the protected resource.
   The syntax for the name and value of the header are described by the
   following ABNF grammar:</p>
-<pre>"Referrer-Policy:" 1#<a data-link-type="dfn" href="#policy-token">policy-token</a>
+<pre>"Referrer-Policy:" 1#<a data-link-type="dfn" href="#policy-token" id="ref-for-policy-token-1">policy-token</a>
 </pre>
-<pre><dfn data-dfn-type="dfn" data-noexport="" id="policy-token">policy-token<a class="self-link" href="#policy-token"></a></dfn>   = "no-referrer" / "no-referrer-when-downgrade" / "origin" / "origin-when-cross-origin" / "unsafe-url"
+<pre><dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="policy-token" data-noexport="" id="policy-token">policy-token<span class="dfn-panel" data-deco=""><b><a href="#policy-token">#policy-token</a></b><b>Referenced in:</b><span><a href="#ref-for-policy-token-1">4.1. Delivery via Referrer-Policy header</a></span></span></dfn>   = "no-referrer" / "no-referrer-when-downgrade" / "origin" / "origin-when-cross-origin" / "unsafe-url"
 </pre>
     <p class="note" role="note">Note: The header name does not share the HTTP Referer header’s misspelling.</p>
-    <p><a href="#integration-with-fetch">§6 Integration with Fetch</a> and <a href="#integration-with-html">§7 Integration with HTML</a> describe
+    <p><a href="#integration-with-fetch">§5 Integration with Fetch</a> and <a href="#integration-with-html">§6 Integration with HTML</a> describe
   how the <code>Referrer-Policy</code> header is processed.</p>
     <section class="informative">
      <h4 class="heading settled" data-level="4.1.1" id="referrer-usage"><span class="secno">4.1.1. </span><span class="content">Usage</span><a class="self-link" href="#referrer-usage"></a></h4>
@@ -1315,209 +1633,109 @@
      <p>This will cause all requests made from the protected resource’s
     context to have an empty <code>Referer</code> [sic] header.</p>
     </section>
-    <h3 class="heading settled" data-level="4.2" id="referrer-policy-delivery-meta"><span class="secno">4.2. </span><span class="content">Delivery via <code><a data-link-type="element" href="http://www.w3.org/TR/html5/document-metadata.html#the-meta-element">meta</a></code></span><a class="self-link" href="#referrer-policy-delivery-meta"></a></h3>
-    <p>A referrer policy may be set when an HTML <code><a data-link-type="element" href="http://www.w3.org/TR/html5/document-metadata.html#the-meta-element">meta</a></code> element with a <code><a data-link-type="element-attr" href="http://www.w3.org/TR/html5/document-metadata.html#attr-meta-name">name</a></code> attribute that is an <a data-link-type="dfn" href="http://www.w3.org/TR/html5/infrastructure.html#ascii-case-insensitive">ASCII case-insensitive match</a> for the string "<code>Referrer</code>" is inserted into a document, for
-  example:</p>
-<pre class="example" id="example-8adbf8f6"><a class="self-link" href="#example-8adbf8f6"></a>&lt;meta name="referrer" content="origin">
-</pre>
-    <p>The following values for the <code>content</code> attribute are valid, and map
-  to the listed <a data-link-type="dfn" href="#referrer-policy">referrer policy</a> values:</p>
-    <dl>
-     <dt>no-referrer
-     <dd><a data-link-type="dfn" href="#no-referrer"><code>No Referrer</code></a>
-     <dt>no-referrer-when-downgrade
-     <dd><a data-link-type="dfn" href="#no-referrer-when-downgrade"><code>No Referrer When Downgrade</code></a>
-     <dt>origin
-     <dd><a data-link-type="dfn" href="#origin-only"><code>Origin Only</code></a>
-     <dt>origin-when-cross-origin
-     <dd><a data-link-type="dfn" href="#origin-when-cross-origin"><code>Origin When Cross-Origin</code></a>
-     <dt>unsafe-url
-     <dd><a data-link-type="dfn" href="#unsafe-url"><code>Unsafe URL</code></a>
-    </dl>
-    <p>Add the following entry to the <a href="http://www.w3.org/TR/html5/document-metadata.html#pragma-directives">pragma directives</a> for the <code><a data-link-type="element" href="http://www.w3.org/TR/html5/document-metadata.html#the-meta-element">meta</a></code> element:</p>
-    <dl>
-     <dt> Referrer policy
-      (<code>name="Referrer"</code>) 
-     <dd>
-      <ol>
-       <li> If the Document’s <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-head-element">head</a></code> element is not an ancestor of the <code><a data-link-type="element" href="http://www.w3.org/TR/html5/document-metadata.html#the-meta-element">meta</a></code> element, abort these steps. 
-       <li> If the <code><a data-link-type="element" href="http://www.w3.org/TR/html5/document-metadata.html#the-meta-element">meta</a></code> element lacks a <code><a data-link-type="element-attr" href="http://www.w3.org/TR/html5/document-metadata.html#attr-meta-content">content</a></code> attribute then abort
-          these steps. 
-       <li> Let <var>environment</var> be the <code class="idl"><a data-link-type="idl" href="http://www.w3.org/TR/dom/#interface-document">Document</a></code>'s <a data-link-type="dfn" href="http://www.w3.org/TR/html5/webappapis.html#incumbent-settings-object">incumbent settings
-          object</a>. 
-       <li> Let <var>meta-value</var> be the value of the element’s <code><a data-link-type="element-attr" href="http://www.w3.org/TR/html5/document-metadata.html#attr-meta-content">content</a></code> attribute, after <a data-link-type="dfn" href="http://www.w3.org/TR/html5/infrastructure.html#strip-leading-and-trailing-whitespace">stripping
-          leading and trailing whitespace</a>. 
-       <li> If <var>meta-value</var> is the empty string, then abort these steps. 
-       <li> Let <var>policy</var> be the result of executing the <a href="#determine-policy-for-token">§8.6 Determine token’s Policy</a> algorithm on <var>meta-value</var>. 
-       <li> Execute the <a href="#set-referrer-policy">§8.2 Set environment’s referrer policy to policy</a> algorithm on <var>environment</var> using <var>policy</var>. 
-      </ol>
-      <p class="note" role="note">Note: Authors are encouraged to avoid the legacy keywords <code>never</code>, <code>default</code>, and <code>always</code>. The
-      keywords <code>no-referrer</code>, <code>no-referrer-when-downgrade</code>, and <code>unsafe-url</code> respectively are preferred.</p>
-      <p class="note" role="note">Note: Implementors are advised to also respect a <a data-link-type="dfn" href="#referrer-policy">referrer policy</a> delivered via a <code><a data-link-type="element" href="http://www.w3.org/TR/html5/document-metadata.html#the-meta-element">meta</a></code> element during
-      speculative resource loads.</p>
-    </dl>
+    <h3 class="heading settled" data-level="4.2" id="referrer-policy-delivery-meta"><span class="secno">4.2. </span><span class="content">Delivery via <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#meta">meta</a></code></span><a class="self-link" href="#referrer-policy-delivery-meta"></a></h3>
+    <p>The HTML Standard defines the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/semantics.html#attr-meta-http-equiv-referrer">Referrer policy state</a> for the <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#meta">meta</a></code> element, which allows setting the <a data-link-type="dfn" href="#referrer-policy" id="ref-for-referrer-policy-4">referrer policy</a> via markup.</p>
     <h3 class="heading settled" data-level="4.3" id="referrer-policy-delivery-referrer-attribute"><span class="secno">4.3. </span><span class="content">Delivery
   via a <code>referrerpolicy</code> content attribute</span><a class="self-link" href="#referrer-policy-delivery-referrer-attribute"></a></h3>
-    <p>A referrer policy may be set when a <code>referrerpolicy</code> content
-  attribute is added to an <code><a data-link-type="element" href="http://www.w3.org/TR/html5/text-level-semantics.html#the-a-element">a</a></code>, <code> <a data-link-type="element" href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-area-element">area</a></code>, <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element">img</a></code>, <code> <a data-link-type="element" href="http://www.w3.org/TR/html5/embedded-content-0.html#the-iframe-element">iframe</a></code>, or <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-link-element">link</a></code> element,
-  for example:</p>
-<pre class="example" id="example-73ba3b1e"><a class="self-link" href="#example-73ba3b1e"></a>&lt;a href="http://example.com" referrerPolicy="origin">
+    <p>The HTML Standard defines the concept of <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#referrer-policy-attribute">referrer policy
+  attributes</a> which applies to several of its elements, for example:</p>
+<pre class="example" id="example-d7516db8"><a class="self-link" href="#example-d7516db8"></a>&lt;a href="http://example.com" referrerpolicy="origin">
 </pre>
-    <p>The following values for the <code>referrerpolicy</code> content attribute
-  are valid, and map to the listed <a data-link-type="dfn" href="#referrer-policy">referrer policy</a> values:</p>
-    <dl>
-     <dt>no-referrer
-     <dd><a data-link-type="dfn" href="#no-referrer"><code>No Referrer</code></a>
-     <dt>no-referrer-when-downgrade
-     <dd><a data-link-type="dfn" href="#no-referrer-when-downgrade"><code>No Referrer When Downgrade</code></a>
-     <dt>origin
-     <dd><a data-link-type="dfn" href="#origin-only"><code>Origin Only</code></a>
-     <dt>origin-when-cross-origin
-     <dd><a data-link-type="dfn" href="#origin-when-cross-origin"><code>Origin When Cross-Origin</code></a>
-     <dt>unsafe-url
-     <dd><a data-link-type="dfn" href="#unsafe-url"><code>Unsafe URL</code></a>
-    </dl>
-    <p>A policy delivered via a <code>referrerpolicy</code> content attribute on an
-  element takes precedence over the policy defined for the whole document via <a data-link-type="dfn" href="#referrer-policy-header-dfn">Referrer-Policy header</a> or a <a data-link-type="element" href="http://www.w3.org/TR/html5/document-metadata.html#the-meta-element">meta</a> element unless the attribute value is invalid.</p>
-    <p class="note" role="note">NOTE: If an <code><a data-link-type="element" href="http://www.w3.org/TR/html5/text-level-semantics.html#the-a-element">a</a></code> or <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-area-element">area</a></code> element includes both
-  a <code>referrerpolicy</code> attribute as well as
-  a <a data-link-type="dfn" href="http://www.w3.org/TR/html5/links.html#link-type-noreferrer"><code>noreferrer</code></a> link type then the <a data-link-type="dfn" href="http://www.w3.org/TR/html5/links.html#link-type-noreferrer"><code>noreferrer</code></a> link type will take precedence and the <a data-link-type="dfn" href="#no-referrer"><code>No Referrer</code></a> policy
-  takes effect.</p>
     <h3 class="heading settled" data-level="4.4" id="referrer-policy-delivery-implicit"><span class="secno">4.4. </span><span class="content">Implicit Delivery</span><a class="self-link" href="#referrer-policy-delivery-implicit"></a></h3>
-    <p>A <a data-link-type="dfn" href="http://www.w3.org/TR/html5/webappapis.html#settings-object">settings object</a> inherits the <a data-link-type="dfn" href="#referrer-policy">referrer policy</a> of another object
+    <p>A <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#settings-object">settings object</a> inherits the <a data-link-type="dfn" href="#referrer-policy" id="ref-for-referrer-policy-5">referrer policy</a> of another object
   in several circumstances:</p>
     <h4 class="heading settled" data-level="4.4.1" id="referrer-policy-delivery-implicit-nested"><span class="secno">4.4.1. </span><span class="content"> Nested Browsing Contexts </span><a class="self-link" href="#referrer-policy-delivery-implicit-nested"></a></h4>
-    <p>Whenever a user agent creates a <a data-link-type="dfn" href="http://www.w3.org/TR/html5/browsers.html#nested-browsing-context">nested browsing context</a> containing <a data-link-type="dfn" href="http://www.w3.org/TR/html5/embedded-content-0.html#an-iframe-srcdoc-document">an iframe srcdoc document</a> or a resource whose <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc6454#section-3.2">origin</a>’s scheme
-  is a <a data-link-type="dfn" href="http://www.w3.org/TR/url/#local-scheme">local scheme</a> (for instance, a <code>blob</code> or <code>data</code> resource):</p>
+    <p>Whenever a user agent creates a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#nested-browsing-context">nested browsing context</a> containing <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#an-iframe-srcdoc-document">an iframe srcdoc document</a> or a resource whose <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc6454#section-3.2">origin</a>’s scheme
+  is a <a data-link-type="dfn" href="https://url.spec.whatwg.org#local-scheme">local scheme</a> (for instance, a <code>blob</code> or <code>data</code> resource):</p>
     <ol>
-     <li> Let <var>environment</var> be the <a data-link-type="dfn" href="http://www.w3.org/TR/html5/browsers.html#nested-browsing-context">nested browsing context</a>’s <a data-link-type="dfn" href="http://www.w3.org/TR/html5/webappapis.html#incumbent-settings-object">incumbent settings object</a>. 
-     <li> Let <var>policy</var> be the <a data-link-type="dfn" href="http://www.w3.org/TR/html5/browsers.html#parent-browsing-context">parent browsing context</a>’s <a data-link-type="dfn" href="http://www.w3.org/TR/html5/webappapis.html#incumbent-settings-object">incumbent settings object</a>’s <a data-link-type="dfn" href="#referrer-policy">referrer policy</a>. 
-     <li> Execute the <a href="#set-referrer-policy">§8.2 Set environment’s referrer policy to policy</a> algorithm on <var>environment</var> using <var>policy</var>. 
+     <li> Let <var>environment</var> be the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#nested-browsing-context">nested browsing context</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#incumbent-settings-object">incumbent settings object</a>. 
+     <li> Let <var>policy</var> be the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#parent-browsing-context">parent browsing context</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#incumbent-settings-object">incumbent settings object</a>’s <a data-link-type="dfn" href="#referrer-policy" id="ref-for-referrer-policy-6">referrer policy</a>. 
+     <li> Execute the <a href="#set-referrer-policy">§7.2 Set environment’s referrer policy to policy</a> algorithm on <var>environment</var> using <var>policy</var>. 
     </ol>
     <h4 class="heading settled" data-level="4.4.2" id="referrer-policy-delivery-implicit-workers"><span class="secno">4.4.2. </span><span class="content"> Workers </span><a class="self-link" href="#referrer-policy-delivery-implicit-workers"></a></h4>
-    <p>Whenever a user agent <a data-link-type="dfn" href="http://www.w3.org/TR/workers/#run-a-worker">runs a worker</a> for a script with <code class="idl"><a data-link-type="idl" href="http://www.w3.org/TR/url/#url">URL</a></code> <var>url</var> and <var>url</var>’s scheme is a <a data-link-type="dfn" href="http://www.w3.org/TR/url/#local-scheme">local scheme</a>:</p>
+    <p>Whenever a user agent <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/workers.html#run-a-worker">runs a worker</a> for a
+  script with <code class="idl"><a data-link-type="idl" href="https://url.spec.whatwg.org#url">URL</a></code> <var>url</var> and <var>url</var>’s scheme is a <a data-link-type="dfn" href="https://url.spec.whatwg.org#local-scheme">local scheme</a>:</p>
     <ol>
-     <li> Let <var>environment</var> be the Worker’s <a data-link-type="dfn" href="http://www.w3.org/TR/html5/webappapis.html#incumbent-settings-object">incumbent settings
+     <li> Let <var>environment</var> be the Worker’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#incumbent-settings-object">incumbent settings
       object</a>. 
      <li> Let <var>policy</var> be <code>No Referrer When Downgrade</code>. 
-     <li> Execute the <a href="#set-referrer-policy">§8.2 Set environment’s referrer policy to policy</a> algorithm on <var>environment</var> using <var>policy</var>. 
+     <li> Execute the <a href="#set-referrer-policy">§7.2 Set environment’s referrer policy to policy</a> algorithm on <var>environment</var> using <var>policy</var>. 
     </ol>
    </section>
    <section>
-    <h2 class="heading settled" data-level="5" id="element-interface-extensions"><span class="secno">5. </span><span class="content">Element interface extensions</span><a class="self-link" href="#element-interface-extensions"></a></h2>
-    <h3 class="heading settled" data-level="5.1" id="html-anchor-element"><span class="secno">5.1. </span><span class="content">HTMLAnchorElement</span><a class="self-link" href="#html-anchor-element"></a></h3>
-<pre class="idl">partial interface <a class="idl-code" data-link-type="interface" href="https://html.spec.whatwg.org/multipage/semantics.html#htmlanchorelement">HTMLAnchorElement</a> {
-  attribute DOMString <dfn class="idl-code" data-dfn-for="HTMLAnchorElement" data-dfn-type="attribute" data-export="" data-type="DOMString " id="dom-htmlanchorelement-referrerpolicy">referrerPolicy<a class="self-link" href="#dom-htmlanchorelement-referrerpolicy"></a></dfn>;
-};
-</pre>
-    <h4 class="heading settled" data-level="5.1.1" id="html-anchor-element-attributes"><span class="secno">5.1.1. </span><span class="content">Attributes</span><a class="self-link" href="#html-anchor-element-attributes"></a></h4>
-     The <code>referrerPolicy</code> IDL attribute must <a data-link-type="dfn" href="http://www.w3.org/TR/html5/infrastructure.html#reflect">reflect</a> the <code>referrerpolicy</code> content attribute, <a data-link-type="dfn" href="http://www.w3.org/TR/html5/infrastructure.html#limited-to-only-known-values">limited to only known
-  values</a>. 
-    <h3 class="heading settled" data-level="5.2" id="html-area-element"><span class="secno">5.2. </span><span class="content">HTMLAreaElement</span><a class="self-link" href="#html-area-element"></a></h3>
-<pre class="idl">partial interface <a class="idl-code" data-link-type="interface" href="https://html.spec.whatwg.org/multipage/embedded-content.html#htmlareaelement">HTMLAreaElement</a> {
-  attribute DOMString <dfn class="idl-code" data-dfn-for="HTMLAreaElement" data-dfn-type="attribute" data-export="" data-type="DOMString " id="dom-htmlareaelement-referrerpolicy">referrerPolicy<a class="self-link" href="#dom-htmlareaelement-referrerpolicy"></a></dfn>;
-};
-</pre>
-    <h4 class="heading settled" data-level="5.2.1" id="html-area-element-attributes"><span class="secno">5.2.1. </span><span class="content">Attributes</span><a class="self-link" href="#html-area-element-attributes"></a></h4>
-     The <code>referrerPolicy</code> IDL attribute must <a data-link-type="dfn" href="http://www.w3.org/TR/html5/infrastructure.html#reflect">reflect</a> the <code>referrerpolicy</code> content attribute, <a data-link-type="dfn" href="http://www.w3.org/TR/html5/infrastructure.html#limited-to-only-known-values">limited to only known
-  values</a>. 
-    <h3 class="heading settled" data-level="5.3" id="html-image-element"><span class="secno">5.3. </span><span class="content">HTMLImageElement</span><a class="self-link" href="#html-image-element"></a></h3>
-<pre class="idl">partial interface <a class="idl-code" data-link-type="interface" href="https://html.spec.whatwg.org/multipage/embedded-content.html#htmlimageelement">HTMLImageElement</a> {
-  attribute DOMString <dfn class="idl-code" data-dfn-for="HTMLImageElement" data-dfn-type="attribute" data-export="" data-type="DOMString " id="dom-htmlimageelement-referrerpolicy">referrerPolicy<a class="self-link" href="#dom-htmlimageelement-referrerpolicy"></a></dfn>;
-};
-</pre>
-    <h4 class="heading settled" data-level="5.3.1" id="html-image-element-attributes"><span class="secno">5.3.1. </span><span class="content">Attributes</span><a class="self-link" href="#html-image-element-attributes"></a></h4>
-     The <code>referrerPolicy</code> IDL attribute must <a data-link-type="dfn" href="http://www.w3.org/TR/html5/infrastructure.html#reflect">reflect</a> the <code>referrerpolicy</code> content attribute, <a data-link-type="dfn" href="http://www.w3.org/TR/html5/infrastructure.html#limited-to-only-known-values">limited to only known
-  values</a>. 
-    <p class="note" role="note">Note: Modifying the <code>referrerPolicy</code> IDL attribute is not a <a data-link-type="dfn" href="http://www.w3.org/TR/html5/embedded-content-0.html#relevant-mutations">relevant mutation</a> for an <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element">img</a></code> element.</p>
-    <h3 class="heading settled" data-level="5.4" id="html-iframe-element"><span class="secno">5.4. </span><span class="content">HTMLIFrameElement</span><a class="self-link" href="#html-iframe-element"></a></h3>
-<pre class="idl">partial interface <a class="idl-code" data-link-type="interface" href="https://html.spec.whatwg.org/multipage/embedded-content.html#htmliframeelement">HTMLIFrameElement</a> {
-  attribute DOMString <dfn class="idl-code" data-dfn-for="HTMLIFrameElement" data-dfn-type="attribute" data-export="" data-type="DOMString " id="dom-htmliframeelement-referrerpolicy">referrerPolicy<a class="self-link" href="#dom-htmliframeelement-referrerpolicy"></a></dfn>;
-};
-</pre>
-    <h4 class="heading settled" data-level="5.4.1" id="html-iframe-element-attributes"><span class="secno">5.4.1. </span><span class="content">Attributes</span><a class="self-link" href="#html-iframe-element-attributes"></a></h4>
-     The <code>referrerPolicy</code> IDL attribute must <a data-link-type="dfn" href="http://www.w3.org/TR/html5/infrastructure.html#reflect">reflect</a> the <code>referrerpolicy</code> content attribute, <a data-link-type="dfn" href="http://www.w3.org/TR/html5/infrastructure.html#limited-to-only-known-values">limited to only known
-  values</a>. 
-    <h3 class="heading settled" data-level="5.5" id="html-link-element"><span class="secno">5.5. </span><span class="content">HTMLLinkElement</span><a class="self-link" href="#html-link-element"></a></h3>
-<pre class="idl">partial interface <a class="idl-code" data-link-type="interface" href="https://html.spec.whatwg.org/multipage/semantics.html#htmllinkelement">HTMLLinkElement</a> {
-  attribute DOMString <dfn class="idl-code" data-dfn-for="HTMLLinkElement" data-dfn-type="attribute" data-export="" data-type="DOMString " id="dom-htmllinkelement-referrerpolicy">referrerPolicy<a class="self-link" href="#dom-htmllinkelement-referrerpolicy"></a></dfn>;
-};
-</pre>
-    <h4 class="heading settled" data-level="5.5.1" id="html-link-element-attributes"><span class="secno">5.5.1. </span><span class="content">Attributes</span><a class="self-link" href="#html-link-element-attributes"></a></h4>
-     The <code>referrerPolicy</code> IDL attribute must <a data-link-type="dfn" href="http://www.w3.org/TR/html5/infrastructure.html#reflect">reflect</a> the <code>referrerpolicy</code> content attribute, <a data-link-type="dfn" href="http://www.w3.org/TR/html5/infrastructure.html#limited-to-only-known-values">limited to only known
-  values</a>. 
-   </section>
-   <section>
-    <h2 class="heading settled" data-level="6" id="integration-with-fetch"><span class="secno">6. </span><span class="content">Integration with Fetch</span><a class="self-link" href="#integration-with-fetch"></a></h2>
-    <p>The Fetch specification calls out to <a href="#set-requests-referrer-policy-on-redirect">§8.3 Set request’s referrer policy on redirect</a> immediately
+    <h2 class="heading settled" data-level="5" id="integration-with-fetch"><span class="secno">5. </span><span class="content">Integration with Fetch</span><a class="self-link" href="#integration-with-fetch"></a></h2>
+    <p>The Fetch specification calls out to <a href="#set-requests-referrer-policy-on-redirect">§7.3 Set request’s referrer policy on redirect</a> immediately
   before <a href="https://fetch.spec.whatwg.org/#http-redirect-fetch">Step
   15 of the HTTP-redirect fetch</a>.</p>
     <p>The Fetch specification calls out to the <a href="#determine-requests-referrer">Determine <var>request</var>’s
   referrer</a> algorithm as <a href="http://fetch.spec.whatwg.org/#concept-fetch">Step 2 of the
   Fetching algorithm</a>, and uses the result to set the <var>request</var>’s <code>referrer</code> property. Fetch is responsible for serializing the
   URL provided, and setting the `<code>Referer</code>` header on <var>request</var>.</p>
-    <h2 class="heading settled" data-level="7" id="integration-with-html"><span class="secno">7. </span><span class="content">Integration with HTML</span><a class="self-link" href="#integration-with-html"></a></h2>
-    <p>When a <code class="idl"><a data-link-type="idl" href="http://www.w3.org/TR/dom/#interface-document">Document</a></code> or <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#workerglobalscope">WorkerGlobalScope</a></code> is created after fetching
+    <h2 class="heading settled" data-level="6" id="integration-with-html"><span class="secno">6. </span><span class="content">Integration with HTML</span><a class="self-link" href="#integration-with-html"></a></h2>
+    <p>When a <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/dom.html#document">Document</a></code> or <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#workerglobalscope">WorkerGlobalScope</a></code> is created after fetching
   a <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#request">Request</a></code> <var>request</var> with a <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#response">Response</a></code> <var>response</var>, then the HTML
-  specification should call out to <a href="#parse-referrer-policy-from-header">§8.1 Parse a referrer policy from a Referrer-Policy header</a> on <var>response</var> and use the
-  resulting <var>policy</var> to execute <a href="#set-referrer-policy">§8.2 Set environment’s referrer policy to policy</a> on <var>request</var>’s <var>environment</var>.</p>
+  specification should call out to <a href="#parse-referrer-policy-from-header">§7.1 Parse a referrer policy from a Referrer-Policy header</a> on <var>response</var> and use the
+  resulting <var>policy</var> to execute <a href="#set-referrer-policy">§7.2 Set environment’s referrer policy to policy</a> on <var>request</var>’s <var>environment</var>.</p>
     <p class="issue" id="issue-cb412d11"><a class="self-link" href="#issue-cb412d11"></a> TODO: define content attribute integrations. For example, for
   img elements, HTML should set the request’s associated referrer policy
   before fetching.</p>
+    <p class="note" role="note">Note: W3C HTML5 does not define the <code>referrerpolicy</code> content
+  attributes, or <code>referrerPolicy</code> IDL attributes, or the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/semantics.html#attr-meta-http-equiv-referrer">Referrer policy state</a> for <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#meta">meta</a></code>. For this spec to make sense
+  with W3C HTML5, those would need to be copied from <a data-link-type="biblio" href="#biblio-html">[HTML]</a>.</p>
    </section>
    <section>
-    <h2 class="heading settled" data-level="8" id="algorithms"><span class="secno">8. </span><span class="content">Algorithms</span><a class="self-link" href="#algorithms"></a></h2>
-    <h3 class="heading settled" data-level="8.1" id="parse-referrer-policy-from-header"><span class="secno">8.1. </span><span class="content"> Parse a referrer policy from a <a data-link-type="dfn" href="#referrer-policy-header-dfn"><code>Referrer-Policy</code></a> header </span><a class="self-link" href="#parse-referrer-policy-from-header"></a></h3>
-    <p>Given a <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#response">Response</a></code> <var>response</var>, the following steps return a <a data-link-type="dfn" href="#referrer-policy">referrer policy</a> according to <var>response</var>’s `<code>Referrer-Policy</code>` header:</p>
+    <h2 class="heading settled" data-level="7" id="algorithms"><span class="secno">7. </span><span class="content">Algorithms</span><a class="self-link" href="#algorithms"></a></h2>
+    <h3 class="heading settled" data-level="7.1" id="parse-referrer-policy-from-header"><span class="secno">7.1. </span><span class="content"> Parse a referrer policy from a <a data-link-type="dfn" href="#referrer-policy-header-dfn" id="ref-for-referrer-policy-header-dfn-1"><code>Referrer-Policy</code></a> header </span><a class="self-link" href="#parse-referrer-policy-from-header"></a></h3>
+    <p>Given a <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#response">Response</a></code> <var>response</var>, the following steps return a <a data-link-type="dfn" href="#referrer-policy" id="ref-for-referrer-policy-7">referrer policy</a> according to <var>response</var>’s `<code>Referrer-Policy</code>` header:</p>
     <ol>
      <li> Let <var>policy-tokens</var> be the result of
       parsing `<code>Referrer-Policy</code>` in <var>response</var>’s header list. 
      <li> Let <var>policy</var> be the empty string. 
-     <li> For each <var>token</var> in <var>policy-tokens</var>, execute <a href="#determine-policy-for-token">§8.6 Determine token’s Policy</a> on <var>token</var> and
+     <li> For each <var>token</var> in <var>policy-tokens</var>, execute <a href="#determine-policy-for-token">§7.6 Determine token’s Policy</a> on <var>token</var> and
       set <var>policy</var> to the result if it is not the empty string. 
      <li> Return <var>policy</var>. 
     </ol>
-    <h3 class="heading settled" data-level="8.2" id="set-referrer-policy"><span class="secno">8.2. </span><span class="content"> Set <var>environment</var>’s referrer policy to <var>policy</var> </span><a class="self-link" href="#set-referrer-policy"></a></h3>
-    <p>If no referrer policy has been set for a <a data-link-type="dfn" href="http://www.w3.org/TR/html5/webappapis.html#settings-object">settings object</a>, then
+    <h3 class="heading settled" data-level="7.2" id="set-referrer-policy"><span class="secno">7.2. </span><span class="content"> Set <var>environment</var>’s referrer policy to <var>policy</var> </span><a class="self-link" href="#set-referrer-policy"></a></h3>
+    <p>If no referrer policy has been set for a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#settings-object">settings object</a>, then
   setting its value is straightforward. If a policy has previously been
   set, then we overwrite it with the new value if the new value is
   not the empty string.</p>
     <ol>
      <li> If <var>policy</var> is the empty string, abort these steps. 
-     <li> If <var>policy</var> is not one of <code><a data-link-type="dfn" href="#no-referrer">No Referrer</a></code>, <code><a data-link-type="dfn" href="#no-referrer-when-downgrade">No Referrer When Downgrade</a></code>, <code><a data-link-type="dfn" href="#origin-only">Origin
-      Only</a></code>, <code><a data-link-type="dfn" href="#origin-when-cross-origin">Origin When Cross-Origin</a></code>, or <code><a data-link-type="dfn" href="#unsafe-url">Unsafe URL</a></code>, then return without setting <var>environment</var>’s referrer policy. 
-     <li> Set <var>environment</var>’s <a data-link-type="dfn" href="#referrer-policy">referrer policy</a> to <var>policy</var>. 
+     <li> If <var>policy</var> is not one of <code><a data-link-type="dfn" href="#no-referrer" id="ref-for-no-referrer-2">No Referrer</a></code>, <code><a data-link-type="dfn" href="#no-referrer-when-downgrade" id="ref-for-no-referrer-when-downgrade-2">No Referrer When Downgrade</a></code>, <code><a data-link-type="dfn" href="#origin-only" id="ref-for-origin-only-2">Origin
+      Only</a></code>, <code><a data-link-type="dfn" href="#origin-when-cross-origin" id="ref-for-origin-when-cross-origin-2">Origin When Cross-Origin</a></code>, or <code><a data-link-type="dfn" href="#unsafe-url" id="ref-for-unsafe-url-2">Unsafe URL</a></code>, then return without setting <var>environment</var>’s referrer policy. 
+     <li> Set <var>environment</var>’s <a data-link-type="dfn" href="#referrer-policy" id="ref-for-referrer-policy-8">referrer policy</a> to <var>policy</var>. 
     </ol>
-    <h3 class="heading settled" data-level="8.3" id="set-requests-referrer-policy-on-redirect"><span class="secno">8.3. </span><span class="content"> Set <var>request</var>’s referrer policy on redirect </span><a class="self-link" href="#set-requests-referrer-policy-on-redirect"></a></h3>
+    <h3 class="heading settled" data-level="7.3" id="set-requests-referrer-policy-on-redirect"><span class="secno">7.3. </span><span class="content"> Set <var>request</var>’s referrer policy on redirect </span><a class="self-link" href="#set-requests-referrer-policy-on-redirect"></a></h3>
     <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> <var>request</var> and a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a> <var>actualResponse</var>,
-  this algorithm updates <var>request</var>’s associated <a data-link-type="dfn" href="#referrer-policy">referrer policy</a> according to the Referrer-Policy header (if any) in <var>actualResponse</var>.</p>
+  this algorithm updates <var>request</var>’s associated <a data-link-type="dfn" href="#referrer-policy" id="ref-for-referrer-policy-9">referrer policy</a> according to the Referrer-Policy header (if any) in <var>actualResponse</var>.</p>
     <ol>
-     <li> Let <var>policy</var> be the result of executing <a href="#parse-referrer-policy-from-header">§8.1 Parse a referrer policy from a Referrer-Policy header</a> on <var>actualResponse</var>. 
+     <li> Let <var>policy</var> be the result of executing <a href="#parse-referrer-policy-from-header">§7.1 Parse a referrer policy from a Referrer-Policy header</a> on <var>actualResponse</var>. 
      <li>If <var>policy</var> is not the empty string, then set <var>request</var>’s
     associated referrer policy to <var>policy</var>.
     </ol>
-    <h3 class="heading settled" data-level="8.4" id="determine-requests-referrer"><span class="secno">8.4. </span><span class="content"> Determine <var>request</var>’s Referrer </span><a class="self-link" href="#determine-requests-referrer"></a></h3>
+    <h3 class="heading settled" data-level="7.4" id="determine-requests-referrer"><span class="secno">7.4. </span><span class="content"> Determine <var>request</var>’s Referrer </span><a class="self-link" href="#determine-requests-referrer"></a></h3>
     <p>Given a <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#request">Request</a></code> <var>request</var>, we can determine the correct
-  referrer information to send by examining the <a data-link-type="dfn" href="#referrer-policy">policy</a> associated
+  referrer information to send by examining the <a data-link-type="dfn" href="#referrer-policy" id="ref-for-referrer-policy-10">policy</a> associated
   with it, as detailed in the following steps, which return
   either <code>no referrer</code> or a URL:</p>
-    <p class="note" role="note">Note: If Fetch is performing a navigation in response to a link of type <code><a data-link-type="dfn" href="http://www.w3.org/TR/html5/links.html#link-type-noreferrer">noreferrer</a></code>, then <var>request</var>’s <code>referrer</code> will be <code>no referrer</code>, and Fetch won’t call
+    <p class="note" role="note">Note: If Fetch is performing a navigation in response to a link of type <code><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/semantics.html#link-type-noreferrer">noreferrer</a></code>, then <var>request</var>’s <code>referrer</code> will be <code>no referrer</code>, and Fetch won’t call
   into this algorithm.</p>
     <ol>
-     <li> Let <var>policy</var> be <var>request</var>’s associated <a data-link-type="dfn" href="#referrer-policy">referrer policy</a>. 
+     <li> Let <var>policy</var> be <var>request</var>’s associated <a data-link-type="dfn" href="#referrer-policy" id="ref-for-referrer-policy-11">referrer policy</a>. 
      <li> Let <var>environment</var> be <var>request</var>’s <code>client</code>. 
      <li>
        If <var>request</var>’s <code>referrer</code> is a URL, then let <var>referrerSource</var> be <var>request</var>’s <code>referrer</code>. Otherwise: 
       <ol>
        <li>
-         If <var>environment</var> is a <a data-link-type="dfn" href="http://www.w3.org/TR/html5/webappapis.html#document-environment">document environment</a>: 
+         If <var>environment</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object">global object</a> is a <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/browsers.html#window">Window</a></code> object: 
         <ol>
-         <li> Let <var>document</var> be the <code class="idl"><a data-link-type="idl" href="http://www.w3.org/TR/dom/#interface-document">Document</a></code> object of the <a data-link-type="dfn" href="http://www.w3.org/TR/html5/browsers.html#active-document">active document</a> of the <a data-link-type="dfn" href="http://www.w3.org/TR/html5/browsers.html#browsing-context">browsing context</a> of <var>environment</var>’s <a data-link-type="dfn" href="http://www.w3.org/TR/html5/webappapis.html#responsible-browsing-context">responsible browsing context</a>. 
+         <li> Let <var>document</var> be the <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/dom.html#document">Document</a></code> object of the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#active-document">active document</a> of the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context">browsing context</a> of <var>environment</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#responsible-browsing-context">responsible browsing context</a>. 
         </ol>
        <li>
-         Otherwise, <var>environment</var> is a <a data-link-type="dfn" href="http://www.w3.org/TR/html5/webappapis.html#worker-environment">worker environment</a>: 
+         Otherwise, <var>environment</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object">global object</a> is a <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#workerglobalscope">WorkerGlobalScope</a></code>: 
         <ol>
-         <li> Let <var>source</var> be the <a data-link-type="dfn" href="http://www.w3.org/TR/html5/webappapis.html#api-referrer-source">API referrer source</a> specified by the <a data-link-type="dfn" href="http://www.w3.org/TR/html5/webappapis.html#incumbent-settings-object">incumbent settings object</a>. 
+         <li> Let <var>source</var> be the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#api-referrer-source">API referrer source</a> specified by the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#incumbent-settings-object">incumbent settings object</a>. 
          <li> If <var>source</var> is a URL, let <var>referrerSource</var> be <var>source</var>, otherwise let <var>document</var> be <var>source</var>. 
         </ol>
        <li>
@@ -1527,31 +1745,31 @@
               origin</a> (because, for example, it has been sandboxed
               into a unique origin), return <code>no referrer</code> and
               abort these steps. 
-         <li> While <var>document</var> corresponds to <a data-link-type="dfn" href="http://www.w3.org/TR/html5/embedded-content-0.html#an-iframe-srcdoc-document">an iframe srcdoc Document</a>,
-              let <var>document</var> be that Document’s <a data-link-type="dfn" href="http://www.w3.org/TR/html5/browsers.html#browsing-context">browsing context</a>’s <a data-link-type="dfn" href="http://www.w3.org/TR/html5/browsers.html#browsing-context-container">browsing context container</a>’s <code class="idl"><a data-link-type="idl" href="http://www.w3.org/TR/dom/#interface-document">Document</a></code>. 
+         <li> While <var>document</var> corresponds to <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#an-iframe-srcdoc-document">an iframe srcdoc Document</a>,
+              let <var>document</var> be that Document’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context">browsing context</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context-container">browsing context container</a>’s <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/dom.html#document">Document</a></code>. 
          <li> Let <var>referrerSource</var> be <var>document</var>’s URL. 
         </ol>
       </ol>
      <li> Let <var>referrerURL</var> be the result of <a href="#strip-url">stripping <var>referrerSource</var> for use as a referrer.</a> 
      <li> Let <var>referrerOrigin</var> be the result of <a href="#strip-url">stripping <var>referrerSource</var> for use as a
-      referrer</a>, with the <code><a data-link-type="dfn" href="#origin-only-flag">origin-only flag</a></code> set to <code>true</code>. 
+      referrer</a>, with the <code><a data-link-type="dfn" href="#origin-only-flag" id="ref-for-origin-only-flag-1">origin-only flag</a></code> set to <code>true</code>. 
      <li>
        Execute the statements corresponding to the value of <var>policy</var>: 
       <dl>
-       <dt><var>policy</var> is <code><a data-link-type="dfn" href="#no-referrer">No Referrer</a></code>
+       <dt><var>policy</var> is <code><a data-link-type="dfn" href="#no-referrer" id="ref-for-no-referrer-3">No Referrer</a></code>
        <dd>Return <code>no referrer</code>
-       <dt><var>policy</var> is <code><a data-link-type="dfn" href="#origin-only">Origin Only</a></code>
+       <dt><var>policy</var> is <code><a data-link-type="dfn" href="#origin-only" id="ref-for-origin-only-3">Origin Only</a></code>
        <dd>Return <var>referrerOrigin</var>
-       <dt><var>policy</var> is <code><a data-link-type="dfn" href="#unsafe-url">Unsafe URL</a></code>
+       <dt><var>policy</var> is <code><a data-link-type="dfn" href="#unsafe-url" id="ref-for-unsafe-url-3">Unsafe URL</a></code>
        <dd>Return <var>referrerURL</var>.
-       <dt> <var>policy</var> is <code><a data-link-type="dfn" href="#origin-when-cross-origin">Origin When Cross-Origin</a></code> 
+       <dt> <var>policy</var> is <code><a data-link-type="dfn" href="#origin-when-cross-origin" id="ref-for-origin-when-cross-origin-3">Origin When Cross-Origin</a></code> 
        <dd>
         <ol>
-         <li> If <var>request</var> is a <a data-link-type="dfn" href="#cross-origin-request">cross-origin request</a>, then
+         <li> If <var>request</var> is a <a data-link-type="dfn" href="#cross-origin-request" id="ref-for-cross-origin-request-5">cross-origin request</a>, then
               return <var>referrerOrigin</var>. 
          <li> Otherwise, return <var>referrerURL</var>. 
         </ol>
-       <dt> <var>policy</var> is <code><a data-link-type="dfn" href="#no-referrer-when-downgrade">No Referrer When Downgrade</a></code> 
+       <dt> <var>policy</var> is <code><a data-link-type="dfn" href="#no-referrer-when-downgrade" id="ref-for-no-referrer-when-downgrade-3">No Referrer When Downgrade</a></code> 
        <dt> <var>policy</var> is the empty string. 
        <dd>
         <ol>
@@ -1566,23 +1784,25 @@
         </ol>
       </dl>
     </ol>
-    <h3 class="heading settled" data-level="8.5" id="strip-url"><span class="secno">8.5. </span><span class="content"> Strip <var>url</var> for use as a referrer </span><a class="self-link" href="#strip-url"></a></h3>
+    <h3 class="heading settled" data-level="7.5" id="strip-url"><span class="secno">7.5. </span><span class="content"> Strip <var>url</var> for use as a referrer </span><a class="self-link" href="#strip-url"></a></h3>
     <p>Certain portions of URLs MUST not be included when sending a URL as the value
   of a `<code>Referer</code>` header: a URLs fragment, username, and password
   components should be stripped from the URL before it’s sent out. This
-  algorithm accepts a <code><dfn data-dfn-type="dfn" data-noexport="" id="origin-only-flag">origin-only flag<a class="self-link" href="#origin-only-flag"></a></dfn></code>, which defaults
+  algorithm accepts a <code><dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="origin-only flag" data-noexport="" id="origin-only-flag">origin-only flag<span class="dfn-panel" data-deco=""><b><a href="#origin-only-flag">#origin-only-flag</a></b><b>Referenced in:</b><span><a href="#ref-for-origin-only-flag-1">7.4. 
+    Determine request’s Referrer </a></span><span><a href="#ref-for-origin-only-flag-2">7.5. 
+    Strip url for use as a referrer </a></span></span></dfn></code>, which defaults
   to <code>false</code>. If set to <code>true</code>, the algorithm will
   additionally remove the URL’s path and query components, leaving only the
   scheme, host, and port.</p>
     <ol>
      <li> If <var>url</var> is <code>null</code>, return <code>no referrer</code>. 
-     <li> If <var>url</var>’s <code>scheme</code> is a <a data-link-type="dfn" href="http://www.w3.org/TR/url/#local-scheme">local scheme</a>, then
+     <li> If <var>url</var>’s <code>scheme</code> is a <a data-link-type="dfn" href="https://url.spec.whatwg.org#local-scheme">local scheme</a>, then
       return <code>no referrer</code>. 
      <li> Set <var>url</var>’s <code>username</code> to the empty string. 
      <li> Set <var>url</var>’s <code>password</code> to <code>null</code>. 
      <li> Set <var>url</var>’s <code>fragment</code> to <code>null</code>. 
      <li>
-       If the <code><a data-link-type="dfn" href="#origin-only-flag">origin-only flag</a></code> is <code>true</code>,
+       If the <code><a data-link-type="dfn" href="#origin-only-flag" id="ref-for-origin-only-flag-2">origin-only flag</a></code> is <code>true</code>,
       then: 
       <ol>
        <li> Set <var>url</var>’s <code>path</code> to <code>null</code>. 
@@ -1590,57 +1810,57 @@
       </ol>
      <li> Return <var>url</var>. 
     </ol>
-    <h3 class="heading settled" data-level="8.6" id="determine-policy-for-token"><span class="secno">8.6. </span><span class="content"> Determine <var>token</var>’s Policy </span><a class="self-link" href="#determine-policy-for-token"></a></h3>
-    <p>Given a string <var>token</var> (for example, the value of a <a data-link-type="dfn" href="#referrer-policy-header-dfn"><code>Referrer-Policy</code></a> header), this algorithm will return the <a data-link-type="dfn" href="#referrer-policy">referrer policy</a> it refers to:</p>
+    <h3 class="heading settled" data-level="7.6" id="determine-policy-for-token"><span class="secno">7.6. </span><span class="content"> Determine <var>token</var>’s Policy </span><a class="self-link" href="#determine-policy-for-token"></a></h3>
+    <p>Given a string <var>token</var> (for example, the value of a <a data-link-type="dfn" href="#referrer-policy-header-dfn" id="ref-for-referrer-policy-header-dfn-2"><code>Referrer-Policy</code></a> header), this algorithm will return the <a data-link-type="dfn" href="#referrer-policy" id="ref-for-referrer-policy-12">referrer policy</a> it refers to:</p>
     <ol>
-     <li> If <var>token</var> is an <a data-link-type="dfn" href="http://www.w3.org/TR/html5/infrastructure.html#ascii-case-insensitive">ASCII case-insensitive match</a> for the
-      strings "<code>never</code>" or "<code>no-referrer</code>", return <a data-link-type="dfn" href="#no-referrer"><code>No Referrer</code></a>. 
-     <li> If <var>token</var> is <a data-link-type="dfn" href="http://www.w3.org/TR/html5/infrastructure.html#ascii-case-insensitive">ASCII case-insensitive match</a> for the string
+     <li> If <var>token</var> is an <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#ascii-case-insensitive">ASCII case-insensitive match</a> for the
+      strings "<code>never</code>" or "<code>no-referrer</code>", return <a data-link-type="dfn" href="#no-referrer" id="ref-for-no-referrer-4"><code>No Referrer</code></a>. 
+     <li> If <var>token</var> is <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#ascii-case-insensitive">ASCII case-insensitive match</a> for the string
       "<code>default</code>" or "<code>no-referrer-when-downgrade</code>",
-      return <a data-link-type="dfn" href="#no-referrer-when-downgrade"><code>No Referrer When Downgrade</code></a>. 
-     <li> If <var>token</var> is an <a data-link-type="dfn" href="http://www.w3.org/TR/html5/infrastructure.html#ascii-case-insensitive">ASCII case-insensitive match</a> for the
-      string "<code>origin</code>", return <a data-link-type="dfn" href="#origin-only"><code>Origin Only</code></a>. 
-     <li> If <var>token</var> is <a data-link-type="dfn" href="http://www.w3.org/TR/html5/infrastructure.html#ascii-case-insensitive">ASCII case-insensitive match</a> for the string
-      "<code>origin-when-cross-origin</code>", return <a data-link-type="dfn" href="#origin-when-cross-origin"><code>Origin When Cross-Origin</code></a>. 
-     <li> If <var>token</var> is <a data-link-type="dfn" href="http://www.w3.org/TR/html5/infrastructure.html#ascii-case-insensitive">ASCII case-insensitive match</a> for the strings
+      return <a data-link-type="dfn" href="#no-referrer-when-downgrade" id="ref-for-no-referrer-when-downgrade-4"><code>No Referrer When Downgrade</code></a>. 
+     <li> If <var>token</var> is an <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#ascii-case-insensitive">ASCII case-insensitive match</a> for the
+      string "<code>origin</code>", return <a data-link-type="dfn" href="#origin-only" id="ref-for-origin-only-4"><code>Origin Only</code></a>. 
+     <li> If <var>token</var> is <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#ascii-case-insensitive">ASCII case-insensitive match</a> for the string
+      "<code>origin-when-cross-origin</code>", return <a data-link-type="dfn" href="#origin-when-cross-origin" id="ref-for-origin-when-cross-origin-4"><code>Origin When Cross-Origin</code></a>. 
+     <li> If <var>token</var> is <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#ascii-case-insensitive">ASCII case-insensitive match</a> for the strings
       "<code>always</code>" or "<code>unsafe-url</code>",
-      return <a data-link-type="dfn" href="#unsafe-url"><code>Unsafe URL</code></a>. 
-     <li> If <var>token</var> is empty, return <a data-link-type="dfn" href="#no-referrer"><code>No Referrer</code></a>. 
+      return <a data-link-type="dfn" href="#unsafe-url" id="ref-for-unsafe-url-4"><code>Unsafe URL</code></a>. 
+     <li> If <var>token</var> is empty, return <a data-link-type="dfn" href="#no-referrer" id="ref-for-no-referrer-5"><code>No Referrer</code></a>. 
      <li> Return the empty string. 
     </ol>
     <p class="note" role="note">Note: Authors are encouraged to avoid the legacy keywords <code>never</code>, <code>default</code>, and <code>always</code>. The
   keywords <code>no-referrer</code>, <code>no-referrer-when-downgrade</code>, and <code>unsafe-url</code> respectively are preferred.</p>
    </section>
    <section>
-    <h2 class="heading settled" data-level="9" id="privacy"><span class="secno">9. </span><span class="content">Privacy Considerations</span><a class="self-link" href="#privacy"></a></h2>
-    <h3 class="heading settled" data-level="9.1" id="user-controls"><span class="secno">9.1. </span><span class="content">User Controls</span><a class="self-link" href="#user-controls"></a></h3>
+    <h2 class="heading settled" data-level="8" id="privacy"><span class="secno">8. </span><span class="content">Privacy Considerations</span><a class="self-link" href="#privacy"></a></h2>
+    <h3 class="heading settled" data-level="8.1" id="user-controls"><span class="secno">8.1. </span><span class="content">User Controls</span><a class="self-link" href="#user-controls"></a></h3>
     <p>Nothing in this specification should be interpreted as preventing user
   agents from offering options to users which would change the information
   sent out via a `<code>Referer</code>` header. For instance, user agents
   MAY allow users to suppress the referrer header entirely, regardless of the
-  active <a data-link-type="dfn" href="#referrer-policy">referrer policy</a> on a page.</p>
+  active <a data-link-type="dfn" href="#referrer-policy" id="ref-for-referrer-policy-13">referrer policy</a> on a page.</p>
    </section>
    <section>
-    <h2 class="heading settled" data-level="10" id="security"><span class="secno">10. </span><span class="content">Security Considerations</span><a class="self-link" href="#security"></a></h2>
-    <h3 class="heading settled" data-level="10.1" id="information-leakage"><span class="secno">10.1. </span><span class="content">Information Leakage</span><a class="self-link" href="#information-leakage"></a></h3>
+    <h2 class="heading settled" data-level="9" id="security"><span class="secno">9. </span><span class="content">Security Considerations</span><a class="self-link" href="#security"></a></h2>
+    <h3 class="heading settled" data-level="9.1" id="information-leakage"><span class="secno">9.1. </span><span class="content">Information Leakage</span><a class="self-link" href="#information-leakage"></a></h3>
     <p>The referrer policies <code>origin</code> and <code>unsafe-url</code> might
   leak the origin and the URL of a secure site respectively via insecure
   transport.</p>
     <p>Those two policies are include in the spec nevertheless to lower the friction
   of sites adopting secure transport.</p>
-    <h3 class="heading settled" data-level="10.2" id="downgrade"><span class="secno">10.2. </span><span class="content">Downgrade to less strict policies</span><a class="self-link" href="#downgrade"></a></h3>
+    <h3 class="heading settled" data-level="9.2" id="downgrade"><span class="secno">9.2. </span><span class="content">Downgrade to less strict policies</span><a class="self-link" href="#downgrade"></a></h3>
     <p>The spec does not forbid downgrading to less strict policies, e.g., from <code>never</code> to <code>unsafe-url</code>.</p>
     <p>On the one hand, it is not clear which policy is more strict for all possible
   pairs of policies: While <code>no-referrer-when-downgrade</code> will not
   leak any information over insecure transport, and <code>origin</code> will,
   the latter reveals less information across cross-origin navigations.</p>
     <p>On the other hand, allowing for setting less strict policies enables authors
-  to define safe fallbacks as described in <a href="#unknown-policy-values">§11.1 Unknown Policy Values</a>.</p>
+  to define safe fallbacks as described in <a href="#unknown-policy-values">§10.1 Unknown Policy Values</a>.</p>
    </section>
    <section>
-    <h2 class="heading settled" data-level="11" id="authoring"><span class="secno">11. </span><span class="content">Authoring Considerations</span><a class="self-link" href="#authoring"></a></h2>
-    <h3 class="heading settled" data-level="11.1" id="unknown-policy-values"><span class="secno">11.1. </span><span class="content">Unknown Policy Values</span><a class="self-link" href="#unknown-policy-values"></a></h3>
-    <p>As described in <a href="#determine-policy-for-token">§8.6 Determine token’s Policy</a> and <a href="#set-referrer-policy">§8.2 Set environment’s referrer policy to policy</a>, unknown policy values will be ignored, and
+    <h2 class="heading settled" data-level="10" id="authoring"><span class="secno">10. </span><span class="content">Authoring Considerations</span><a class="self-link" href="#authoring"></a></h2>
+    <h3 class="heading settled" data-level="10.1" id="unknown-policy-values"><span class="secno">10.1. </span><span class="content">Unknown Policy Values</span><a class="self-link" href="#unknown-policy-values"></a></h3>
+    <p>As described in <a href="#determine-policy-for-token">§7.6 Determine token’s Policy</a> and <a href="#set-referrer-policy">§7.2 Set environment’s referrer policy to policy</a>, unknown policy values will be ignored, and
   when multiple sources specify a referrer policy, the value of the
   latest one will be used. This makes it possible to deploy new policy
   values.</p>
@@ -1652,29 +1872,29 @@
     the last to be processed. </div>
    </section>
    <section>
-    <h2 class="heading settled" data-level="12" id="acknowledgements"><span class="secno">12. </span><span class="content">Acknowledgements</span><a class="self-link" href="#acknowledgements"></a></h2>
+    <h2 class="heading settled" data-level="11" id="acknowledgements"><span class="secno">11. </span><span class="content">Acknowledgements</span><a class="self-link" href="#acknowledgements"></a></h2>
     <p>This specification is based in large part on Adam Barth and Jochen Eisinger’s <a href="http://wiki.whatwg.org/wiki/Meta_referrer">Meta referrer</a> document.</p>
    </section>
   </main>
   <h2 class="no-ref no-num heading settled" id="conformance"><span class="content">Conformance</span><a class="self-link" href="#conformance"></a></h2>
   <h3 class="no-ref no-num heading settled" id="conventions"><span class="content">Document conventions</span><a class="self-link" href="#conventions"></a></h3>
   <p>Conformance requirements are expressed with a combination of
-    descriptive assertions and RFC 2119 terminology. The key words "MUST",
-    "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT",
-    "RECOMMENDED", "MAY", and "OPTIONAL" in the normative parts of this
+    descriptive assertions and RFC 2119 terminology. The key words “MUST”,
+    “MUST NOT”, “REQUIRED”, “SHALL”, “SHALL NOT”, “SHOULD”, “SHOULD NOT”,
+    “RECOMMENDED”, “MAY”, and “OPTIONAL” in the normative parts of this
     document are to be interpreted as described in RFC 2119.
     However, for readability, these words do not appear in all uppercase
     letters in this specification. </p>
   <p>All of the text of this specification is normative except sections
     explicitly marked as non-normative, examples, and notes. <a data-link-type="biblio" href="#biblio-rfc2119">[RFC2119]</a></p>
-  <p>Examples in this specification are introduced with the words "for example"
+  <p>Examples in this specification are introduced with the words “for example”
     or are set apart from the normative text with <code>class="example"</code>,
     like this: </p>
   <div class="example" id="example-f839f6c8">
    <a class="self-link" href="#example-f839f6c8"></a> 
    <p>This is an example of an informative example.</p>
   </div>
-  <p>Informative notes begin with the word "Note" and are set apart from the
+  <p>Informative notes begin with the word “Note” and are set apart from the
     normative text with <code>class="note"</code>, like this: </p>
   <p class="note" role="note">Note, this is an informative note.</p>
   <h3 class="no-ref no-num heading settled" id="conformant-algorithms"><span class="content">Conformant Algorithms</span><a class="self-link" href="#conformant-algorithms"></a></h3>
@@ -1687,27 +1907,19 @@
     particular, the algorithms defined in this specification are intended to
     be easy to understand and are not intended to be performant. Implementers
     are encouraged to optimize.</p>
-  <h2 class="no-num heading settled" id="index"><span class="content">Index</span><a class="self-link" href="#index"></a></h2>
-  <h3 class="no-num heading settled" id="index-defined-here"><span class="content">Terms defined by this specification</span><a class="self-link" href="#index-defined-here"></a></h3>
-  <ul class="indexlist">
+<script src="https://www.w3.org/scripts/TR/2016/fixup.js"></script>
+  <h2 class="no-num no-ref heading settled" id="index"><span class="content">Index</span><a class="self-link" href="#index"></a></h2>
+  <h3 class="no-num no-ref heading settled" id="index-defined-here"><span class="content">Terms defined by this specification</span><a class="self-link" href="#index-defined-here"></a></h3>
+  <ul class="index">
    <li><a href="#cross-origin-request">cross-origin</a><span>, in §2</span>
    <li><a href="#cross-origin-request">cross-origin request</a><span>, in §2</span>
    <li><a href="#no-referrer">No Referrer</a><span>, in §3.1</span>
    <li><a href="#no-referrer-when-downgrade">No Referrer When Downgrade</a><span>, in §3.2</span>
    <li><a href="#origin-only">Origin Only</a><span>, in §3.3</span>
-   <li><a href="#origin-only-flag">origin-only flag</a><span>, in §8.5</span>
+   <li><a href="#origin-only-flag">origin-only flag</a><span>, in §7.5</span>
    <li><a href="#origin-when-cross-origin">Origin When Cross-Origin</a><span>, in §3.4</span>
    <li><a href="#referrer-policy">policy</a><span>, in §2</span>
    <li><a href="#policy-token">policy-token</a><span>, in §4.1</span>
-   <li>
-    referrerPolicy
-    <ul>
-     <li><a href="#dom-htmlanchorelement-referrerpolicy">attribute for HTMLAnchorElement</a><span>, in §5.1</span>
-     <li><a href="#dom-htmlareaelement-referrerpolicy">attribute for HTMLAreaElement</a><span>, in §5.2</span>
-     <li><a href="#dom-htmlimageelement-referrerpolicy">attribute for HTMLImageElement</a><span>, in §5.3</span>
-     <li><a href="#dom-htmliframeelement-referrerpolicy">attribute for HTMLIFrameElement</a><span>, in §5.4</span>
-     <li><a href="#dom-htmllinkelement-referrerpolicy">attribute for HTMLLinkElement</a><span>, in §5.5</span>
-    </ul>
    <li><a href="#referrer-policy-header-dfn">Referrer-Policy</a><span>, in §4.1</span>
    <li><a href="#referrer-policy">referrer policy</a><span>, in §2</span>
    <li><a href="#referrer-policy-header-dfn">referrer-policy header</a><span>, in §4.1</span>
@@ -1715,15 +1927,10 @@
    <li><a href="#same-origin-request">same-origin request</a><span>, in §2</span>
    <li><a href="#unsafe-url">Unsafe URL</a><span>, in §3.5</span>
   </ul>
-  <h3 class="no-num heading settled" id="index-defined-elsewhere"><span class="content">Terms defined by reference</span><a class="self-link" href="#index-defined-elsewhere"></a></h3>
-  <ul class="indexlist">
+  <h3 class="no-num no-ref heading settled" id="index-defined-elsewhere"><span class="content">Terms defined by reference</span><a class="self-link" href="#index-defined-elsewhere"></a></h3>
+  <ul class="index">
    <li>
-    <a data-link-type="biblio" href="#biblio-dom">[dom]</a> defines the following terms:
-    <ul>
-     <li><a href="http://www.w3.org/TR/dom/#interface-document">Document</a>
-    </ul>
-   <li>
-    <a data-link-type="biblio" href="#biblio-fetch">[FETCH]</a> defines the following terms:
+    <a data-link-type="biblio">[FETCH]</a> defines the following terms:
     <ul>
      <li><a href="https://fetch.spec.whatwg.org/#request">Request</a>
      <li><a href="https://fetch.spec.whatwg.org/#response">Response</a>
@@ -1734,143 +1941,143 @@
      <li><a href="https://fetch.spec.whatwg.org/#concept-request-url">url</a>
     </ul>
    <li>
-    <a data-link-type="biblio" href="#biblio-html">[HTML]</a> defines the following terms:
+    <a data-link-type="biblio">[HTML]</a> defines the following terms:
     <ul>
+     <li><a href="https://html.spec.whatwg.org/multipage/dom.html#document">Document</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/#the-a-element">a</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/browsers.html#active-document">active document</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/embedded-content.html#an-iframe-srcdoc-document">an iframe srcdoc document</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#api-referrer-source">api referrer source</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/infrastructure.html#ascii-case-insensitive">ascii case-insensitive match</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context">browsing context</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context-container">browsing context container</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object">global object</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#incumbent-settings-object">incumbent settings object</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/semantics.html#attr-meta-name">name</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/browsers.html#nested-browsing-context">nested browsing context</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/semantics.html#link-type-noreferrer">noreferrer</a>
      <li><a href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin-opaque">opaque origin</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/browsers.html#parent-browsing-context">parent browsing context</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/infrastructure.html#referrer-policy-attribute">referrer policy attribute</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/semantics.html#attr-meta-http-equiv-referrer">referrer policy state</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#responsible-browsing-context">responsible browsing context</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/workers.html#run-a-worker">run a worker</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#settings-object">settings object</a>
     </ul>
    <li>
-    <a data-link-type="biblio" href="#biblio-html5">[html5]</a> defines the following terms:
-    <ul>
-     <li><a href="http://www.w3.org/TR/html5/text-level-semantics.html#the-a-element">a</a>
-     <li><a href="http://www.w3.org/TR/html5/browsers.html#active-document">active document</a>
-     <li><a href="http://www.w3.org/TR/html5/embedded-content-0.html#an-iframe-srcdoc-document">an iframe srcdoc document</a>
-     <li><a href="http://www.w3.org/TR/html5/webappapis.html#api-referrer-source">api referrer source</a>
-     <li><a href="http://www.w3.org/TR/html5/infrastructure.html#ascii-case-insensitive">ascii case-insensitive match</a>
-     <li><a href="http://www.w3.org/TR/html5/browsers.html#browsing-context">browsing context</a>
-     <li><a href="http://www.w3.org/TR/html5/browsers.html#browsing-context-container">browsing context container</a>
-     <li><a href="http://www.w3.org/TR/html5/document-metadata.html#attr-meta-content">content</a>
-     <li><a href="http://www.w3.org/TR/html5/webappapis.html#document-environment">document environment</a>
-     <li><a href="http://www.w3.org/TR/html5/embedded-content-0.html#the-iframe-element">iframe</a>
-     <li><a href="http://www.w3.org/TR/html5/webappapis.html#incumbent-settings-object">incumbent settings object</a>
-     <li><a href="http://www.w3.org/TR/html5/infrastructure.html#limited-to-only-known-values">limited to only known values</a>
-     <li><a href="http://www.w3.org/TR/html5/document-metadata.html#the-meta-element">meta</a>
-     <li><a href="http://www.w3.org/TR/html5/document-metadata.html#attr-meta-name">name</a>
-     <li><a href="http://www.w3.org/TR/html5/browsers.html#nested-browsing-context">nested browsing context</a>
-     <li><a href="http://www.w3.org/TR/html5/links.html#link-type-noreferrer">noreferrer</a>
-     <li><a href="http://www.w3.org/TR/html5/browsers.html#parent-browsing-context">parent browsing context</a>
-     <li><a href="http://www.w3.org/TR/html5/infrastructure.html#reflect">reflect</a>
-     <li><a href="http://www.w3.org/TR/html5/embedded-content-0.html#relevant-mutations">relevant mutation</a>
-     <li><a href="http://www.w3.org/TR/html5/webappapis.html#responsible-browsing-context">responsible browsing context</a>
-     <li><a href="http://www.w3.org/TR/html5/webappapis.html#settings-object">settings object</a>
-     <li><a href="http://www.w3.org/TR/html5/infrastructure.html#strip-leading-and-trailing-whitespace">strip leading and trailing whitespace</a>
-     <li><a href="http://www.w3.org/TR/html5/webappapis.html#worker-environment">worker environment</a>
-    </ul>
-   <li>
-    <a data-link-type="biblio" href="#biblio-mix">[MIX]</a> defines the following terms:
+    <a data-link-type="biblio">[MIX]</a> defines the following terms:
     <ul>
      <li><a href="https://w3c.github.io/webappsec/specs/mixedcontent/#a-priori-authenticated-url">a priori authenticated url</a>
     </ul>
    <li>
-    <a data-link-type="biblio" href="#biblio-rfc6454">[RFC6454]</a> defines the following terms:
+    <a data-link-type="biblio">[RFC6454]</a> defines the following terms:
     <ul>
      <li><a href="https://tools.ietf.org/html/rfc6454#section-6.2">ascii serialization of an origin</a>
      <li><a href="https://tools.ietf.org/html/rfc6454#section-3.2">origin</a>
      <li><a href="https://tools.ietf.org/html/rfc6454#section-5">the same</a>
     </ul>
    <li>
-    <a data-link-type="biblio" href="#biblio-rfc7231">[RFC7231]</a> defines the following terms:
+    <a data-link-type="biblio">[RFC7231]</a> defines the following terms:
     <ul>
      <li><a href="https://tools.ietf.org/html/rfc7231#section-5.5.2">referer</a>
     </ul>
    <li>
-    <a data-link-type="biblio" href="#biblio-url">[url]</a> defines the following terms:
+    <a data-link-type="biblio">[WHATWG-URL]</a> defines the following terms:
     <ul>
-     <li><a href="http://www.w3.org/TR/url/#url">URL</a>
-     <li><a href="http://www.w3.org/TR/url/#local-scheme">local scheme</a>
+     <li><a href="https://url.spec.whatwg.org#url">URL</a>
+     <li><a href="https://url.spec.whatwg.org#local-scheme">local scheme</a>
     </ul>
    <li>
-    <a data-link-type="biblio" href="#biblio-workers">[workers]</a> defines the following terms:
-    <ul>
-     <li><a href="http://www.w3.org/TR/workers/#run-a-worker">runs a worker</a>
-    </ul>
-   <li>
-    <a data-link-type="biblio" href="#biblio-wsc-ui">[wsc-ui]</a> defines the following terms:
+    <a data-link-type="biblio">[wsc-ui]</a> defines the following terms:
     <ul>
      <li><a href="http://www.w3.org/TR/2010/REC-wsc-ui-20100812/#typesoftls">tls-protected</a>
     </ul>
    <li>
-    <a data-link-type="biblio" href="#biblio-html">[HTML]</a> defines the following terms:
+    <a data-link-type="biblio">[HTML]</a> defines the following terms:
     <ul>
-     <li><a href="https://html.spec.whatwg.org/multipage/semantics.html#htmlanchorelement">HTMLAnchorElement</a>
-     <li><a href="https://html.spec.whatwg.org/multipage/embedded-content.html#htmlareaelement">HTMLAreaElement</a>
-     <li><a href="https://html.spec.whatwg.org/multipage/embedded-content.html#htmliframeelement">HTMLIFrameElement</a>
-     <li><a href="https://html.spec.whatwg.org/multipage/embedded-content.html#htmlimageelement">HTMLImageElement</a>
-     <li><a href="https://html.spec.whatwg.org/multipage/semantics.html#htmllinkelement">HTMLLinkElement</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/browsers.html#window">Window</a>
      <li><a href="https://html.spec.whatwg.org/multipage/workers.html#workerglobalscope">WorkerGlobalScope</a>
      <li><a href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-area-element">area</a>
-     <li><a href="https://html.spec.whatwg.org/multipage/semantics.html#the-head-element">head</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-iframe-element">iframe</a>
      <li><a href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element">img</a>
      <li><a href="https://html.spec.whatwg.org/multipage/semantics.html#the-link-element">link</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/semantics.html#meta">meta</a>
     </ul>
   </ul>
-  <h2 class="no-num heading settled" id="references"><span class="content">References</span><a class="self-link" href="#references"></a></h2>
-  <h3 class="no-num heading settled" id="normative"><span class="content">Normative References</span><a class="self-link" href="#normative"></a></h3>
+  <h2 class="no-num no-ref heading settled" id="references"><span class="content">References</span><a class="self-link" href="#references"></a></h2>
+  <h3 class="no-num no-ref heading settled" id="normative"><span class="content">Normative References</span><a class="self-link" href="#normative"></a></h3>
   <dl>
-   <dt id="biblio-fetch"><a class="self-link" href="#biblio-fetch"></a>[FETCH]
+   <dt id="biblio-fetch">[FETCH]
    <dd>Anne van Kesteren. <a href="http://fetch.spec.whatwg.org/">Fetch</a>. Living Standard. URL: <a href="http://fetch.spec.whatwg.org/">http://fetch.spec.whatwg.org/</a>
-   <dt id="biblio-html"><a class="self-link" href="#biblio-html"></a>[HTML]
+   <dt id="biblio-html">[HTML]
    <dd>Ian Hickson. <a href="https://html.spec.whatwg.org/multipage/">HTML Standard</a>. Living Standard. URL: <a href="https://html.spec.whatwg.org/multipage/">https://html.spec.whatwg.org/multipage/</a>
-   <dt id="biblio-mix"><a class="self-link" href="#biblio-mix"></a>[MIX]
+   <dt id="biblio-mix">[MIX]
    <dd>Mike West. <a href="https://w3c.github.io/webappsec/specs/mixedcontent/">Mixed Content</a>. ED. URL: <a href="https://w3c.github.io/webappsec/specs/mixedcontent/">https://w3c.github.io/webappsec/specs/mixedcontent/</a>
-   <dt id="biblio-rfc6454"><a class="self-link" href="#biblio-rfc6454"></a>[RFC6454]
-   <dd>Adam Barth. <a href="http://www.ietf.org/rfc/rfc6454.txt">The Web Origin Concept</a>. RFC. URL: <a href="http://www.ietf.org/rfc/rfc6454.txt">http://www.ietf.org/rfc/rfc6454.txt</a>
-   <dt id="biblio-rfc7231"><a class="self-link" href="#biblio-rfc7231"></a>[RFC7231]
-   <dd>Roy T. Fielding; Julian F. Reschke. <a href="http://www.ietf.org/rfc/rfc7231.txt">HTTP/1.1 Semantics and Content</a>. RFC. URL: <a href="http://www.ietf.org/rfc/rfc7231.txt">http://www.ietf.org/rfc/rfc7231.txt</a>
-   <dt id="biblio-dom"><a class="self-link" href="#biblio-dom"></a>[DOM]
-   <dd>Anne van Kesteren; et al. <a href="http://www.w3.org/TR/dom/">W3C DOM4</a>. 6 October 2015. PR. URL: <a href="http://www.w3.org/TR/dom/">http://www.w3.org/TR/dom/</a>
-   <dt id="biblio-html5"><a class="self-link" href="#biblio-html5"></a>[HTML5]
-   <dd>Ian Hickson; et al. <a href="http://www.w3.org/TR/html5/">HTML5</a>. 28 October 2014. REC. URL: <a href="http://www.w3.org/TR/html5/">http://www.w3.org/TR/html5/</a>
-   <dt id="biblio-rfc2119"><a class="self-link" href="#biblio-rfc2119"></a>[RFC2119]
+   <dt id="biblio-rfc2119">[RFC2119]
    <dd>S. Bradner. <a href="https://tools.ietf.org/html/rfc2119">Key words for use in RFCs to Indicate Requirement Levels</a>. March 1997. Best Current Practice. URL: <a href="https://tools.ietf.org/html/rfc2119">https://tools.ietf.org/html/rfc2119</a>
-   <dt id="biblio-url"><a class="self-link" href="#biblio-url"></a>[URL]
-   <dd>Anne van Kesteren; Sam Ruby. <a href="http://www.w3.org/TR/url-1/">URL</a>. 9 December 2014. WD. URL: <a href="http://www.w3.org/TR/url-1/">http://www.w3.org/TR/url-1/</a>
-   <dt id="biblio-workers"><a class="self-link" href="#biblio-workers"></a>[WORKERS]
-   <dd>Ian Hickson. <a href="http://www.w3.org/TR/workers/">Web Workers</a>. 24 September 2015. WD. URL: <a href="http://www.w3.org/TR/workers/">http://www.w3.org/TR/workers/</a>
-   <dt id="biblio-wsc-ui"><a class="self-link" href="#biblio-wsc-ui"></a>[WSC-UI]
+   <dt id="biblio-rfc6454">[RFC6454]
+   <dd>Adam Barth. <a href="http://www.ietf.org/rfc/rfc6454.txt">The Web Origin Concept</a>. RFC. URL: <a href="http://www.ietf.org/rfc/rfc6454.txt">http://www.ietf.org/rfc/rfc6454.txt</a>
+   <dt id="biblio-rfc7231">[RFC7231]
+   <dd>Roy T. Fielding; Julian F. Reschke. <a href="http://www.ietf.org/rfc/rfc7231.txt">HTTP/1.1 Semantics and Content</a>. RFC. URL: <a href="http://www.ietf.org/rfc/rfc7231.txt">http://www.ietf.org/rfc/rfc7231.txt</a>
+   <dt id="biblio-whatwg-url">[WHATWG-URL]
+   <dd>Anne van Kesteren; Sam Ruby. <a href="https://url.spec.whatwg.org/">URL Standard</a>. Living Standard. URL: <a href="https://url.spec.whatwg.org/">https://url.spec.whatwg.org/</a>
+   <dt id="biblio-wsc-ui">[WSC-UI]
    <dd>Thomas Roessler; Anil Saldhana. <a href="http://www.w3.org/TR/wsc-ui/">Web Security Context: User Interface Guidelines</a>. 12 August 2010. REC. URL: <a href="http://www.w3.org/TR/wsc-ui/">http://www.w3.org/TR/wsc-ui/</a>
   </dl>
-  <h3 class="no-num heading settled" id="informative"><span class="content">Informative References</span><a class="self-link" href="#informative"></a></h3>
+  <h3 class="no-num no-ref heading settled" id="informative"><span class="content">Informative References</span><a class="self-link" href="#informative"></a></h3>
   <dl>
-   <dt id="biblio-capability-urls"><a class="self-link" href="#biblio-capability-urls"></a>[CAPABILITY-URLS]
+   <dt id="biblio-capability-urls">[CAPABILITY-URLS]
    <dd>Jenni Tennison. <a href="http://www.w3.org/TR/capability-urls/">Capability URLs</a>. WD. URL: <a href="http://www.w3.org/TR/capability-urls/">http://www.w3.org/TR/capability-urls/</a>
   </dl>
-  <h2 class="no-num heading settled" id="idl-index"><span class="content">IDL Index</span><a class="self-link" href="#idl-index"></a></h2>
-<pre class="idl">partial interface <a class="idl-code" data-link-type="interface" href="https://html.spec.whatwg.org/multipage/semantics.html#htmlanchorelement">HTMLAnchorElement</a> {
-  attribute DOMString <a data-type="DOMString " href="#dom-htmlanchorelement-referrerpolicy">referrerPolicy</a>;
-};
-
-partial interface <a class="idl-code" data-link-type="interface" href="https://html.spec.whatwg.org/multipage/embedded-content.html#htmlareaelement">HTMLAreaElement</a> {
-  attribute DOMString <a data-type="DOMString " href="#dom-htmlareaelement-referrerpolicy">referrerPolicy</a>;
-};
-
-partial interface <a class="idl-code" data-link-type="interface" href="https://html.spec.whatwg.org/multipage/embedded-content.html#htmlimageelement">HTMLImageElement</a> {
-  attribute DOMString <a data-type="DOMString " href="#dom-htmlimageelement-referrerpolicy">referrerPolicy</a>;
-};
-
-partial interface <a class="idl-code" data-link-type="interface" href="https://html.spec.whatwg.org/multipage/embedded-content.html#htmliframeelement">HTMLIFrameElement</a> {
-  attribute DOMString <a data-type="DOMString " href="#dom-htmliframeelement-referrerpolicy">referrerPolicy</a>;
-};
-
-partial interface <a class="idl-code" data-link-type="interface" href="https://html.spec.whatwg.org/multipage/semantics.html#htmllinkelement">HTMLLinkElement</a> {
-  attribute DOMString <a data-type="DOMString " href="#dom-htmllinkelement-referrerpolicy">referrerPolicy</a>;
-};
-
-</pre>
-  <h2 class="no-num heading settled" id="issues-index"><span class="content">Issues Index</span><a class="self-link" href="#issues-index"></a></h2>
+  <h2 class="no-num no-ref heading settled" id="issues-index"><span class="content">Issues Index</span><a class="self-link" href="#issues-index"></a></h2>
   <div style="counter-reset:issue">
    <div class="issue"> TODO: define content attribute integrations. For example, for
   img elements, HTML should set the request’s associated referrer policy
   before fetching.<a href="#issue-cb412d11"> ↵ </a></div>
   </div>
- </body>
-</html>
+<script>/* script-dfn-panel */
+
+        document.body.addEventListener("click", function(e) {
+            var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
+            // Find the dfn element or panel, if any, that was clicked on.
+            var el = e.target;
+            var target;
+            while(el.parentElement) {
+                if(el.tagName == "A") {
+                    // Clicked on a link; intercept this early in case it was nested in a <dfn>
+                    return true;
+                }
+                if(el.tagName == "DFN") {
+                    target = "dfn";
+                    break;
+                }
+                if(/H\d/.test(el.tagName) && el.getAttribute('data-dfn-type') != null) {
+                    target = "dfn";
+                    break;
+                }
+                if(el.classList.contains("dfn-panel")) {
+                    target = "dfn-panel";
+                    break;
+                }
+                el = el.parentElement;
+            }
+            if(target != "dfn-panel") {
+                // Turn off any currently "on" or "activated" panels.
+                queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
+                    el.classList.remove("on");
+                    el.classList.remove("activated");
+                });
+            }
+            if(target == "dfn") {
+                // open the panel
+                var dfnPanel = el.querySelector(".dfn-panel");
+                if(dfnPanel) {
+                    dfnPanel.classList.add("on");
+                }
+            } else if(target == "dfn-panel") {
+                // Switch it to "activated" state, which pins it.
+                el.classList.add("activated");
+            }
+
+        });
+        </script>

--- a/index.html
+++ b/index.html
@@ -1323,7 +1323,7 @@ Possible extra rowspan handling
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="http://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Referrer Policy</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2016-05-02">2 May 2016</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2016-05-04">4 May 2016</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1385,13 +1385,13 @@ Possible extra rowspan handling
      </ol>
     <li><a href="#terms"><span class="secno">2</span> <span class="content">Key Concepts and Terminology</span></a>
     <li>
-     <a href="#referrer-policy-states"><span class="secno">3</span> <span class="content">Referrer Policy States</span></a>
+     <a href="#referrer-policies"><span class="secno">3</span> <span class="content">Referrer Policies</span></a>
      <ol class="toc">
-      <li><a href="#referrer-policy-state-no-referrer"><span class="secno">3.1</span> <span class="content">No Referrer</span></a>
-      <li><a href="#referrer-policy-state-no-referrer-when-downgrade"><span class="secno">3.2</span> <span class="content">No Referrer When Downgrade</span></a>
-      <li><a href="#referrer-policy-state-origin"><span class="secno">3.3</span> <span class="content">Origin Only</span></a>
-      <li><a href="#referrer-policy-state-origin-when-cross-origin"><span class="secno">3.4</span> <span class="content">Origin When Cross-Origin</span></a>
-      <li><a href="#referrer-policy-state-unsafe-url"><span class="secno">3.5</span> <span class="content">Unsafe URL</span></a>
+      <li><a href="#referrer-policy-no-referrer"><span class="secno">3.1</span> <span class="content">"<code>no-referrer</code>"</span></a>
+      <li><a href="#referrer-policy-no-referrer-when-downgrade"><span class="secno">3.2</span> <span class="content">"<code>no-referrer-when-downgrade</code>"</span></a>
+      <li><a href="#referrer-policy-origin"><span class="secno">3.3</span> <span class="content">"<code>origin-only</code>"</span></a>
+      <li><a href="#referrer-policy-origin-when-cross-origin"><span class="secno">3.4</span> <span class="content">"<code>origin-when-cross-origin</code>"</span></a>
+      <li><a href="#referrer-policy-unsafe-url"><span class="secno">3.5</span> <span class="content">"<code>unsafe-url</code>"</span></a>
      </ol>
     <li>
      <a href="#referrer-policy-delivery"><span class="secno">4</span> <span class="content">Referrer Policy Delivery</span></a>
@@ -1495,103 +1495,102 @@ Possible extra rowspan handling
    <section>
     <h2 class="heading settled" data-level="2" id="terms"><span class="secno">2. </span><span class="content">Key Concepts and Terminology</span><a class="self-link" href="#terms"></a></h2>
     <dl>
-     <dt> <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" data-local-lt="policy" data-lt="referrer policy" id="referrer-policy">referrer policy<span class="dfn-panel" data-deco=""><b><a href="#referrer-policy">#referrer-policy</a></b><b>Referenced in:</b><span><a href="#ref-for-referrer-policy-1">3. Referrer Policy States</a> <a href="#ref-for-referrer-policy-2">(2)</a></span><span><a href="#ref-for-referrer-policy-3">4. Referrer Policy Delivery</a></span><span><a href="#ref-for-referrer-policy-4">4.2. Delivery via meta</a></span><span><a href="#ref-for-referrer-policy-5">4.4. Implicit Delivery</a></span><span><a href="#ref-for-referrer-policy-6">4.4.1. 
-     Nested Browsing Contexts </a></span><span><a href="#ref-for-referrer-policy-7">7.1. 
-    Parse a referrer policy from a Referrer-Policy header </a></span><span><a href="#ref-for-referrer-policy-8">7.2. 
-    Set environment’s referrer policy to policy </a></span><span><a href="#ref-for-referrer-policy-9">7.3. 
-    Set request’s referrer policy on redirect </a></span><span><a href="#ref-for-referrer-policy-10">7.4. 
-    Determine request’s Referrer </a> <a href="#ref-for-referrer-policy-11">(2)</a></span><span><a href="#ref-for-referrer-policy-12">7.6. 
-    Determine token’s Policy </a></span><span><a href="#ref-for-referrer-policy-13">8.1. User Controls</a></span></span></dfn> 
+     <dt> <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-referrer-policy">referrer policy</a> 
      <dd>
-       A <strong>referrer policy</strong> is a property of a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#settings-object">settings
-      object</a> that defines the algorithm used to populate the <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc7231#section-5.5.2"><code>Referer</code></a> header when <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#fetching">fetching</a> subresources,
-      prefetching, or performing navigations. 
-      <p>If no referrer policy is explicitly set for a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#settings-object">settings object</a>,
-      then the value of the property is the empty string. Otherwise, the value
-      is whatever has been explicitly set, as explained in the <a href="#set-referrer-policy">§7.2 Set environment’s referrer policy to policy</a> algorithm.</p>
-     <dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-local-lt="same-origin" data-lt="same-origin request" data-noexport="" id="same-origin-request">same-origin request<span class="dfn-panel" data-deco=""><b><a href="#same-origin-request">#same-origin-request</a></b><b>Referenced in:</b><span><a href="#ref-for-same-origin-request-1">2. Key Concepts and Terminology</a></span><span><a href="#ref-for-same-origin-request-2">3.3. Origin Only</a></span><span><a href="#ref-for-same-origin-request-3">3.4. Origin When Cross-Origin</a></span><span><a href="#ref-for-same-origin-request-4">3.5. Unsafe URL</a></span></span></dfn>
+       A <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-referrer-policy">referrer policy</a> modifies the algorithm used to populate the <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc7231#section-5.5.2"><code>Referer</code></a> header when <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#fetching">fetching</a> subresources,
+      prefetching, or performing navigations. This document defines the various
+      behaviors for each <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-referrer-policy">referrer policy</a>. 
+      <p>The empty string corresponds to no <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-referrer-policy">referrer policy</a>, causing a
+      fallback to a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-referrer-policy">referrer policy</a> defined elsewhere, or in the case
+      where no such higher-level policy is available, defaulting to <a data-link-type="dfn" href="#referrer-policy-no-referrer-when-downgrade" id="ref-for-referrer-policy-no-referrer-when-downgrade-1">"<code>no-referrer-when-downgrade</code>"</a>.</p>
+      <p>Every <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">environment settings object</a> has a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-referrer-policy">referrer policy</a>. If
+      no <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-referrer-policy">referrer policy</a> is explicitly set for an <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">environment settings
+      object</a>, then the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-referrer-policy">referrer policy</a> is the empty string. Otherwise,
+      the value is whatever has been explicitly set, as explained in the <a href="#set-referrer-policy">§7.2 Set environment’s referrer policy to policy</a> algorithm.</p>
+     <dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="same-origin request" data-noexport="" id="same-origin-request">same-origin request<span class="dfn-panel" data-deco=""><b><a href="#same-origin-request">#same-origin-request</a></b><b>Referenced in:</b><span><a href="#ref-for-same-origin-request-1">2. Key Concepts and Terminology</a></span><span><a href="#ref-for-same-origin-request-2">3.3. "origin-only"</a></span><span><a href="#ref-for-same-origin-request-3">3.4. "origin-when-cross-origin"</a></span><span><a href="#ref-for-same-origin-request-4">3.5. "unsafe-url"</a></span></span></dfn>
      <dd> A <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#request">Request</a></code> <var>request</var> is a <strong>same-origin request</strong> if <var>request</var>’s <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#concept-request-origin">origin</a></code> and the <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc6454#section-3.2">origin</a> of <var>request</var>’s <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#concept-request-url">url</a></code> are <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc6454#section-5"><code>the same</code></a>. 
-     <dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-local-lt="cross-origin" data-lt="cross-origin request" data-noexport="" id="cross-origin-request">cross-origin request<span class="dfn-panel" data-deco=""><b><a href="#cross-origin-request">#cross-origin-request</a></b><b>Referenced in:</b><span><a href="#ref-for-cross-origin-request-1">3.3. Origin Only</a></span><span><a href="#ref-for-cross-origin-request-2">3.4. Origin When Cross-Origin</a> <a href="#ref-for-cross-origin-request-3">(2)</a></span><span><a href="#ref-for-cross-origin-request-4">3.5. Unsafe URL</a></span><span><a href="#ref-for-cross-origin-request-5">7.4. 
+     <dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="cross-origin request" data-noexport="" id="cross-origin-request">cross-origin request<span class="dfn-panel" data-deco=""><b><a href="#cross-origin-request">#cross-origin-request</a></b><b>Referenced in:</b><span><a href="#ref-for-cross-origin-request-1">3.3. "origin-only"</a></span><span><a href="#ref-for-cross-origin-request-2">3.4. "origin-when-cross-origin"</a> <a href="#ref-for-cross-origin-request-3">(2)</a></span><span><a href="#ref-for-cross-origin-request-4">3.5. "unsafe-url"</a></span><span><a href="#ref-for-cross-origin-request-5">7.4. 
     Determine request’s Referrer </a></span></span></dfn>
      <dd> A <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#request">Request</a></code> is a <strong>cross-origin request</strong> if it is <em>not</em> <a data-link-type="dfn" href="#same-origin-request" id="ref-for-same-origin-request-1">same-origin</a>. 
     </dl>
    </section>
    <section>
-    <h2 class="heading settled" data-level="3" id="referrer-policy-states"><span class="secno">3. </span><span class="content">Referrer Policy States</span><a class="self-link" href="#referrer-policy-states"></a></h2>
-    <p>Every <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#settings-object">settings object</a> has a <a data-link-type="dfn" href="#referrer-policy" id="ref-for-referrer-policy-1">referrer policy</a> which governs
-  the referrer information sent along with requests made for subresources, and
-  for navigations. The <a data-link-type="dfn" href="#referrer-policy" id="ref-for-referrer-policy-2">policy</a> will be the empty string if no policy has
-  been set, otherwise it will be one of the following five values: <code><a data-link-type="dfn" href="#no-referrer" id="ref-for-no-referrer-1">No Referrer</a></code>, <code><a data-link-type="dfn" href="#no-referrer-when-downgrade" id="ref-for-no-referrer-when-downgrade-1">No Referrer When
-  Downgrade</a></code>, <code><a data-link-type="dfn" href="#origin-only" id="ref-for-origin-only-1">Origin Only</a></code>, <code><a data-link-type="dfn" href="#origin-when-cross-origin" id="ref-for-origin-when-cross-origin-1">Origin When
-  Cross-origin</a></code>, and <code><a data-link-type="dfn" href="#unsafe-url" id="ref-for-unsafe-url-1">Unsafe URL</a></code>. Each is explained
-  below, and a detailed algorithm for evaluating their effect is given in the <a href="#integration-with-fetch">§5 Integration with Fetch</a> and <a href="#algorithms">§7 Algorithms</a> sections:</p>
-    <p class="note" role="note">Note: The referrer policy for a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#settings-object">settings object</a> provides a default
-  baseline policy for requests. This policy may be tightened for specific
-  requests via mechanisms like the <code><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/semantics.html#link-type-noreferrer">noreferrer</a></code> link type.</p>
-    <h3 class="heading settled" data-level="3.1" id="referrer-policy-state-no-referrer"><span class="secno">3.1. </span><span class="content">No Referrer</span><a class="self-link" href="#referrer-policy-state-no-referrer"></a></h3>
-    <p>The simplest policy is <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="No Referrer" data-noexport="" id="no-referrer">No Referrer<span class="dfn-panel" data-deco=""><b><a href="#no-referrer">#no-referrer</a></b><b>Referenced in:</b><span><a href="#ref-for-no-referrer-1">3. Referrer Policy States</a></span><span><a href="#ref-for-no-referrer-2">7.2. 
-    Set environment’s referrer policy to policy </a></span><span><a href="#ref-for-no-referrer-3">7.4. 
-    Determine request’s Referrer </a></span><span><a href="#ref-for-no-referrer-4">7.6. 
-    Determine token’s Policy </a> <a href="#ref-for-no-referrer-5">(2)</a></span></span></dfn>, which specifies that no
-  referrer information is to be sent along with requests made from a particular <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#settings-object">settings object</a> to any <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc6454#section-3.2">origin</a>. The header will be omitted
-  entirely.</p>
-    <div class="example" id="example-27d86a4b"><a class="self-link" href="#example-27d86a4b"></a> If a document at <code>https://example.com/page.html</code> sets a policy of <code>No Referrer</code>, then navigations to <code>https://example.com/</code> (or any other URL) would send no <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc7231#section-5.5.2"><code>Referer</code></a> header. </div>
-    <h3 class="heading settled" data-level="3.2" id="referrer-policy-state-no-referrer-when-downgrade"><span class="secno">3.2. </span><span class="content">No Referrer When Downgrade</span><a class="self-link" href="#referrer-policy-state-no-referrer-when-downgrade"></a></h3>
-    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="No Referrer When Downgrade" data-noexport="" id="no-referrer-when-downgrade">No Referrer When Downgrade<span class="dfn-panel" data-deco=""><b><a href="#no-referrer-when-downgrade">#no-referrer-when-downgrade</a></b><b>Referenced in:</b><span><a href="#ref-for-no-referrer-when-downgrade-1">3. Referrer Policy States</a></span><span><a href="#ref-for-no-referrer-when-downgrade-2">7.2. 
-    Set environment’s referrer policy to policy </a></span><span><a href="#ref-for-no-referrer-when-downgrade-3">7.4. 
-    Determine request’s Referrer </a></span><span><a href="#ref-for-no-referrer-when-downgrade-4">7.6. 
-    Determine token’s Policy </a></span></span></dfn> policy sends a full URL along with
-  requests from <a data-link-type="dfn" href="http://www.w3.org/TR/2010/REC-wsc-ui-20100812/#typesoftls">TLS-protected</a> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#settings-object">settings object</a> to a <a data-link-type="dfn" href="https://w3c.github.io/webappsec/specs/mixedcontent/#a-priori-authenticated-url"><em>a priori</em> authenticated URL</a>, and requests from <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#settings-object">settings
-  objects</a> which are <em>not</em> <a data-link-type="dfn" href="http://www.w3.org/TR/2010/REC-wsc-ui-20100812/#typesoftls">TLS-protected</a> to any <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc6454#section-3.2">origin</a>.</p>
-    <p>Requests from <a data-link-type="dfn" href="http://www.w3.org/TR/2010/REC-wsc-ui-20100812/#typesoftls">TLS-protected</a> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#settings-object">settings objects</a> to not-<a data-link-type="dfn" href="https://w3c.github.io/webappsec/specs/mixedcontent/#a-priori-authenticated-url"><em>a
-  priori</em> authenticated URL</a>, on the other hand, will contain no referrer
-  information. A <code><a data-link-type="dfn" href="https://tools.ietf.org/html/rfc7231#section-5.5.2">Referer</a></code> HTTP header will not be sent.</p>
-    <div class="example" id="example-506cf3f7">
-     <a class="self-link" href="#example-506cf3f7"></a> If a document at <code>https://example.com/page.html</code> sets a policy of <code>No Referrer When Downgrade</code>, then navigations to <code>https://not.example.com/</code> would send a <code><a data-link-type="dfn" href="https://tools.ietf.org/html/rfc7231#section-5.5.2">Referer</a></code> HTTP header with a value of <code>https://example.com/page.html</code>, as neither resource’s origin is an
+    <h2 class="heading settled" data-level="3" id="referrer-policies"><span class="secno">3. </span><span class="content">Referrer Policies</span><span id="referrer-policy-states"></span><a class="self-link" href="#referrer-policies"></a></h2>
+    <p>Each possible <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-referrer-policy">referrer policy</a>, besides the empty string, is explained
+  below. A detailed algorithm for evaluating their effect is given in the <a href="#integration-with-fetch">§5 Integration with Fetch</a> and <a href="#algorithms">§7 Algorithms</a> sections.</p>
+    <p class="note" role="note">Note: The referrer policy for an <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">environment settings object</a> provides a
+  default baseline policy for requests when that <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">environment settings
+  object</a> is used as a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client">request client</a>. This policy may be tightened
+  for specific requests via mechanisms like the <code><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/semantics.html#link-type-noreferrer">noreferrer</a></code> link type.</p>
+    <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-export="" data-level="3.1" data-lt="&quot;no-referrer&quot;" id="referrer-policy-no-referrer"><span class="secno">3.1. </span><span class="content">"<code>no-referrer</code>"</span><span id="referrer-policy-state-no-referrer"></span><span class="dfn-panel" data-deco=""><b><a href="#referrer-policy-no-referrer">#referrer-policy-no-referrer</a></b><b>Referenced in:</b><span><a href="#ref-for-referrer-policy-no-referrer-1">3.1. "no-referrer"</a> <a href="#ref-for-referrer-policy-no-referrer-2">(2)</a></span><span><a href="#ref-for-referrer-policy-no-referrer-3">7.2. 
+    Set environment’s referrer policy to policy </a></span><span><a href="#ref-for-referrer-policy-no-referrer-4">7.4. 
+    Determine request’s Referrer </a></span><span><a href="#ref-for-referrer-policy-no-referrer-5">7.6. 
+    Determine token’s Policy </a> <a href="#ref-for-referrer-policy-no-referrer-6">(2)</a></span><span><a href="#ref-for-referrer-policy-no-referrer-7">9.2. Downgrade to less strict policies</a></span></span></h3>
+    <p>The simplest policy is <a data-link-type="dfn" href="#referrer-policy-no-referrer" id="ref-for-referrer-policy-no-referrer-1">"<code>no-referrer</code>"</a>, which specifies
+  that no referrer information is to be sent along with requests made from a
+  particular <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client">request client</a> to any <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc6454#section-3.2">origin</a>. The header will be
+  omitted entirely.</p>
+    <div class="example" id="example-df4273ed"><a class="self-link" href="#example-df4273ed"></a> If a document at <code>https://example.com/page.html</code> sets a policy of <a data-link-type="dfn" href="#referrer-policy-no-referrer" id="ref-for-referrer-policy-no-referrer-2">"<code>no-referrer</code>"</a>, then navigations to <code>https://example.com/</code> (or any other URL) would send no <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc7231#section-5.5.2"><code>Referer</code></a> header. </div>
+    <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-export="" data-level="3.2" data-lt="&quot;no-referrer-when-downgrade&quot;" id="referrer-policy-no-referrer-when-downgrade"><span class="secno">3.2. </span><span class="content">"<code>no-referrer-when-downgrade</code>"</span><span id="referrer-policy-state-no-referrer-when-downgrade"></span><span class="dfn-panel" data-deco=""><b><a href="#referrer-policy-no-referrer-when-downgrade">#referrer-policy-no-referrer-when-downgrade</a></b><b>Referenced in:</b><span><a href="#ref-for-referrer-policy-no-referrer-when-downgrade-1">2. Key Concepts and Terminology</a></span><span><a href="#ref-for-referrer-policy-no-referrer-when-downgrade-2">3.2. "no-referrer-when-downgrade"</a> <a href="#ref-for-referrer-policy-no-referrer-when-downgrade-3">(2)</a></span><span><a href="#ref-for-referrer-policy-no-referrer-when-downgrade-4">4.4.2. 
+    Workers </a></span><span><a href="#ref-for-referrer-policy-no-referrer-when-downgrade-5">7.2. 
+    Set environment’s referrer policy to policy </a></span><span><a href="#ref-for-referrer-policy-no-referrer-when-downgrade-6">7.4. 
+    Determine request’s Referrer </a></span><span><a href="#ref-for-referrer-policy-no-referrer-when-downgrade-7">7.6. 
+    Determine token’s Policy </a></span><span><a href="#ref-for-referrer-policy-no-referrer-when-downgrade-8">9.2. Downgrade to less strict policies</a></span></span></h3>
+    <p>The <a data-link-type="dfn" href="#referrer-policy-no-referrer-when-downgrade" id="ref-for-referrer-policy-no-referrer-when-downgrade-2">"<code>no-referrer-when-downgrade</code>"</a> policy sends a full URL
+  along with requests from <a data-link-type="dfn" href="http://www.w3.org/TR/2010/REC-wsc-ui-20100812/#typesoftls">TLS-protected</a> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">environment settings
+  object</a> to a <a data-link-type="dfn" href="https://w3c.github.io/webappsec/specs/mixedcontent/#a-priori-authenticated-url"><em>a priori</em> authenticated URL</a>, and requests from <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client">request clients</a> which are <em>not</em> <a data-link-type="dfn" href="http://www.w3.org/TR/2010/REC-wsc-ui-20100812/#typesoftls">TLS-protected</a> to any <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc6454#section-3.2">origin</a>.</p>
+    <p>Requests from <a data-link-type="dfn" href="http://www.w3.org/TR/2010/REC-wsc-ui-20100812/#typesoftls">TLS-protected</a> <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client">request clients</a> to non-<a data-link-type="dfn" href="https://w3c.github.io/webappsec/specs/mixedcontent/#a-priori-authenticated-url"><em>a
+  priori</em> authenticated URLs</a>, on the other hand, will contain no
+  referrer information. A <code><a data-link-type="dfn" href="https://tools.ietf.org/html/rfc7231#section-5.5.2">Referer</a></code> HTTP header will not be
+  sent.</p>
+    <div class="example" id="example-0323e875">
+     <a class="self-link" href="#example-0323e875"></a> If a document at <code>https://example.com/page.html</code> sets a policy of <a data-link-type="dfn" href="#referrer-policy-no-referrer-when-downgrade" id="ref-for-referrer-policy-no-referrer-when-downgrade-3">"<code>no-referrer-when-downgrade</code>"</a>, then navigations to <code>https://not.example.com/</code> would send a <code><a data-link-type="dfn" href="https://tools.ietf.org/html/rfc7231#section-5.5.2">Referer</a></code> HTTP header with a value of <code>https://example.com/page.html</code>, as neither resource’s origin is an
     non-<a data-link-type="dfn" href="https://w3c.github.io/webappsec/specs/mixedcontent/#a-priori-authenticated-url"><em>a priori</em> authenticated URL</a>. 
      <p>Navigations from that same page to <code><strong>http</strong>://not.example.com/</code> would send no <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc7231#section-5.5.2"><code>Referer</code></a> header.</p>
     </div>
     <p>This is a user agent’s default behavior, if no policy is otherwise specified.</p>
-    <h3 class="heading settled" data-level="3.3" id="referrer-policy-state-origin"><span class="secno">3.3. </span><span class="content">Origin Only</span><a class="self-link" href="#referrer-policy-state-origin"></a></h3>
-    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="Origin Only" data-noexport="" id="origin-only">Origin Only<span class="dfn-panel" data-deco=""><b><a href="#origin-only">#origin-only</a></b><b>Referenced in:</b><span><a href="#ref-for-origin-only-1">3. Referrer Policy States</a></span><span><a href="#ref-for-origin-only-2">7.2. 
-    Set environment’s referrer policy to policy </a></span><span><a href="#ref-for-origin-only-3">7.4. 
-    Determine request’s Referrer </a></span><span><a href="#ref-for-origin-only-4">7.6. 
-    Determine token’s Policy </a></span></span></dfn> policy specifies that only the <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc6454#section-6.2">ASCII serialization</a> of the <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc6454#section-3.2">origin</a> of the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#settings-object">settings object</a> from which a request is
-  made is sent as referrer information when making both <a data-link-type="dfn" href="#same-origin-request" id="ref-for-same-origin-request-2">same-origin
-  requests</a> and <a data-link-type="dfn" href="#cross-origin-request" id="ref-for-cross-origin-request-1">cross-origin requests</a> from a particular <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#settings-object">settings object</a>.</p>
+    <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-export="" data-level="3.3" data-lt="&quot;origin-only&quot;" id="referrer-policy-origin"><span class="secno">3.3. </span><span class="content">"<code>origin-only</code>"</span><span id="referrer-policy-state-origin"></span><span class="dfn-panel" data-deco=""><b><a href="#referrer-policy-origin">#referrer-policy-origin</a></b><b>Referenced in:</b><span><a href="#ref-for-referrer-policy-origin-1">3.3. "origin-only"</a> <a href="#ref-for-referrer-policy-origin-2">(2)</a> <a href="#ref-for-referrer-policy-origin-3">(3)</a></span><span><a href="#ref-for-referrer-policy-origin-4">7.2. 
+    Set environment’s referrer policy to policy </a></span><span><a href="#ref-for-referrer-policy-origin-5">7.4. 
+    Determine request’s Referrer </a></span><span><a href="#ref-for-referrer-policy-origin-6">7.6. 
+    Determine token’s Policy </a></span><span><a href="#ref-for-referrer-policy-origin-7">9.1. Information Leakage</a></span><span><a href="#ref-for-referrer-policy-origin-8">9.2. Downgrade to less strict policies</a></span><span><a href="#ref-for-referrer-policy-origin-9">10.1. Unknown Policy Values</a> <a href="#ref-for-referrer-policy-origin-10">(2)</a></span></span></h3>
+    <p>The <a data-link-type="dfn" href="#referrer-policy-origin" id="ref-for-referrer-policy-origin-1">"<code>origin-only</code>"</a> policy specifies that only the <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc6454#section-6.2">ASCII serialization</a> of the <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc6454#section-3.2">origin</a> of the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client">request client</a> is sent as referrer information
+  when making both <a data-link-type="dfn" href="#same-origin-request" id="ref-for-same-origin-request-2">same-origin requests</a> and <a data-link-type="dfn" href="#cross-origin-request" id="ref-for-cross-origin-request-1">cross-origin requests</a> from a particular <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client">request client</a>.</p>
     <p class="note" role="note">Note: The serialization of an origin looks like <code>https://example.com</code>. To ensure that a valid URL is sent in the
   `<code>Referer</code>` header, user agents will append a U+002F SOLIDUS
   ("<code>/</code>") character to the origin (e.g. <code>https://example.com/</code>).</p>
-    <p class="note" role="note">Note: The <code>Origin Only</code> policy causes the origin of HTTPS referrers
-  to be sent over the network as part of unencrypted HTTP requests.</p>
-    <div class="example" id="example-6fbea3ba"><a class="self-link" href="#example-6fbea3ba"></a> If a document at <code>https://example.com/page.html</code> sets a policy of <code>Origin Only</code>, then navigations to any <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc6454#section-3.2">origin</a> would send a <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc7231#section-5.5.2"><code>Referer</code></a> header with a value of <code>https://example.com/</code>, even to URLs that are not <a data-link-type="dfn" href="https://w3c.github.io/webappsec/specs/mixedcontent/#a-priori-authenticated-url"><em>a
+    <p class="note" role="note">Note: The <a data-link-type="dfn" href="#referrer-policy-origin" id="ref-for-referrer-policy-origin-2">"<code>origin-only</code>"</a> policy causes the origin of HTTPS
+  referrers to be sent over the network as part of unencrypted HTTP requests.</p>
+    <div class="example" id="example-53e91b6d"><a class="self-link" href="#example-53e91b6d"></a> If a document at <code>https://example.com/page.html</code> sets a policy of <a data-link-type="dfn" href="#referrer-policy-origin" id="ref-for-referrer-policy-origin-3">"<code>origin-only</code>"</a>, then navigations to any <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc6454#section-3.2">origin</a> would send a <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc7231#section-5.5.2"><code>Referer</code></a> header with a value
+    of <code>https://example.com/</code>, even to URLs that are not <a data-link-type="dfn" href="https://w3c.github.io/webappsec/specs/mixedcontent/#a-priori-authenticated-url"><em>a
     priori</em> authenticated URLs</a>. </div>
-    <h3 class="heading settled" data-level="3.4" id="referrer-policy-state-origin-when-cross-origin"><span class="secno">3.4. </span><span class="content">Origin When Cross-Origin</span><a class="self-link" href="#referrer-policy-state-origin-when-cross-origin"></a></h3>
-    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="Origin When Cross-Origin" data-noexport="" id="origin-when-cross-origin">Origin When Cross-Origin<span class="dfn-panel" data-deco=""><b><a href="#origin-when-cross-origin">#origin-when-cross-origin</a></b><b>Referenced in:</b><span><a href="#ref-for-origin-when-cross-origin-1">3. Referrer Policy States</a></span><span><a href="#ref-for-origin-when-cross-origin-2">7.2. 
-    Set environment’s referrer policy to policy </a></span><span><a href="#ref-for-origin-when-cross-origin-3">7.4. 
-    Determine request’s Referrer </a></span><span><a href="#ref-for-origin-when-cross-origin-4">7.6. 
-    Determine token’s Policy </a></span></span></dfn> policy specifies that a full URL, <a href="#strip-url">stripped for use as a referrer</a>, is sent as referrer
-  information when making <a data-link-type="dfn" href="#same-origin-request" id="ref-for-same-origin-request-3">same-origin requests</a> from a particular <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#settings-object">settings object</a>, and only the <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc6454#section-6.2">ASCII serialization</a> of the <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc6454#section-3.2">origin</a> of the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#settings-object">settings object</a> from which a request is
-  made is sent as referrer information when making <a data-link-type="dfn" href="#cross-origin-request" id="ref-for-cross-origin-request-2">cross-origin requests</a> from a particular <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#settings-object">settings object</a>.</p>
-    <p class="note" role="note">Note: For the <code>Origin When Cross-Origin</code> policy, we also consider
-  protocol upgrades, e.g. requests from <code>http://example.com/</code> to <code>https://example.com/</code> to be <a data-link-type="dfn" href="#cross-origin-request" id="ref-for-cross-origin-request-3">cross-origin requests</a>.</p>
-    <p class="note" role="note">Note: The <code>Origin When Cross-Origin</code> policy causes the origin of
-  HTTPS referrers to be sent over the network as part of unencrypted HTTP
-  requests.</p>
-    <div class="example" id="example-95035dec">
-     <a class="self-link" href="#example-95035dec"></a> If a document at <code>https://example.com/page.html</code> sets a policy of <code>Origin When Cross-Origin</code>, then navigations to any <code>https://example.com/not-page.html</code> would send a <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc7231#section-5.5.2"><code>Referer</code></a> header with a value of <code>https://example.com/page.html</code>. 
+    <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-export="" data-level="3.4" data-lt="&quot;origin-when-cross-origin&quot;" id="referrer-policy-origin-when-cross-origin"><span class="secno">3.4. </span><span class="content">"<code>origin-when-cross-origin</code>"</span><span id="referrer-policy-state-origin-when-cross-origin"></span><span class="dfn-panel" data-deco=""><b><a href="#referrer-policy-origin-when-cross-origin">#referrer-policy-origin-when-cross-origin</a></b><b>Referenced in:</b><span><a href="#ref-for-referrer-policy-origin-when-cross-origin-1">3.4. "origin-when-cross-origin"</a> <a href="#ref-for-referrer-policy-origin-when-cross-origin-2">(2)</a> <a href="#ref-for-referrer-policy-origin-when-cross-origin-3">(3)</a> <a href="#ref-for-referrer-policy-origin-when-cross-origin-4">(4)</a></span><span><a href="#ref-for-referrer-policy-origin-when-cross-origin-5">7.2. 
+    Set environment’s referrer policy to policy </a></span><span><a href="#ref-for-referrer-policy-origin-when-cross-origin-6">7.4. 
+    Determine request’s Referrer </a></span><span><a href="#ref-for-referrer-policy-origin-when-cross-origin-7">7.6. 
+    Determine token’s Policy </a></span></span></h3>
+    <p>The <a data-link-type="dfn" href="#referrer-policy-origin-when-cross-origin" id="ref-for-referrer-policy-origin-when-cross-origin-1">"<code>origin-when-cross-origin</code>"</a> policy specifies that a
+  full URL, <a href="#strip-url">stripped for use as a referrer</a>, is sent as
+  referrer information when making <a data-link-type="dfn" href="#same-origin-request" id="ref-for-same-origin-request-3">same-origin requests</a> from a particular <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client">request client</a>, and only the <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc6454#section-6.2">ASCII serialization</a> of the <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc6454#section-3.2">origin</a> of the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client">request client</a> is sent as referrer information
+  when making <a data-link-type="dfn" href="#cross-origin-request" id="ref-for-cross-origin-request-2">cross-origin requests</a> from a particular <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client">request
+  client</a>.</p>
+    <p class="note" role="note">Note: For the <a data-link-type="dfn" href="#referrer-policy-origin-when-cross-origin" id="ref-for-referrer-policy-origin-when-cross-origin-2">"<code>origin-when-cross-origin</code>"</a> policy, we also
+  consider protocol upgrades, e.g. requests from <code>http://example.com/</code> to <code>https://example.com/</code>, to be <a data-link-type="dfn" href="#cross-origin-request" id="ref-for-cross-origin-request-3">cross-origin requests</a>.</p>
+    <p class="note" role="note">Note: The <a data-link-type="dfn" href="#referrer-policy-origin-when-cross-origin" id="ref-for-referrer-policy-origin-when-cross-origin-3">"<code>origin-when-cross-origin</code>"</a> policy causes the
+  origin of HTTPS referrers to be sent over the network as part of unencrypted
+  HTTP requests.</p>
+    <div class="example" id="example-13ea72fa">
+     <a class="self-link" href="#example-13ea72fa"></a> If a document at <code>https://example.com/page.html</code> sets a policy of <a data-link-type="dfn" href="#referrer-policy-origin-when-cross-origin" id="ref-for-referrer-policy-origin-when-cross-origin-4">"<code>origin-when-cross-origin</code>"</a>, then navigations to any <code>https://example.com/not-page.html</code> would send a <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc7231#section-5.5.2"><code>Referer</code></a> header with a value of <code>https://example.com/page.html</code>. 
      <p>Navigations from that same page to <code>https://not.example.com/</code> would send a <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc7231#section-5.5.2"><code>Referer</code></a> header with a value of <code>https://example.com/</code>, even to URLs that are not <a data-link-type="dfn" href="https://w3c.github.io/webappsec/specs/mixedcontent/#a-priori-authenticated-url"><em>a
     priori</em> authenticated URLs</a>.</p>
     </div>
-    <h3 class="heading settled" data-level="3.5" id="referrer-policy-state-unsafe-url"><span class="secno">3.5. </span><span class="content">Unsafe URL</span><a class="self-link" href="#referrer-policy-state-unsafe-url"></a></h3>
-    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="Unsafe URL" data-noexport="" id="unsafe-url">Unsafe URL<span class="dfn-panel" data-deco=""><b><a href="#unsafe-url">#unsafe-url</a></b><b>Referenced in:</b><span><a href="#ref-for-unsafe-url-1">3. Referrer Policy States</a></span><span><a href="#ref-for-unsafe-url-2">7.2. 
-    Set environment’s referrer policy to policy </a></span><span><a href="#ref-for-unsafe-url-3">7.4. 
-    Determine request’s Referrer </a></span><span><a href="#ref-for-unsafe-url-4">7.6. 
-    Determine token’s Policy </a></span></span></dfn> policy specifies that a full URL, <a href="#strip-url">stripped for use as a referrer</a>, is sent along with
+    <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-export="" data-level="3.5" data-lt="&quot;unsafe-url&quot;" id="referrer-policy-unsafe-url"><span class="secno">3.5. </span><span class="content">"<code>unsafe-url</code>"</span><span id="referrer-policy-state-unsafe-url"></span><span class="dfn-panel" data-deco=""><b><a href="#referrer-policy-unsafe-url">#referrer-policy-unsafe-url</a></b><b>Referenced in:</b><span><a href="#ref-for-referrer-policy-unsafe-url-1">3.5. "unsafe-url"</a> <a href="#ref-for-referrer-policy-unsafe-url-2">(2)</a></span><span><a href="#ref-for-referrer-policy-unsafe-url-3">7.2. 
+    Set environment’s referrer policy to policy </a></span><span><a href="#ref-for-referrer-policy-unsafe-url-4">7.4. 
+    Determine request’s Referrer </a></span><span><a href="#ref-for-referrer-policy-unsafe-url-5">7.6. 
+    Determine token’s Policy </a></span><span><a href="#ref-for-referrer-policy-unsafe-url-6">9.1. Information Leakage</a></span><span><a href="#ref-for-referrer-policy-unsafe-url-7">9.2. Downgrade to less strict policies</a></span><span><a href="#ref-for-referrer-policy-unsafe-url-8">10.1. Unknown Policy Values</a> <a href="#ref-for-referrer-policy-unsafe-url-9">(2)</a> <a href="#ref-for-referrer-policy-unsafe-url-10">(3)</a> <a href="#ref-for-referrer-policy-unsafe-url-11">(4)</a></span></span></h3>
+    <p>The <a data-link-type="dfn" href="#referrer-policy-unsafe-url" id="ref-for-referrer-policy-unsafe-url-1">"<code>unsafe-url</code>"</a> policy specifies that a full URL, <a href="#strip-url">stripped for use as a referrer</a>, is sent along with
   both <a data-link-type="dfn" href="#cross-origin-request" id="ref-for-cross-origin-request-4">cross-origin requests</a> and <a data-link-type="dfn" href="#same-origin-request" id="ref-for-same-origin-request-4">same-origin requests</a> made from
-  a particular <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#settings-object">settings object</a>.</p>
-    <div class="example" id="example-ed289e46"><a class="self-link" href="#example-ed289e46"></a> If a document at <code>https://example.com/sekrit.html</code> sets a policy
-    of <code>Unsafe URL</code>, then navigations to <code>http://not.example.com/</code> (and every other origin) would send a <code><a data-link-type="dfn" href="https://tools.ietf.org/html/rfc7231#section-5.5.2">Referer</a></code> HTTP header with a value of <code>https://example.com/sekrit.html</code>. </div>
+  a particular <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client">request client</a>.</p>
+    <div class="example" id="example-32de6eb8"><a class="self-link" href="#example-32de6eb8"></a> If a document at <code>https://example.com/sekrit.html</code> sets a policy
+    of <a data-link-type="dfn" href="#referrer-policy-unsafe-url" id="ref-for-referrer-policy-unsafe-url-2">"<code>unsafe-url</code>"</a>, then navigations to <code>http://not.example.com/</code> (and every other origin) would send a <code><a data-link-type="dfn" href="https://tools.ietf.org/html/rfc7231#section-5.5.2">Referer</a></code> HTTP header with a value of <code>https://example.com/sekrit.html</code>. </div>
     <p class="note" role="note">Note: The policy’s name doesn’t lie; it is unsafe. This policy will leak
   origins and paths from <a data-link-type="dfn" href="http://www.w3.org/TR/2010/REC-wsc-ui-20100812/#typesoftls">TLS-protected</a> resources to insecure origins.
   Carefully consider the impact of setting such a policy for potentially
@@ -1599,13 +1598,13 @@ Possible extra rowspan handling
    </section>
    <section>
     <h2 class="heading settled" data-level="4" id="referrer-policy-delivery"><span class="secno">4. </span><span class="content">Referrer Policy Delivery</span><a class="self-link" href="#referrer-policy-delivery"></a></h2>
-    <p>A <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#settings-object">settings object</a>’s <a data-link-type="dfn" href="#referrer-policy" id="ref-for-referrer-policy-3">referrer policy</a> is delivered in one of four
-  ways:</p>
+    <p>A <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-referrer-policy">referrer policy</a> is delivered in one of five ways:</p>
     <ul>
      <li> Via the <code>Referrer-Policy</code> HTTP header (defined
       in <a href="#referrer-policy-header">§4.1 Delivery via Referrer-Policy header</a>). 
-     <li> Via a <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#meta">meta</a></code> element with a <code><a data-link-type="element-sub" href="https://html.spec.whatwg.org/multipage/semantics.html#attr-meta-name">name</a></code> of <code>referrer</code>. 
+     <li> Via a <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#meta">meta</a></code> element with a <code><a data-link-type="element-sub" href="https://html.spec.whatwg.org/multipage/semantics.html#attr-meta-name">name</a></code> of <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/semantics.html#meta-referrer"><code>referrer</code></a>. 
      <li> Via a <code>referrerpolicy</code> content attribute on an <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/#the-a-element">a</a></code>, <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-area-element">area</a></code>, <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element">img</a></code>, <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-iframe-element">iframe</a></code>, or <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-link-element">link</a></code> element. 
+     <li> Via the <code><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/semantics.html#link-type-noreferrer">noreferrer</a></code> link relation on an <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/#the-a-element">a</a></code>, <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-area-element">area</a></code>, or <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-link-element">link</a></code> element. 
      <li> Implicitly, via inheritance. 
     </ul>
     <h3 class="heading settled" data-level="4.1" id="referrer-policy-header"><span class="secno">4.1. </span><span class="content">Delivery via Referrer-Policy header</span><a class="self-link" href="#referrer-policy-header"></a></h3>
@@ -1619,7 +1618,7 @@ Possible extra rowspan handling
   following ABNF grammar:</p>
 <pre>"Referrer-Policy:" 1#<a data-link-type="dfn" href="#policy-token" id="ref-for-policy-token-1">policy-token</a>
 </pre>
-<pre><dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="policy-token" data-noexport="" id="policy-token">policy-token<span class="dfn-panel" data-deco=""><b><a href="#policy-token">#policy-token</a></b><b>Referenced in:</b><span><a href="#ref-for-policy-token-1">4.1. Delivery via Referrer-Policy header</a></span></span></dfn>   = "no-referrer" / "no-referrer-when-downgrade" / "origin" / "origin-when-cross-origin" / "unsafe-url"
+<pre><dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" data-lt="policy-token" id="policy-token">policy-token<span class="dfn-panel" data-deco=""><b><a href="#policy-token">#policy-token</a></b><b>Referenced in:</b><span><a href="#ref-for-policy-token-1">4.1. Delivery via Referrer-Policy header</a></span></span></dfn>   = "no-referrer" / "no-referrer-when-downgrade" / "origin" / "origin-when-cross-origin" / "unsafe-url"
 </pre>
     <p class="note" role="note">Note: The header name does not share the HTTP Referer header’s misspelling.</p>
     <p><a href="#integration-with-fetch">§5 Integration with Fetch</a> and <a href="#integration-with-html">§6 Integration with HTML</a> describe
@@ -1634,7 +1633,8 @@ Possible extra rowspan handling
     context to have an empty <code>Referer</code> [sic] header.</p>
     </section>
     <h3 class="heading settled" data-level="4.2" id="referrer-policy-delivery-meta"><span class="secno">4.2. </span><span class="content">Delivery via <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#meta">meta</a></code></span><a class="self-link" href="#referrer-policy-delivery-meta"></a></h3>
-    <p>The HTML Standard defines the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/semantics.html#attr-meta-http-equiv-referrer">Referrer policy state</a> for the <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#meta">meta</a></code> element, which allows setting the <a data-link-type="dfn" href="#referrer-policy" id="ref-for-referrer-policy-4">referrer policy</a> via markup.</p>
+    <p>The HTML Standard defines the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/semantics.html#meta-referrer"><code>referrer</code></a> keyword for the <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#meta">meta</a></code> element, which allows setting the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-referrer-policy">referrer
+  policy</a> via markup.</p>
     <h3 class="heading settled" data-level="4.3" id="referrer-policy-delivery-referrer-attribute"><span class="secno">4.3. </span><span class="content">Delivery
   via a <code>referrerpolicy</code> content attribute</span><a class="self-link" href="#referrer-policy-delivery-referrer-attribute"></a></h3>
     <p>The HTML Standard defines the concept of <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#referrer-policy-attribute">referrer policy
@@ -1642,14 +1642,14 @@ Possible extra rowspan handling
 <pre class="example" id="example-d7516db8"><a class="self-link" href="#example-d7516db8"></a>&lt;a href="http://example.com" referrerpolicy="origin">
 </pre>
     <h3 class="heading settled" data-level="4.4" id="referrer-policy-delivery-implicit"><span class="secno">4.4. </span><span class="content">Implicit Delivery</span><a class="self-link" href="#referrer-policy-delivery-implicit"></a></h3>
-    <p>A <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#settings-object">settings object</a> inherits the <a data-link-type="dfn" href="#referrer-policy" id="ref-for-referrer-policy-5">referrer policy</a> of another object
-  in several circumstances:</p>
+    <p>An <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">environment settings object</a> inherits the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-referrer-policy">referrer
+  policy</a> of another object in several circumstances:</p>
     <h4 class="heading settled" data-level="4.4.1" id="referrer-policy-delivery-implicit-nested"><span class="secno">4.4.1. </span><span class="content"> Nested Browsing Contexts </span><a class="self-link" href="#referrer-policy-delivery-implicit-nested"></a></h4>
     <p>Whenever a user agent creates a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#nested-browsing-context">nested browsing context</a> containing <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#an-iframe-srcdoc-document">an iframe srcdoc document</a> or a resource whose <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc6454#section-3.2">origin</a>’s scheme
   is a <a data-link-type="dfn" href="https://url.spec.whatwg.org#local-scheme">local scheme</a> (for instance, a <code>blob</code> or <code>data</code> resource):</p>
     <ol>
      <li> Let <var>environment</var> be the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#nested-browsing-context">nested browsing context</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#incumbent-settings-object">incumbent settings object</a>. 
-     <li> Let <var>policy</var> be the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#parent-browsing-context">parent browsing context</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#incumbent-settings-object">incumbent settings object</a>’s <a data-link-type="dfn" href="#referrer-policy" id="ref-for-referrer-policy-6">referrer policy</a>. 
+     <li> Let <var>policy</var> be the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#parent-browsing-context">parent browsing context</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#incumbent-settings-object">incumbent settings object</a>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-referrer-policy">referrer policy</a>. 
      <li> Execute the <a href="#set-referrer-policy">§7.2 Set environment’s referrer policy to policy</a> algorithm on <var>environment</var> using <var>policy</var>. 
     </ol>
     <h4 class="heading settled" data-level="4.4.2" id="referrer-policy-delivery-implicit-workers"><span class="secno">4.4.2. </span><span class="content"> Workers </span><a class="self-link" href="#referrer-policy-delivery-implicit-workers"></a></h4>
@@ -1658,7 +1658,7 @@ Possible extra rowspan handling
     <ol>
      <li> Let <var>environment</var> be the Worker’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#incumbent-settings-object">incumbent settings
       object</a>. 
-     <li> Let <var>policy</var> be <code>No Referrer When Downgrade</code>. 
+     <li> Let <var>policy</var> be <a data-link-type="dfn" href="#referrer-policy-no-referrer-when-downgrade" id="ref-for-referrer-policy-no-referrer-when-downgrade-4">"<code>no-referrer-when-downgrade</code>"</a>. 
      <li> Execute the <a href="#set-referrer-policy">§7.2 Set environment’s referrer policy to policy</a> algorithm on <var>environment</var> using <var>policy</var>. 
     </ol>
    </section>
@@ -1680,13 +1680,13 @@ Possible extra rowspan handling
   img elements, HTML should set the request’s associated referrer policy
   before fetching.</p>
     <p class="note" role="note">Note: W3C HTML5 does not define the <code>referrerpolicy</code> content
-  attributes, or <code>referrerPolicy</code> IDL attributes, or the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/semantics.html#attr-meta-http-equiv-referrer">Referrer policy state</a> for <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#meta">meta</a></code>. For this spec to make sense
-  with W3C HTML5, those would need to be copied from <a data-link-type="biblio" href="#biblio-html">[HTML]</a>.</p>
+  attributes, or <code>referrerPolicy</code> IDL attributes, or the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/semantics.html#meta-referrer"><code>referrer</code></a> keyword for <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#meta">meta</a></code>. For this spec to
+  make sense with W3C HTML5, those would need to be copied from <a data-link-type="biblio" href="#biblio-html">[HTML]</a>.</p>
    </section>
    <section>
     <h2 class="heading settled" data-level="7" id="algorithms"><span class="secno">7. </span><span class="content">Algorithms</span><a class="self-link" href="#algorithms"></a></h2>
     <h3 class="heading settled" data-level="7.1" id="parse-referrer-policy-from-header"><span class="secno">7.1. </span><span class="content"> Parse a referrer policy from a <a data-link-type="dfn" href="#referrer-policy-header-dfn" id="ref-for-referrer-policy-header-dfn-1"><code>Referrer-Policy</code></a> header </span><a class="self-link" href="#parse-referrer-policy-from-header"></a></h3>
-    <p>Given a <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#response">Response</a></code> <var>response</var>, the following steps return a <a data-link-type="dfn" href="#referrer-policy" id="ref-for-referrer-policy-7">referrer policy</a> according to <var>response</var>’s `<code>Referrer-Policy</code>` header:</p>
+    <p>Given a <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#response">Response</a></code> <var>response</var>, the following steps return a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-referrer-policy">referrer policy</a> according to <var>response</var>’s `<code>Referrer-Policy</code>` header:</p>
     <ol>
      <li> Let <var>policy-tokens</var> be the result of
       parsing `<code>Referrer-Policy</code>` in <var>response</var>’s header list. 
@@ -1696,19 +1696,19 @@ Possible extra rowspan handling
      <li> Return <var>policy</var>. 
     </ol>
     <h3 class="heading settled" data-level="7.2" id="set-referrer-policy"><span class="secno">7.2. </span><span class="content"> Set <var>environment</var>’s referrer policy to <var>policy</var> </span><a class="self-link" href="#set-referrer-policy"></a></h3>
-    <p>If no referrer policy has been set for a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#settings-object">settings object</a>, then
-  setting its value is straightforward. If a policy has previously been
-  set, then we overwrite it with the new value if the new value is
-  not the empty string.</p>
+    <p>If no referrer policy has been set for an <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">environment settings
+  object</a>, then setting its value is straightforward. If a policy has
+  previously been set, then we overwrite it with the new value if the
+  new value is not the empty string.</p>
     <ol>
      <li> If <var>policy</var> is the empty string, abort these steps. 
-     <li> If <var>policy</var> is not one of <code><a data-link-type="dfn" href="#no-referrer" id="ref-for-no-referrer-2">No Referrer</a></code>, <code><a data-link-type="dfn" href="#no-referrer-when-downgrade" id="ref-for-no-referrer-when-downgrade-2">No Referrer When Downgrade</a></code>, <code><a data-link-type="dfn" href="#origin-only" id="ref-for-origin-only-2">Origin
-      Only</a></code>, <code><a data-link-type="dfn" href="#origin-when-cross-origin" id="ref-for-origin-when-cross-origin-2">Origin When Cross-Origin</a></code>, or <code><a data-link-type="dfn" href="#unsafe-url" id="ref-for-unsafe-url-2">Unsafe URL</a></code>, then return without setting <var>environment</var>’s referrer policy. 
-     <li> Set <var>environment</var>’s <a data-link-type="dfn" href="#referrer-policy" id="ref-for-referrer-policy-8">referrer policy</a> to <var>policy</var>. 
+     <li> If <var>policy</var> is not one of <a data-link-type="dfn" href="#referrer-policy-no-referrer" id="ref-for-referrer-policy-no-referrer-3">"<code>no-referrer</code>"</a>, <a data-link-type="dfn" href="#referrer-policy-no-referrer-when-downgrade" id="ref-for-referrer-policy-no-referrer-when-downgrade-5">"<code>no-referrer-when-downgrade</code>"</a>, <a data-link-type="dfn" href="#referrer-policy-origin" id="ref-for-referrer-policy-origin-4">"<code>origin-only</code>"</a>, <a data-link-type="dfn" href="#referrer-policy-origin-when-cross-origin" id="ref-for-referrer-policy-origin-when-cross-origin-5">"<code>origin-when-cross-origin</code>"</a>, or <a data-link-type="dfn" href="#referrer-policy-unsafe-url" id="ref-for-referrer-policy-unsafe-url-3">"<code>unsafe-url</code>"</a>,
+      abort these steps. 
+     <li> Set <var>environment</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-referrer-policy">referrer policy</a> to <var>policy</var>. 
     </ol>
     <h3 class="heading settled" data-level="7.3" id="set-requests-referrer-policy-on-redirect"><span class="secno">7.3. </span><span class="content"> Set <var>request</var>’s referrer policy on redirect </span><a class="self-link" href="#set-requests-referrer-policy-on-redirect"></a></h3>
     <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> <var>request</var> and a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a> <var>actualResponse</var>,
-  this algorithm updates <var>request</var>’s associated <a data-link-type="dfn" href="#referrer-policy" id="ref-for-referrer-policy-9">referrer policy</a> according to the Referrer-Policy header (if any) in <var>actualResponse</var>.</p>
+  this algorithm updates <var>request</var>’s associated <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-referrer-policy">referrer policy</a> according to the Referrer-Policy header (if any) in <var>actualResponse</var>.</p>
     <ol>
      <li> Let <var>policy</var> be the result of executing <a href="#parse-referrer-policy-from-header">§7.1 Parse a referrer policy from a Referrer-Policy header</a> on <var>actualResponse</var>. 
      <li>If <var>policy</var> is not the empty string, then set <var>request</var>’s
@@ -1716,13 +1716,12 @@ Possible extra rowspan handling
     </ol>
     <h3 class="heading settled" data-level="7.4" id="determine-requests-referrer"><span class="secno">7.4. </span><span class="content"> Determine <var>request</var>’s Referrer </span><a class="self-link" href="#determine-requests-referrer"></a></h3>
     <p>Given a <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#request">Request</a></code> <var>request</var>, we can determine the correct
-  referrer information to send by examining the <a data-link-type="dfn" href="#referrer-policy" id="ref-for-referrer-policy-10">policy</a> associated
-  with it, as detailed in the following steps, which return
+  referrer information to send by examining the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-referrer-policy">referrer policy</a> associated with it, as detailed in the following steps, which return
   either <code>no referrer</code> or a URL:</p>
     <p class="note" role="note">Note: If Fetch is performing a navigation in response to a link of type <code><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/semantics.html#link-type-noreferrer">noreferrer</a></code>, then <var>request</var>’s <code>referrer</code> will be <code>no referrer</code>, and Fetch won’t call
   into this algorithm.</p>
     <ol>
-     <li> Let <var>policy</var> be <var>request</var>’s associated <a data-link-type="dfn" href="#referrer-policy" id="ref-for-referrer-policy-11">referrer policy</a>. 
+     <li> Let <var>policy</var> be <var>request</var>’s associated <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-referrer-policy">referrer policy</a>. 
      <li> Let <var>environment</var> be <var>request</var>’s <code>client</code>. 
      <li>
        If <var>request</var>’s <code>referrer</code> is a URL, then let <var>referrerSource</var> be <var>request</var>’s <code>referrer</code>. Otherwise: 
@@ -1755,22 +1754,22 @@ Possible extra rowspan handling
       referrer</a>, with the <code><a data-link-type="dfn" href="#origin-only-flag" id="ref-for-origin-only-flag-1">origin-only flag</a></code> set to <code>true</code>. 
      <li>
        Execute the statements corresponding to the value of <var>policy</var>: 
-      <dl>
-       <dt><var>policy</var> is <code><a data-link-type="dfn" href="#no-referrer" id="ref-for-no-referrer-3">No Referrer</a></code>
+      <dl class="switch">
+       <dt><a data-link-type="dfn" href="#referrer-policy-no-referrer" id="ref-for-referrer-policy-no-referrer-4">"<code>no-referrer</code>"</a>
        <dd>Return <code>no referrer</code>
-       <dt><var>policy</var> is <code><a data-link-type="dfn" href="#origin-only" id="ref-for-origin-only-3">Origin Only</a></code>
+       <dt><a data-link-type="dfn" href="#referrer-policy-origin" id="ref-for-referrer-policy-origin-5">"<code>origin-only</code>"</a>
        <dd>Return <var>referrerOrigin</var>
-       <dt><var>policy</var> is <code><a data-link-type="dfn" href="#unsafe-url" id="ref-for-unsafe-url-3">Unsafe URL</a></code>
+       <dt><a data-link-type="dfn" href="#referrer-policy-unsafe-url" id="ref-for-referrer-policy-unsafe-url-4">"<code>unsafe-url</code>"</a>
        <dd>Return <var>referrerURL</var>.
-       <dt> <var>policy</var> is <code><a data-link-type="dfn" href="#origin-when-cross-origin" id="ref-for-origin-when-cross-origin-3">Origin When Cross-Origin</a></code> 
+       <dt><a data-link-type="dfn" href="#referrer-policy-origin-when-cross-origin" id="ref-for-referrer-policy-origin-when-cross-origin-6">"<code>origin-when-cross-origin</code>"</a>
        <dd>
         <ol>
          <li> If <var>request</var> is a <a data-link-type="dfn" href="#cross-origin-request" id="ref-for-cross-origin-request-5">cross-origin request</a>, then
               return <var>referrerOrigin</var>. 
          <li> Otherwise, return <var>referrerURL</var>. 
         </ol>
-       <dt> <var>policy</var> is <code><a data-link-type="dfn" href="#no-referrer-when-downgrade" id="ref-for-no-referrer-when-downgrade-3">No Referrer When Downgrade</a></code> 
-       <dt> <var>policy</var> is the empty string. 
+       <dt><a data-link-type="dfn" href="#referrer-policy-no-referrer-when-downgrade" id="ref-for-referrer-policy-no-referrer-when-downgrade-6">"<code>no-referrer-when-downgrade</code>"</a>
+       <dt>the empty string
        <dd>
         <ol>
          <li>
@@ -1796,36 +1795,36 @@ Possible extra rowspan handling
   scheme, host, and port.</p>
     <ol>
      <li> If <var>url</var> is <code>null</code>, return <code>no referrer</code>. 
-     <li> If <var>url</var>’s <code>scheme</code> is a <a data-link-type="dfn" href="https://url.spec.whatwg.org#local-scheme">local scheme</a>, then
+     <li> If <var>url</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme">scheme</a> is a <a data-link-type="dfn" href="https://url.spec.whatwg.org#local-scheme">local scheme</a>, then
       return <code>no referrer</code>. 
-     <li> Set <var>url</var>’s <code>username</code> to the empty string. 
-     <li> Set <var>url</var>’s <code>password</code> to <code>null</code>. 
-     <li> Set <var>url</var>’s <code>fragment</code> to <code>null</code>. 
+     <li> Set <var>url</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-username">username</a> to the empty string. 
+     <li> Set <var>url</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-password">password</a> to <code>null</code>. 
+     <li> Set <var>url</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#concept-url-fragment">fragment</a> to <code>null</code>. 
      <li>
        If the <code><a data-link-type="dfn" href="#origin-only-flag" id="ref-for-origin-only-flag-2">origin-only flag</a></code> is <code>true</code>,
       then: 
       <ol>
-       <li> Set <var>url</var>’s <code>path</code> to <code>null</code>. 
-       <li> Set <var>url</var>’s <code>query</code> to <code>null</code>. 
+       <li> Set <var>url</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-path">path</a> to <code>null</code>. 
+       <li> Set <var>url</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-query">query</a> to <code>null</code>. 
       </ol>
      <li> Return <var>url</var>. 
     </ol>
     <h3 class="heading settled" data-level="7.6" id="determine-policy-for-token"><span class="secno">7.6. </span><span class="content"> Determine <var>token</var>’s Policy </span><a class="self-link" href="#determine-policy-for-token"></a></h3>
-    <p>Given a string <var>token</var> (for example, the value of a <a data-link-type="dfn" href="#referrer-policy-header-dfn" id="ref-for-referrer-policy-header-dfn-2"><code>Referrer-Policy</code></a> header), this algorithm will return the <a data-link-type="dfn" href="#referrer-policy" id="ref-for-referrer-policy-12">referrer policy</a> it refers to:</p>
+    <p>Given a string <var>token</var> (for example, the value of a <a data-link-type="dfn" href="#referrer-policy-header-dfn" id="ref-for-referrer-policy-header-dfn-2"><code>Referrer-Policy</code></a> header), this algorithm will return the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-referrer-policy">referrer policy</a> it refers to:</p>
     <ol>
      <li> If <var>token</var> is an <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#ascii-case-insensitive">ASCII case-insensitive match</a> for the
-      strings "<code>never</code>" or "<code>no-referrer</code>", return <a data-link-type="dfn" href="#no-referrer" id="ref-for-no-referrer-4"><code>No Referrer</code></a>. 
+      strings "<code>never</code>" or "<code>no-referrer</code>", return <a data-link-type="dfn" href="#referrer-policy-no-referrer" id="ref-for-referrer-policy-no-referrer-5">"<code>no-referrer</code>"</a>. 
      <li> If <var>token</var> is <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#ascii-case-insensitive">ASCII case-insensitive match</a> for the string
       "<code>default</code>" or "<code>no-referrer-when-downgrade</code>",
-      return <a data-link-type="dfn" href="#no-referrer-when-downgrade" id="ref-for-no-referrer-when-downgrade-4"><code>No Referrer When Downgrade</code></a>. 
+      return <a data-link-type="dfn" href="#referrer-policy-no-referrer-when-downgrade" id="ref-for-referrer-policy-no-referrer-when-downgrade-7">"<code>no-referrer-when-downgrade</code>"</a>. 
      <li> If <var>token</var> is an <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#ascii-case-insensitive">ASCII case-insensitive match</a> for the
-      string "<code>origin</code>", return <a data-link-type="dfn" href="#origin-only" id="ref-for-origin-only-4"><code>Origin Only</code></a>. 
+      string "<code>origin</code>", return <a data-link-type="dfn" href="#referrer-policy-origin" id="ref-for-referrer-policy-origin-6">"<code>origin-only</code>"</a>. 
      <li> If <var>token</var> is <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#ascii-case-insensitive">ASCII case-insensitive match</a> for the string
-      "<code>origin-when-cross-origin</code>", return <a data-link-type="dfn" href="#origin-when-cross-origin" id="ref-for-origin-when-cross-origin-4"><code>Origin When Cross-Origin</code></a>. 
+      "<code>origin-when-cross-origin</code>", return <a data-link-type="dfn" href="#referrer-policy-origin-when-cross-origin" id="ref-for-referrer-policy-origin-when-cross-origin-7">"<code>origin-when-cross-origin</code>"</a>. 
      <li> If <var>token</var> is <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#ascii-case-insensitive">ASCII case-insensitive match</a> for the strings
       "<code>always</code>" or "<code>unsafe-url</code>",
-      return <a data-link-type="dfn" href="#unsafe-url" id="ref-for-unsafe-url-4"><code>Unsafe URL</code></a>. 
-     <li> If <var>token</var> is empty, return <a data-link-type="dfn" href="#no-referrer" id="ref-for-no-referrer-5"><code>No Referrer</code></a>. 
+      return <a data-link-type="dfn" href="#referrer-policy-unsafe-url" id="ref-for-referrer-policy-unsafe-url-5">"<code>unsafe-url</code>"</a>. 
+     <li> If <var>token</var> is empty, return <a data-link-type="dfn" href="#referrer-policy-no-referrer" id="ref-for-referrer-policy-no-referrer-6">"<code>no-referrer</code>"</a>. 
      <li> Return the empty string. 
     </ol>
     <p class="note" role="note">Note: Authors are encouraged to avoid the legacy keywords <code>never</code>, <code>default</code>, and <code>always</code>. The
@@ -1838,22 +1837,21 @@ Possible extra rowspan handling
   agents from offering options to users which would change the information
   sent out via a `<code>Referer</code>` header. For instance, user agents
   MAY allow users to suppress the referrer header entirely, regardless of the
-  active <a data-link-type="dfn" href="#referrer-policy" id="ref-for-referrer-policy-13">referrer policy</a> on a page.</p>
+  active <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-referrer-policy">referrer policy</a> on a page.</p>
    </section>
    <section>
     <h2 class="heading settled" data-level="9" id="security"><span class="secno">9. </span><span class="content">Security Considerations</span><a class="self-link" href="#security"></a></h2>
     <h3 class="heading settled" data-level="9.1" id="information-leakage"><span class="secno">9.1. </span><span class="content">Information Leakage</span><a class="self-link" href="#information-leakage"></a></h3>
-    <p>The referrer policies <code>origin</code> and <code>unsafe-url</code> might
-  leak the origin and the URL of a secure site respectively via insecure
-  transport.</p>
+    <p>The <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-referrer-policy">referrer policies</a> <a data-link-type="dfn" href="#referrer-policy-origin" id="ref-for-referrer-policy-origin-7">"<code>origin-only</code>"</a> and <a data-link-type="dfn" href="#referrer-policy-unsafe-url" id="ref-for-referrer-policy-unsafe-url-6">"<code>unsafe-url</code>"</a> might leak the origin and the URL of
+  a secure site respectively via insecure transport.</p>
     <p>Those two policies are include in the spec nevertheless to lower the friction
   of sites adopting secure transport.</p>
     <h3 class="heading settled" data-level="9.2" id="downgrade"><span class="secno">9.2. </span><span class="content">Downgrade to less strict policies</span><a class="self-link" href="#downgrade"></a></h3>
-    <p>The spec does not forbid downgrading to less strict policies, e.g., from <code>never</code> to <code>unsafe-url</code>.</p>
+    <p>The spec does not forbid downgrading to less strict policies, e.g., from <a data-link-type="dfn" href="#referrer-policy-no-referrer" id="ref-for-referrer-policy-no-referrer-7">"<code>no-referrer</code>"</a> to <a data-link-type="dfn" href="#referrer-policy-unsafe-url" id="ref-for-referrer-policy-unsafe-url-7">"<code>unsafe-url</code>"</a>.</p>
     <p>On the one hand, it is not clear which policy is more strict for all possible
-  pairs of policies: While <code>no-referrer-when-downgrade</code> will not
-  leak any information over insecure transport, and <code>origin</code> will,
-  the latter reveals less information across cross-origin navigations.</p>
+  pairs of policies: While <a data-link-type="dfn" href="#referrer-policy-no-referrer-when-downgrade" id="ref-for-referrer-policy-no-referrer-when-downgrade-8">"<code>no-referrer-when-downgrade</code>"</a> will
+  not leak any information over insecure transport, and <a data-link-type="dfn" href="#referrer-policy-origin" id="ref-for-referrer-policy-origin-8">"<code>origin-only</code>"</a> will, the latter reveals less information
+  across cross-origin navigations.</p>
     <p>On the other hand, allowing for setting less strict policies enables authors
   to define safe fallbacks as described in <a href="#unknown-policy-values">§10.1 Unknown Policy Values</a>.</p>
    </section>
@@ -1864,12 +1862,10 @@ Possible extra rowspan handling
   when multiple sources specify a referrer policy, the value of the
   latest one will be used. This makes it possible to deploy new policy
   values.</p>
-    <div class="example" id="example-f2dce9f1"><a class="self-link" href="#example-f2dce9f1"></a> Suppose older user agents don’t understand
-    the <code>unsafe-url</code> policy. A site can specify
-    an <code>origin</code> policy followed by an <code>unsafe-url</code> policy: older user agents will ignore the
-    unknown <code>unsafe-url</code> value and use <code>origin</code>,
-    while newer user agents will use <code>unsafe-url</code> because it is
-    the last to be processed. </div>
+    <div class="example" id="example-fd11ad55"><a class="self-link" href="#example-fd11ad55"></a> Suppose older user agents don’t understand
+    the <a data-link-type="dfn" href="#referrer-policy-unsafe-url" id="ref-for-referrer-policy-unsafe-url-8">"<code>unsafe-url</code>"</a> policy. A site can specify
+    an <a data-link-type="dfn" href="#referrer-policy-origin" id="ref-for-referrer-policy-origin-9">"<code>origin-only</code>"</a> policy followed by an <a data-link-type="dfn" href="#referrer-policy-unsafe-url" id="ref-for-referrer-policy-unsafe-url-9">"<code>unsafe-url</code>"</a> policy: older user agents will ignore the
+    unknown <a data-link-type="dfn" href="#referrer-policy-unsafe-url" id="ref-for-referrer-policy-unsafe-url-10">"<code>unsafe-url</code>"</a> value and use <a data-link-type="dfn" href="#referrer-policy-origin" id="ref-for-referrer-policy-origin-10">"<code>origin-only</code>"</a>, while newer user agents will use <a data-link-type="dfn" href="#referrer-policy-unsafe-url" id="ref-for-referrer-policy-unsafe-url-11">"<code>unsafe-url</code>"</a> because it is the last to be processed. </div>
    </section>
    <section>
     <h2 class="heading settled" data-level="11" id="acknowledgements"><span class="secno">11. </span><span class="content">Acknowledgements</span><a class="self-link" href="#acknowledgements"></a></h2>
@@ -1911,21 +1907,17 @@ Possible extra rowspan handling
   <h2 class="no-num no-ref heading settled" id="index"><span class="content">Index</span><a class="self-link" href="#index"></a></h2>
   <h3 class="no-num no-ref heading settled" id="index-defined-here"><span class="content">Terms defined by this specification</span><a class="self-link" href="#index-defined-here"></a></h3>
   <ul class="index">
-   <li><a href="#cross-origin-request">cross-origin</a><span>, in §2</span>
    <li><a href="#cross-origin-request">cross-origin request</a><span>, in §2</span>
-   <li><a href="#no-referrer">No Referrer</a><span>, in §3.1</span>
-   <li><a href="#no-referrer-when-downgrade">No Referrer When Downgrade</a><span>, in §3.2</span>
-   <li><a href="#origin-only">Origin Only</a><span>, in §3.3</span>
+   <li><a href="#referrer-policy-no-referrer">"no-referrer"</a><span>, in §3</span>
+   <li><a href="#referrer-policy-no-referrer-when-downgrade">"no-referrer-when-downgrade"</a><span>, in §3.1</span>
+   <li><a href="#referrer-policy-origin">"origin-only"</a><span>, in §3.2</span>
    <li><a href="#origin-only-flag">origin-only flag</a><span>, in §7.5</span>
-   <li><a href="#origin-when-cross-origin">Origin When Cross-Origin</a><span>, in §3.4</span>
-   <li><a href="#referrer-policy">policy</a><span>, in §2</span>
+   <li><a href="#referrer-policy-origin-when-cross-origin">"origin-when-cross-origin"</a><span>, in §3.3</span>
    <li><a href="#policy-token">policy-token</a><span>, in §4.1</span>
    <li><a href="#referrer-policy-header-dfn">Referrer-Policy</a><span>, in §4.1</span>
-   <li><a href="#referrer-policy">referrer policy</a><span>, in §2</span>
    <li><a href="#referrer-policy-header-dfn">referrer-policy header</a><span>, in §4.1</span>
-   <li><a href="#same-origin-request">same-origin</a><span>, in §2</span>
    <li><a href="#same-origin-request">same-origin request</a><span>, in §2</span>
-   <li><a href="#unsafe-url">Unsafe URL</a><span>, in §3.5</span>
+   <li><a href="#referrer-policy-unsafe-url">"unsafe-url"</a><span>, in §3.4</span>
   </ul>
   <h3 class="no-num no-ref heading settled" id="index-defined-elsewhere"><span class="content">Terms defined by reference</span><a class="self-link" href="#index-defined-elsewhere"></a></h3>
   <ul class="index">
@@ -1936,7 +1928,9 @@ Possible extra rowspan handling
      <li><a href="https://fetch.spec.whatwg.org/#response">Response</a>
      <li><a href="https://fetch.spec.whatwg.org/#fetching">fetching</a>
      <li><a href="https://fetch.spec.whatwg.org/#concept-request-origin">origin</a>
+     <li><a href="https://fetch.spec.whatwg.org/#concept-referrer-policy">referrer policy</a>
      <li><a href="https://fetch.spec.whatwg.org/#concept-request">request</a>
+     <li><a href="https://fetch.spec.whatwg.org/#concept-request-client">request client</a>
      <li><a href="https://fetch.spec.whatwg.org/#concept-response">response</a>
      <li><a href="https://fetch.spec.whatwg.org/#concept-request-url">url</a>
     </ul>
@@ -1951,6 +1945,8 @@ Possible extra rowspan handling
      <li><a href="https://html.spec.whatwg.org/multipage/infrastructure.html#ascii-case-insensitive">ascii case-insensitive match</a>
      <li><a href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context">browsing context</a>
      <li><a href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context-container">browsing context container</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">environment settings object</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/infrastructure.html#concept-url-fragment">fragment</a>
      <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object">global object</a>
      <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#incumbent-settings-object">incumbent settings object</a>
      <li><a href="https://html.spec.whatwg.org/multipage/semantics.html#attr-meta-name">name</a>
@@ -1958,11 +1954,10 @@ Possible extra rowspan handling
      <li><a href="https://html.spec.whatwg.org/multipage/semantics.html#link-type-noreferrer">noreferrer</a>
      <li><a href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin-opaque">opaque origin</a>
      <li><a href="https://html.spec.whatwg.org/multipage/browsers.html#parent-browsing-context">parent browsing context</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/semantics.html#meta-referrer">referrer</a>
      <li><a href="https://html.spec.whatwg.org/multipage/infrastructure.html#referrer-policy-attribute">referrer policy attribute</a>
-     <li><a href="https://html.spec.whatwg.org/multipage/semantics.html#attr-meta-http-equiv-referrer">referrer policy state</a>
      <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#responsible-browsing-context">responsible browsing context</a>
      <li><a href="https://html.spec.whatwg.org/multipage/workers.html#run-a-worker">run a worker</a>
-     <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#settings-object">settings object</a>
     </ul>
    <li>
     <a data-link-type="biblio">[MIX]</a> defines the following terms:
@@ -2002,6 +1997,15 @@ Possible extra rowspan handling
      <li><a href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element">img</a>
      <li><a href="https://html.spec.whatwg.org/multipage/semantics.html#the-link-element">link</a>
      <li><a href="https://html.spec.whatwg.org/multipage/semantics.html#meta">meta</a>
+    </ul>
+   <li>
+    <a data-link-type="biblio">[WHATWG-URL]</a> defines the following terms:
+    <ul>
+     <li><a href="https://url.spec.whatwg.org/#concept-url-password">password</a>
+     <li><a href="https://url.spec.whatwg.org/#concept-url-path">path</a>
+     <li><a href="https://url.spec.whatwg.org/#concept-url-query">query</a>
+     <li><a href="https://url.spec.whatwg.org/#concept-url-scheme">scheme</a>
+     <li><a href="https://url.spec.whatwg.org/#concept-url-username">username</a>
     </ul>
   </ul>
   <h2 class="no-num no-ref heading settled" id="references"><span class="content">References</span><a class="self-link" href="#references"></a></h2>

--- a/index.src.html
+++ b/index.src.html
@@ -21,6 +21,8 @@ spec: FETCH; urlPrefix: https://fetch.spec.whatwg.org/
     text: fetching
     text: request; url: concept-request
     text: response; url: concept-response
+    text: referrer policy; url: concept-referrer-policy
+    text: request client; url: concept-request-client
   type: interface
     text: Request
   type: interface
@@ -36,7 +38,7 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/multipage/
     urlPrefix: semantics.html
       text: pragma directives
       text: noreferrer; url: link-type-noreferrer
-      text: Referrer policy state; url: attr-meta-http-equiv-referrer
+      text: referrer; url: meta-referrer; for: meta
     urlPrefix: embedded-content.html
       text: an iframe srcdoc document
       text: relevant mutation; url: relevant-mutations
@@ -82,10 +84,8 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/multipage/
       text: queue a task
       text: task source
       text: tasks; url: concept-task
-      text: settings object
+      text: environment settings object
       text: incumbent settings object
-      text: relevant settings object for a script
-      text: responsible document
       text: responsible browsing context
       text: API referrer source
       text: global object
@@ -193,82 +193,85 @@ spec:html; type:element; text:link
 
   <dl>
     <dt>
-      <dfn export local-lt="policy">referrer policy</dfn>
+      <a>referrer policy</a>
     </dt>
     <dd>
-      A <strong>referrer policy</strong> is a property of a <a>settings
-      object</a> that defines the algorithm used to populate the
+      A <a>referrer policy</a> modifies the algorithm used to populate the
       <a><code>Referer</code></a> header when <a>fetching</a> subresources,
-      prefetching, or performing navigations.
+      prefetching, or performing navigations. This document defines the various
+      behaviors for each <a>referrer policy</a>.
 
-      If no referrer policy is explicitly set for a <a>settings object</a>,
-      then the value of the property is the empty string. Otherwise, the value
-      is whatever has been explicitly set, as explained in the
-      <a section href="#set-referrer-policy"></a> algorithm.
+      The empty string corresponds to no <a>referrer policy</a>, causing a
+      fallback to a <a>referrer policy</a> defined elsewhere, or in the case
+      where no such higher-level policy is available, defaulting to
+      <a>"<code>no-referrer-when-downgrade</code>"</a>.
+
+      Every <a>environment settings object</a> has a <a>referrer policy</a>. If
+      no <a>referrer policy</a> is explicitly set for an <a>environment settings
+      object</a>, then the <a>referrer policy</a> is the empty string. Otherwise,
+      the value is whatever has been explicitly set, as explained in the <a
+      section href="#set-referrer-policy"></a> algorithm.
     </dd>
 
-    <dt><dfn local-lt="same-origin">same-origin request</dfn></dt>
+    <dt><dfn>same-origin request</dfn></dt>
     <dd>
       A {{Request}} <var>request</var> is a <strong>same-origin request</strong>
       if <var>request</var>'s {{Request/origin}} and the <a>origin</a> of
       <var>request</var>'s {{Request/url}} are <a><code>the same</code></a>.
     </dd>
 
-    <dt><dfn local-lt="cross-origin">cross-origin request</dfn></dt>
+    <dt><dfn>cross-origin request</dfn></dt>
     <dd>
       A {{Request}} is a <strong>cross-origin request</strong> if it is
-      <em>not</em> <a>same-origin</a>.
+      <em>not</em> <a lt="same-origin request">same-origin</a>.
     </dd>
   </dl>
 </section>
 
 <section>
-  <h2 id="referrer-policy-states">Referrer Policy States</h2>
+  <h2 id="referrer-policies" oldids="referrer-policy-states">Referrer Policies</h2>
 
-  Every <a>settings object</a> has a <a>referrer policy</a> which governs
-  the referrer information sent along with requests made for subresources, and
-  for navigations. The <a>policy</a> will be the empty string if no policy has
-  been set, otherwise it will be one of the following five values:
-  <code><a>No Referrer</a></code>, <code><a>No Referrer When
-  Downgrade</a></code>, <code><a>Origin Only</a></code>, <code><a>Origin When
-  Cross-origin</a></code>, and <code><a>Unsafe URL</a></code>. Each is explained
-  below, and a detailed algorithm for evaluating their effect is given in the
+  Each possible <a>referrer policy</a>, besides the empty string, is explained
+  below. A detailed algorithm for evaluating their effect is given in the
   <a section href="#integration-with-fetch"></a> and
-  <a section href="#algorithms"></a> sections:
+  <a section href="#algorithms"></a> sections.
 
-  Note: The referrer policy for a <a>settings object</a> provides a default
-  baseline policy for requests. This policy may be tightened for specific
-  requests via mechanisms like the <code><a>noreferrer</a></code> link type.
+  Note: The referrer policy for an <a>environment settings object</a> provides a
+  default baseline policy for requests when that <a>environment settings
+  object</a> is used as a <a>request client</a>. This policy may be tightened
+  for specific requests via mechanisms like the <code><a>noreferrer</a></code>
+  link type.
 
-  <h3 id="referrer-policy-state-no-referrer">No Referrer</h3>
+  <h3 dfn export id="referrer-policy-no-referrer" oldids="referrer-policy-state-no-referrer">"<code>no-referrer</code>"</h3>
 
-  The simplest policy is <dfn>No Referrer</dfn>, which specifies that no
-  referrer information is to be sent along with requests made from a particular
-  <a>settings object</a> to any <a>origin</a>. The header will be omitted
-  entirely.
+  The simplest policy is <a>"<code>no-referrer</code>"</a>, which specifies
+  that no referrer information is to be sent along with requests made from a
+  particular <a>request client</a> to any <a>origin</a>. The header will be
+  omitted entirely.
 
   <div class="example">
     If a document at <code>https://example.com/page.html</code> sets a policy of
-    <code>No Referrer</code>, then navigations to
+    <a>"<code>no-referrer</code>"</a>, then navigations to
     <code>https://example.com/</code> (or any other URL) would send no
     <a><code>Referer</code></a> header.
   </div>
 
-  <h3 id="referrer-policy-state-no-referrer-when-downgrade">No Referrer When Downgrade</h3>
+  <h3 dfn export id="referrer-policy-no-referrer-when-downgrade" oldids="referrer-policy-state-no-referrer-when-downgrade">"<code>no-referrer-when-downgrade</code>"</h3>
 
-  The <dfn>No Referrer When Downgrade</dfn> policy sends a full URL along with
-  requests from <a>TLS-protected</a> <a>settings object</a> to a
-  <a><em>a priori</em> authenticated URL</a>, and requests from <a>settings
-  objects</a> which are <em>not</em> <a>TLS-protected</a> to any
+  The <a>"<code>no-referrer-when-downgrade</code>"</a> policy sends a full URL
+  along with requests from <a>TLS-protected</a> <a>environment settings
+  object</a> to a <a><em>a priori</em> authenticated URL</a>, and requests from
+  <a>request clients</a> which are <em>not</em> <a>TLS-protected</a> to any
   <a>origin</a>.
 
-  Requests from <a>TLS-protected</a> <a>settings objects</a> to not-<a><em>a
-  priori</em> authenticated URL</a>, on the other hand, will contain no referrer
-  information. A <code><a>Referer</a></code> HTTP header will not be sent.
+  Requests from <a>TLS-protected</a> <a>request clients</a> to non-<a><em>a
+  priori</em> authenticated URLs</a>, on the other hand, will contain no
+  referrer information. A <code><a>Referer</a></code> HTTP header will not be
+  sent.
 
   <div class="example">
     If a document at <code>https://example.com/page.html</code> sets a policy of
-    <code>No Referrer When Downgrade</code>, then navigations to
+    <a>"<code>no-referrer-when-downgrade</code>"</a>, then navigations to
     <code>https://not.example.com/</code> would send a
     <code><a>Referer</a></code> HTTP header with a value of
     <code>https://example.com/page.html</code>, as neither resource's origin is an
@@ -281,14 +284,13 @@ spec:html; type:element; text:link
 
   This is a user agent's default behavior, if no policy is otherwise specified.
 
-  <h3 id="referrer-policy-state-origin">Origin Only</h3>
+  <h3 dfn export id="referrer-policy-origin" oldids="referrer-policy-state-origin">"<code>origin-only</code>"</h3>
 
-  The <dfn>Origin Only</dfn> policy specifies that only the
+  The <a>"<code>origin-only</code>"</a> policy specifies that only the
   <a lt="ASCII serialization of an origin">ASCII serialization</a> of the
-  <a>origin</a> of the <a>settings object</a> from which a request is
-  made is sent as referrer information when making both <a>same-origin
-  requests</a> and <a>cross-origin requests</a> from a particular
-  <a>settings object</a>.
+  <a>origin</a> of the <a>request client</a> is sent as referrer information
+  when making both <a>same-origin requests</a> and <a>cross-origin requests</a>
+  from a particular <a>request client</a>.
 
   Note: The serialization of an origin looks like
   <code>https://example.com</code>. To ensure that a valid URL is sent in the
@@ -296,39 +298,40 @@ spec:html; type:element; text:link
   ("<code>/</code>") character to the origin (e.g.
   <code>https://example.com/</code>).
 
-  Note: The <code>Origin Only</code> policy causes the origin of HTTPS referrers
-  to be sent over the network as part of unencrypted HTTP requests.
+  Note: The <a>"<code>origin-only</code>"</a> policy causes the origin of HTTPS
+  referrers to be sent over the network as part of unencrypted HTTP requests.
 
   <div class="example">
     If a document at <code>https://example.com/page.html</code> sets a policy of
-    <code>Origin Only</code>, then navigations to any <a>origin</a> would send a
-    <a><code>Referer</code></a> header with a value of
-    <code>https://example.com/</code>, even to URLs that are not <a><em>a
+    <a>"<code>origin-only</code>"</a>, then navigations to any
+    <a>origin</a> would send a <a><code>Referer</code></a> header with a value
+    of <code>https://example.com/</code>, even to URLs that are not <a><em>a
     priori</em> authenticated URLs</a>.
   </div>
 
-  <h3 id="referrer-policy-state-origin-when-cross-origin">Origin When Cross-Origin</h3>
+  <h3 dfn export id="referrer-policy-origin-when-cross-origin" oldids="referrer-policy-state-origin-when-cross-origin">"<code>origin-when-cross-origin</code>"</h3>
 
-  The <dfn>Origin When Cross-Origin</dfn> policy specifies that a full URL,
-  <a href="#strip-url">stripped for use as a referrer</a>, is sent as referrer
-  information when making <a>same-origin requests</a> from a particular
-  <a>settings object</a>, and only the
+  The <a>"<code>origin-when-cross-origin</code>"</a> policy specifies that a
+  full URL, <a href="#strip-url">stripped for use as a referrer</a>, is sent as
+  referrer information when making <a>same-origin requests</a> from a particular
+  <a>request client</a>, and only the
   <a lt="ASCII serialization of an origin">ASCII serialization</a> of the
-  <a>origin</a> of the <a>settings object</a> from which a request is
-  made is sent as referrer information when making <a>cross-origin requests</a>
-  from a particular <a>settings object</a>.
+  <a>origin</a> of the <a>request client</a> is sent as referrer information
+  when making <a>cross-origin requests</a> from a particular <a>request
+  client</a>.
 
-  Note: For the <code>Origin When Cross-Origin</code> policy, we also consider
-  protocol upgrades, e.g. requests from <code>http://example.com/</code> to
-  <code>https://example.com/</code> to be <a>cross-origin requests</a>.
+  Note: For the <a>"<code>origin-when-cross-origin</code>"</a> policy, we also
+  consider protocol upgrades, e.g. requests from
+  <code>http://example.com/</code> to <code>https://example.com/</code>, to be
+  <a>cross-origin requests</a>.
 
-  Note: The <code>Origin When Cross-Origin</code> policy causes the origin of
-  HTTPS referrers to be sent over the network as part of unencrypted HTTP
-  requests.
+  Note: The <a>"<code>origin-when-cross-origin</code>"</a> policy causes the
+  origin of HTTPS referrers to be sent over the network as part of unencrypted
+  HTTP requests.
 
   <div class="example">
     If a document at <code>https://example.com/page.html</code> sets a policy of
-    <code>Origin When Cross-Origin</code>, then navigations to any
+    <a>"<code>origin-when-cross-origin</code>"</a>, then navigations to any
     <code>https://example.com/not-page.html</code> would send a
     <a><code>Referer</code></a> header with a value of
     <code>https://example.com/page.html</code>.
@@ -339,16 +342,16 @@ spec:html; type:element; text:link
     priori</em> authenticated URLs</a>.
   </div>
 
-  <h3 id="referrer-policy-state-unsafe-url">Unsafe URL</h3>
+  <h3 dfn export id="referrer-policy-unsafe-url" oldids="referrer-policy-state-unsafe-url">"<code>unsafe-url</code>"</h3>
 
-  The <dfn>Unsafe URL</dfn> policy specifies that a full URL,
+  The <a>"<code>unsafe-url</code>"</a> policy specifies that a full URL,
   <a href="#strip-url">stripped for use as a referrer</a>, is sent along with
   both <a>cross-origin requests</a> and <a>same-origin requests</a> made from
-  a particular <a>settings object</a>.
+  a particular <a>request client</a>.
 
   <div class="example">
     If a document at <code>https://example.com/sekrit.html</code> sets a policy
-    of <code>Unsafe URL</code>, then navigations to
+    of <a>"<code>unsafe-url</code>"</a>, then navigations to
     <code>http://not.example.com/</code> (and every other origin) would send a
     <code><a>Referer</a></code> HTTP header with a value of
     <code>https://example.com/sekrit.html</code>.
@@ -363,8 +366,7 @@ spec:html; type:element; text:link
 <section>
   <h2 id="referrer-policy-delivery">Referrer Policy Delivery</h2>
 
-  A <a>settings object</a>'s <a>referrer policy</a> is delivered in one of four
-  ways:
+  A <a>request</a>'s <a>referrer policy</a> is delivered in one of five ways:
 
   <ul>
     <li>
@@ -372,11 +374,16 @@ spec:html; type:element; text:link
       in [[#referrer-policy-header]]).
     </li>
     <li>
-      Via a <{meta}> element with a <{meta/name}> of <code>referrer</code>.
+      Via a <{meta}> element with a <{meta/name}> of
+      <a for="meta"><code>referrer</code></a>.
     </li>
     <li>
       Via a <code>referrerpolicy</code> content attribute on an <{a}>,
       <{area}>, <{img}>, <{iframe}>, or <{link}> element.
+    </li>
+    <li>
+      Via the <code><a>noreferrer</a></code> link relation on an <{a}>,
+      <{area}>, or <{link}> element.
     </li>
     <li>
       Implicitly, via inheritance.
@@ -398,7 +405,7 @@ spec:html; type:element; text:link
     "Referrer-Policy:" 1#<a>policy-token</a>
   </pre>
   <pre>
-    <dfn>policy-token</dfn>   = "no-referrer" / "no-referrer-when-downgrade" / "origin" / "origin-when-cross-origin" / "unsafe-url"
+    <dfn export>policy-token</dfn>   = "no-referrer" / "no-referrer-when-downgrade" / "origin" / "origin-when-cross-origin" / "unsafe-url"
   </pre>
 
   Note: The header name does not share the HTTP Referer header's misspelling.
@@ -425,8 +432,9 @@ spec:html; type:element; text:link
 
   <h3 id="referrer-policy-delivery-meta">Delivery via <{meta}></h3>
 
-  The HTML Standard defines the <a>Referrer policy state</a> for the <{meta}>
-  element, which allows setting the <a>referrer policy</a> via markup.
+  The HTML Standard defines the <a for="meta"><code>referrer</code></a>
+  keyword for the <{meta}> element, which allows setting the <a>referrer
+  policy</a> via markup.
 
   <h3 id="referrer-policy-delivery-referrer-attribute">Delivery
   via a <code>referrerpolicy</code> content attribute</h3>
@@ -440,8 +448,8 @@ spec:html; type:element; text:link
 
   <h3 id="referrer-policy-delivery-implicit">Implicit Delivery</h3>
 
-  A <a>settings object</a> inherits the <a>referrer policy</a> of another object
-  in several circumstances:
+  An <a>environment settings object</a> inherits the <a>referrer
+  policy</a> of another object in several circumstances:
 
   <h4 id="referrer-policy-delivery-implicit-nested">
      Nested Browsing Contexts
@@ -481,7 +489,7 @@ spec:html; type:element; text:link
       object</a>.
     </li>
     <li>
-      Let <var>policy</var> be <code>No Referrer When Downgrade</code>.
+      Let <var>policy</var> be <a>"<code>no-referrer-when-downgrade</code>"</a>.
     </li>
     <li>
       Execute the <a section href="#set-referrer-policy"></a> algorithm on
@@ -522,8 +530,8 @@ spec:html; type:element; text:link
 
   Note: W3C HTML5 does not define the <code>referrerpolicy</code> content
   attributes, or <code>referrerPolicy</code> IDL attributes, or the
-  <a>Referrer policy state</a> for <{meta}>. For this spec to make sense
-  with W3C HTML5, those would need to be copied from [[HTML]].
+  <a for="meta"><code>referrer</code></a> keyword for <{meta}>. For this spec to
+  make sense with W3C HTML5, those would need to be copied from [[HTML]].
 </section>
 
 <section>
@@ -557,10 +565,10 @@ spec:html; type:element; text:link
     Set <var>environment</var>'s referrer policy to <var>policy</var>
   </h3>
 
-  If no referrer policy has been set for a <a>settings object</a>, then
-  setting its value is straightforward. If a policy has previously been
-  set, then we overwrite it with the new value if the new value is
-  not the empty string.
+  If no referrer policy has been set for an <a>environment settings
+  object</a>, then setting its value is straightforward. If a policy has
+  previously been set, then we overwrite it with the new value if the
+  new value is not the empty string.
 
   <ol>
     <li>
@@ -568,11 +576,13 @@ spec:html; type:element; text:link
     </li>
 
     <li>
-      If <var>policy</var> is not one of <code><a>No Referrer</a></code>,
-      <code><a>No Referrer When Downgrade</a></code>, <code><a>Origin
-      Only</a></code>, <code><a>Origin When Cross-Origin</a></code>, or
-      <code><a>Unsafe URL</a></code>, then return without setting
-      <var>environment</var>'s referrer policy.
+      If <var>policy</var> is not one of
+      <a>"<code>no-referrer</code>"</a>,
+      <a>"<code>no-referrer-when-downgrade</code>"</a>,
+      <a>"<code>origin-only</code>"</a>,
+      <a>"<code>origin-when-cross-origin</code>"</a>, or
+      <a>"<code>unsafe-url</code>"</a>,
+      abort these steps.
     </li>
 
     <li>
@@ -603,8 +613,8 @@ spec:html; type:element; text:link
   </h3>
 
   Given a {{Request}} <var>request</var>, we can determine the correct
-  referrer information to send by examining the <a>policy</a> associated
-  with it, as detailed in the following steps, which return
+  referrer information to send by examining the <a>referrer policy</a>
+  associated with it, as detailed in the following steps, which return
   either <code>no referrer</code> or a URL:
 
   Note: If Fetch is performing a navigation in response to a link of type
@@ -691,19 +701,17 @@ spec:html; type:element; text:link
     <li>
       Execute the statements corresponding to the value of <var>policy</var>:
 
-      <dl>
-        <dt><var>policy</var> is <code><a>No Referrer</a></code></dt>
+      <dl class="switch">
+        <dt><a>"<code>no-referrer</code>"</a></dt>
         <dd>Return <code>no referrer</code></dd>
 
-        <dt><var>policy</var> is <code><a>Origin Only</a></code></dt>
+        <dt><a>"<code>origin-only</code>"</a></dt>
         <dd>Return <var>referrerOrigin</var></dd>
 
-        <dt><var>policy</var> is <code><a>Unsafe URL</a></code></dt>
+        <dt><a>"<code>unsafe-url</code>"</a></dt>
         <dd>Return <var>referrerURL</var>.</dd>
 
-        <dt>
-          <var>policy</var> is <code><a>Origin When Cross-Origin</a></code>
-        </dt>
+        <dt><a>"<code>origin-when-cross-origin</code>"</a></dt>
         <dd>
           <ol>
             <li>
@@ -716,12 +724,8 @@ spec:html; type:element; text:link
           </ol>
         </dd>
 
-        <dt>
-          <var>policy</var> is <code><a>No Referrer When Downgrade</a></code>
-        </dt>
-        <dt>
-          <var>policy</var> is the empty string.
-        </dt>
+        <dt><a>"<code>no-referrer-when-downgrade</code>"</a></dt>
+        <dt>the empty string</dt>
         <dd>
           <ol>
             <li>
@@ -760,17 +764,17 @@ spec:html; type:element; text:link
       If <var>url</var> is <code>null</code>, return <code>no referrer</code>.
     </li>
     <li>
-      If <var>url</var>'s <code>scheme</code> is a <a>local scheme</a>, then
+      If <var>url</var>'s <a for=url>scheme</a> is a <a>local scheme</a>, then
       return <code>no referrer</code>.
     </li>
     <li>
-      Set <var>url</var>'s <code>username</code> to the empty string.
+      Set <var>url</var>'s <a>username</a> to the empty string.
     </li>
     <li>
-      Set <var>url</var>'s <code>password</code> to <code>null</code>.
+      Set <var>url</var>'s <a>password</a> to <code>null</code>.
     </li>
     <li>
-      Set <var>url</var>'s <code>fragment</code> to <code>null</code>.
+      Set <var>url</var>'s <a>fragment</a> to <code>null</code>.
     </li>
     <li>
       If the <code><a>origin-only flag</a></code> is <code>true</code>,
@@ -778,10 +782,10 @@ spec:html; type:element; text:link
 
       <ol>
         <li>
-          Set <var>url</var>'s <code>path</code> to <code>null</code>.
+          Set <var>url</var>'s <a for=url>path</a> to <code>null</code>.
         </li>
         <li>
-          Set <var>url</var>'s <code>query</code> to <code>null</code>.
+          Set <var>url</var>'s <a for=url>query</a> to <code>null</code>.
         </li>
       </ol>
     </li>
@@ -802,29 +806,29 @@ spec:html; type:element; text:link
     <li>
       If <var>token</var> is an <a>ASCII case-insensitive match</a> for the
       strings "<code>never</code>" or "<code>no-referrer</code>", return
-      <a><code>No Referrer</code></a>.
+      <a>"<code>no-referrer</code>"</a>.
     </li>
     <li>
       If <var>token</var> is <a>ASCII case-insensitive match</a> for the string
       "<code>default</code>" or "<code>no-referrer-when-downgrade</code>",
-      return <a><code>No Referrer When Downgrade</code></a>.
+      return <a>"<code>no-referrer-when-downgrade</code>"</a>.
     </li>
     <li>
       If <var>token</var> is an <a>ASCII case-insensitive match</a> for the
-      string "<code>origin</code>", return <a><code>Origin Only</code></a>.
+      string "<code>origin</code>", return <a>"<code>origin-only</code>"</a>.
     </li>
     <li>
       If <var>token</var> is <a>ASCII case-insensitive match</a> for the string
       "<code>origin-when-cross-origin</code>", return
-      <a><code>Origin When Cross-Origin</code></a>.
+      <a>"<code>origin-when-cross-origin</code>"</a>.
     </li>
     <li>
       If <var>token</var> is <a>ASCII case-insensitive match</a> for the strings
       "<code>always</code>" or "<code>unsafe-url</code>",
-      return <a><code>Unsafe URL</code></a>.
+      return <a>"<code>unsafe-url</code>"</a>.
     </li>
     <li>
-      If <var>token</var> is empty, return <a><code>No Referrer</code></a>.
+      If <var>token</var> is empty, return <a>"<code>no-referrer</code>"</a>.
     </li>
     <li>
       Return the empty string.
@@ -856,9 +860,9 @@ spec:html; type:element; text:link
 
   <h3 id="information-leakage">Information Leakage</h3>
 
-  The referrer policies <code>origin</code> and <code>unsafe-url</code> might
-  leak the origin and the URL of a secure site respectively via insecure
-  transport.
+  The <a>referrer policies</a> <a>"<code>origin-only</code>"</a> and
+  <a>"<code>unsafe-url</code>"</a> might leak the origin and the URL of
+  a secure site respectively via insecure transport.
 
   Those two policies are include in the spec nevertheless to lower the friction
   of sites adopting secure transport.
@@ -866,12 +870,13 @@ spec:html; type:element; text:link
   <h3 id="downgrade">Downgrade to less strict policies</h3>
 
   The spec does not forbid downgrading to less strict policies, e.g., from
-  <code>never</code> to <code>unsafe-url</code>.
+  <a>"<code>no-referrer</code>"</a> to <a>"<code>unsafe-url</code>"</a>.
 
   On the one hand, it is not clear which policy is more strict for all possible
-  pairs of policies: While <code>no-referrer-when-downgrade</code> will not
-  leak any information over insecure transport, and <code>origin</code> will,
-  the latter reveals less information across cross-origin navigations.
+  pairs of policies: While <a>"<code>no-referrer-when-downgrade</code>"</a> will
+  not leak any information over insecure transport, and
+  <a>"<code>origin-only</code>"</a> will, the latter reveals less information
+  across cross-origin navigations.
 
   On the other hand, allowing for setting less strict policies enables authors
   to define safe fallbacks as described in [[#unknown-policy-values]].
@@ -889,13 +894,13 @@ spec:html; type:element; text:link
   values.
 
   <div class="example">
-	Suppose older user agents don't understand
-    the <code>unsafe-url</code> policy. A site can specify
-    an <code>origin</code> policy followed by an <code>unsafe-url</code>
-    policy: older user agents will ignore the
-    unknown <code>unsafe-url</code> value and use <code>origin</code>,
-    while newer user agents will use <code>unsafe-url</code> because it is
-    the last to be processed.
+  	Suppose older user agents don't understand
+    the <a>"<code>unsafe-url</code>"</a> policy. A site can specify
+    an <a>"<code>origin-only</code>"</a> policy followed by an
+    <a>"<code>unsafe-url</code>"</a> policy: older user agents will ignore the
+    unknown <a>"<code>unsafe-url</code>"</a> value and use
+    <a>"<code>origin-only</code>"</a>, while newer user agents will use
+    <a>"<code>unsafe-url</code>"</a> because it is the last to be processed.
   </div>
 </section>
 

--- a/index.src.html
+++ b/index.src.html
@@ -16,11 +16,6 @@ Repository: w3c/webappsec-referrer-policy
 </pre>
 
 <pre class="anchors">
-spec: DOM; urlPrefix: http://www.w3.org/TR/dom/
-  type: attribute
-    text: textContent; for: Node; url: dom-node-textcontent
-  type: interface
-    text: Document; url: interface-document
 spec: FETCH; urlPrefix: https://fetch.spec.whatwg.org/
   type: dfn
     text: fetching
@@ -38,30 +33,15 @@ spec: FETCH; urlPrefix: https://fetch.spec.whatwg.org/
     text: context-frame-type; for: Request; url: concept-request-context-frame-type
 spec: HTML; urlPrefix: https://html.spec.whatwg.org/multipage/
   type: dfn
-    urlPrefix: browsers.html
-      text: opaque origin; url: concept-origin-opaque
-spec: HTML5; urlPrefix: http://www.w3.org/TR/html5/
-  type: element-attr
-    urlPrefix: document-metadata.html
-      text: name; for: meta; url: attr-meta-name
-      text: content; for: meta; url: attr-meta-content
-  type: element
-    urlPrefix: embedded-content-0.html
-      text: iframe; url: the-iframe-element
-    urlPrefix: text-level-semantics.html
-      text: a; url: the-a-element
-    urlPrefix: document-metadata.html
-      text: meta; url: the-meta-element
-  type: dfn
-    urlPrefix: document-metadata.html
+    urlPrefix: semantics.html
       text: pragma directives
-    urlPrefix: dom.html
-      text: fallback content
-      text: the document's address
-    urlPrefix: embedded-content-0.html
+      text: noreferrer; url: link-type-noreferrer
+      text: Referrer policy state; url: attr-meta-http-equiv-referrer
+    urlPrefix: embedded-content.html
       text: an iframe srcdoc document
       text: relevant mutation; url: relevant-mutations
     urlPrefix: browsers.html
+      text: opaque origin; url: concept-origin-opaque
       text: active document
       text: parse a sandboxing directive
       text: forced sandboxing flag set
@@ -97,12 +77,7 @@ spec: HTML5; urlPrefix: http://www.w3.org/TR/html5/
       text: firing; url: concept-event-fire
       text: reflect
       text: limited to only known values
-    urlPrefix: links.html
-      text: icon; url: rel-icon
-      text: link type stylesheet
-      text: noreferrer; url: link-type-noreferrer
-    urlPrefix: scripting-1.html
-      text: the script block's source
+      text: referrer policy attribute
     urlPrefix: webappapis.html
       text: queue a task
       text: task source
@@ -113,15 +88,21 @@ spec: HTML5; urlPrefix: http://www.w3.org/TR/html5/
       text: responsible document
       text: responsible browsing context
       text: API referrer source
-      text: document environment
-      text: worker environment
+      text: global object
+    urlPrefix: workers.html
+      text: run a worker
+  type: interface
+    urlPrefix: dom.html
+      text: Document
+  type: element
+    text: a; url: the-a-element
+  type: element-attr
+    urlPrefix: semantics.html
+      text: name; for: meta; url: attr-meta-name
 spec: MIX; urlPrefix: https://w3c.github.io/webappsec/specs/mixedcontent/
   type: dfn
     text: a priori authenticated URL
-spec: WORKERS; urlPrefix: http://www.w3.org/TR/workers/
-  type: dfn
-    text: runs a worker; url: run-a-worker
-spec: URL; urlPrefix: http://www.w3.org/TR/url/
+spec: URL; urlPrefix: https://url.spec.whatwg.org
   type: dfn
     text: local scheme
   type: interface
@@ -444,130 +425,18 @@ spec:html; type:element; text:link
 
   <h3 id="referrer-policy-delivery-meta">Delivery via <{meta}></h3>
 
-  A referrer policy may be set when an HTML <{meta}> element with a
-  <{meta/name}> attribute that is an <a>ASCII case-insensitive match</a>
-  for the string "<code>Referrer</code>" is inserted into a document, for
-  example:
-
-  <pre class="example">
-    &lt;meta name="referrer" content="origin"&gt;
-  </pre>
-
-  The following values for the <code>content</code> attribute are valid, and map
-  to the listed <a>referrer policy</a> values:
-
-  <dl>
-    <dt>no-referrer</dt>
-    <dd><a><code>No Referrer</code></a></dd>
-    <dt>no-referrer-when-downgrade</dt>
-    <dd><a><code>No Referrer When Downgrade</code></a></dd>
-    <dt>origin</dt>
-    <dd><a><code>Origin Only</code></a></dd>
-    <dt>origin-when-cross-origin</dt>
-    <dd><a><code>Origin When Cross-Origin</code></a></dd>
-    <dt>unsafe-url</dt>
-    <dd><a><code>Unsafe URL</code></a></dd>
-  </dl>
-
-  Add the following entry to the
-  <a href="http://www.w3.org/TR/html5/document-metadata.html#pragma-directives">pragma directives</a>
-  for the <{meta}> element:
-
-  <dl>
-    <dt>
-      Referrer policy
-      (<code>name="Referrer"</code>)
-    </dt>
-    <dd>
-      <ol>
-        <li>
-          If the Document's <{head}> element is not an ancestor of the <{meta}>
-          element, abort these steps.
-        </li>
-
-        <li>
-          If the <{meta}> element lacks a <{meta/content}> attribute then abort
-          these steps.
-        </li>
-
-        <li>
-          Let <var>environment</var> be the {{Document}}'s <a>incumbent settings
-          object</a>.
-        </li>
-
-        <li>
-          Let <var>meta-value</var> be the value of the element's
-          <{meta/content}> attribute, after
-          <a lt="strip leading and trailing whitespace" >stripping
-          leading and trailing whitespace</a>.
-        </li>
-
-        <li>
-          If <var>meta-value</var> is the empty string, then abort these steps.
-        </li>
-
-        <li>
-          Let <var>policy</var> be the result of executing the
-          [[#determine-policy-for-token]] algorithm on <var>meta-value</var>.
-        </li>
-
-        <li>
-          Execute the [[#set-referrer-policy]] algorithm on
-          |environment| using |policy|.
-        </li>
-      </ol>
-
-      Note: Authors are encouraged to avoid the legacy keywords
-      <code>never</code>, <code>default</code>, and <code>always</code>. The
-      keywords <code>no-referrer</code>,
-      <code>no-referrer-when-downgrade</code>, and <code>unsafe-url</code>
-      respectively are preferred.
-
-      Note: Implementors are advised to also respect a <a>referrer policy</a>
-      delivered via a <code><a element>meta</a></code> element during
-      speculative resource loads.
-    </dd>
-  </dl>
+  The HTML Standard defines the <a>Referrer policy state</a> for the <{meta}>
+  element, which allows setting the <a>referrer policy</a> via markup.
 
   <h3 id="referrer-policy-delivery-referrer-attribute">Delivery
   via a <code>referrerpolicy</code> content attribute</h3>
 
-  A referrer policy may be set when a <code>referrerpolicy</code> content
-  attribute is added to an <code><a element>a</a></code>, <code>
-  <a element>area</a></code>, <code><a element>img</a></code>, <code>
-  <a element>iframe</a></code>, or <code><a element>link</a></code> element,
-  for example:
+  The HTML Standard defines the concept of <a>referrer policy
+  attributes</a> which applies to several of its elements, for example:
 
   <pre class="example">
-    &lt;a href="http://example.com" referrerPolicy="origin"&gt;
+    &lt;a href="http://example.com" referrerpolicy="origin"&gt;
   </pre>
-
-  The following values for the <code>referrerpolicy</code> content attribute
-  are valid, and map to the listed <a>referrer policy</a> values:
-
-  <dl>
-    <dt>no-referrer</dt>
-    <dd><a><code>No Referrer</code></a></dd>
-    <dt>no-referrer-when-downgrade</dt>
-    <dd><a><code>No Referrer When Downgrade</code></a></dd>
-    <dt>origin</dt>
-    <dd><a><code>Origin Only</code></a></dd>
-    <dt>origin-when-cross-origin</dt>
-    <dd><a><code>Origin When Cross-Origin</code></a></dd>
-    <dt>unsafe-url</dt>
-    <dd><a><code>Unsafe URL</code></a></dd>
-  </dl>
-
-  A policy delivered via a <code>referrerpolicy</code> content attribute on an
-  element takes precedence over the policy defined for the whole document via
-  <a>Referrer-Policy header</a> or a <a element>meta</a> element unless the attribute value is invalid.
-
-  NOTE: If an <code><a element>a</a></code>
-  or <code><a element>area</a></code> element includes both
-  a <code>referrerpolicy</code> attribute as well as
-  a <a><code>noreferrer</code></a> link type then the <a><code>noreferrer</code></a>
-  link type will take precedence and the <a><code>No Referrer</code></a> policy
-  takes effect.
 
   <h3 id="referrer-policy-delivery-implicit">Implicit Delivery</h3>
 
@@ -602,8 +471,9 @@ spec:html; type:element; text:link
     Workers
   </h4>
 
-  Whenever a user agent <a>runs a worker</a> for a script with {{URL}}
-  <var>url</var> and <var>url</var>'s scheme is a <a>local scheme</a>:
+  Whenever a user agent <a lt="run a worker">runs a worker</a> for a
+  script with {{URL}} <var>url</var> and <var>url</var>'s scheme is a
+  <a>local scheme</a>:
 
   <ol>
     <li>
@@ -618,68 +488,6 @@ spec:html; type:element; text:link
       <var>environment</var> using <var>policy</var>.
     </li>
   </ol>
-</section>
-
-<section>
-  <h2 id="element-interface-extensions">Element interface extensions</h2>
-
-  <h3 id="html-anchor-element">HTMLAnchorElement</h3>
-  <pre class="idl">
-    partial interface HTMLAnchorElement {
-      attribute DOMString referrerPolicy;
-    };
-  </pre>
-  <h4 id="html-anchor-element-attributes">Attributes</h4>
-  The <code>referrerPolicy</code> IDL attribute must <a>reflect</a> the
-  <code>referrerpolicy</code> content attribute, <a>limited to only known
-  values</a>.
-
-  <h3 id="html-area-element">HTMLAreaElement</h3>
-  <pre class="idl">
-    partial interface HTMLAreaElement {
-      attribute DOMString referrerPolicy;
-    };
-  </pre>
-  <h4 id="html-area-element-attributes">Attributes</h4>
-  The <code>referrerPolicy</code> IDL attribute must <a>reflect</a> the
-  <code>referrerpolicy</code> content attribute, <a>limited to only known
-  values</a>.
-
-  <h3 id="html-image-element">HTMLImageElement</h3>
-  <pre class="idl">
-    partial interface HTMLImageElement {
-      attribute DOMString referrerPolicy;
-    };
-  </pre>
-  <h4 id="html-image-element-attributes">Attributes</h4>
-  The <code>referrerPolicy</code> IDL attribute must <a>reflect</a> the
-  <code>referrerpolicy</code> content attribute, <a>limited to only known
-  values</a>.
-
-  Note: Modifying the <code>referrerPolicy</code> IDL attribute is not a
-  <a>relevant mutation</a> for an <code><a element>img</a></code> element.
-
-  <h3 id="html-iframe-element">HTMLIFrameElement</h3>
-  <pre class="idl">
-    partial interface HTMLIFrameElement {
-      attribute DOMString referrerPolicy;
-    };
-  </pre>
-  <h4 id="html-iframe-element-attributes">Attributes</h4>
-  The <code>referrerPolicy</code> IDL attribute must <a>reflect</a> the
-  <code>referrerpolicy</code> content attribute, <a>limited to only known
-  values</a>.
-
-  <h3 id="html-link-element">HTMLLinkElement</h3>
-  <pre class="idl">
-    partial interface HTMLLinkElement {
-      attribute DOMString referrerPolicy;
-    };
-  </pre>
-  <h4 id="html-link-element-attributes">Attributes</h4>
-  The <code>referrerPolicy</code> IDL attribute must <a>reflect</a> the
-  <code>referrerpolicy</code> content attribute, <a>limited to only known
-  values</a>.
 </section>
 
 <section>
@@ -712,6 +520,10 @@ spec:html; type:element; text:link
   img elements, HTML should set the request's associated referrer policy
   before fetching.
 
+  Note: W3C HTML5 does not define the <code>referrerpolicy</code> content
+  attributes, or <code>referrerPolicy</code> IDL attributes, or the
+  <a>Referrer policy state</a> for <{meta}>. For this spec to make sense
+  with W3C HTML5, those would need to be copied from [[HTML]].
 </section>
 
 <section>
@@ -814,7 +626,8 @@ spec:html; type:element; text:link
 
       <ol>
         <li>
-          If <var>environment</var> is a <a>document environment</a>:
+          If <var>environment</var>'s <a>global object</a> is a {{Window}}
+          object:
 
           <ol>
             <li>
@@ -825,7 +638,8 @@ spec:html; type:element; text:link
           </ol>
         </li>
         <li>
-          Otherwise, <var>environment</var> is a <a>worker environment</a>:
+          Otherwise, <var>environment</var>'s <a>global object</a> is a
+          {{WorkerGlobalScope}}:
 
           <ol>
             <li>

--- a/index.src.html
+++ b/index.src.html
@@ -284,9 +284,9 @@ spec:html; type:element; text:link
 
   This is a user agent's default behavior, if no policy is otherwise specified.
 
-  <h3 dfn export id="referrer-policy-origin" oldids="referrer-policy-state-origin">"<code>origin-only</code>"</h3>
+  <h3 dfn export id="referrer-policy-origin" oldids="referrer-policy-state-origin">"<code>origin</code>"</h3>
 
-  The <a>"<code>origin-only</code>"</a> policy specifies that only the
+  The <a>"<code>origin</code>"</a> policy specifies that only the
   <a lt="ASCII serialization of an origin">ASCII serialization</a> of the
   <a>origin</a> of the <a>request client</a> is sent as referrer information
   when making both <a>same-origin requests</a> and <a>cross-origin requests</a>
@@ -298,12 +298,12 @@ spec:html; type:element; text:link
   ("<code>/</code>") character to the origin (e.g.
   <code>https://example.com/</code>).
 
-  Note: The <a>"<code>origin-only</code>"</a> policy causes the origin of HTTPS
+  Note: The <a>"<code>origin</code>"</a> policy causes the origin of HTTPS
   referrers to be sent over the network as part of unencrypted HTTP requests.
 
   <div class="example">
     If a document at <code>https://example.com/page.html</code> sets a policy of
-    <a>"<code>origin-only</code>"</a>, then navigations to any
+    <a>"<code>origin</code>"</a>, then navigations to any
     <a>origin</a> would send a <a><code>Referer</code></a> header with a value
     of <code>https://example.com/</code>, even to URLs that are not <a><em>a
     priori</em> authenticated URLs</a>.
@@ -579,7 +579,7 @@ spec:html; type:element; text:link
       If <var>policy</var> is not one of
       <a>"<code>no-referrer</code>"</a>,
       <a>"<code>no-referrer-when-downgrade</code>"</a>,
-      <a>"<code>origin-only</code>"</a>,
+      <a>"<code>origin</code>"</a>,
       <a>"<code>origin-when-cross-origin</code>"</a>, or
       <a>"<code>unsafe-url</code>"</a>,
       abort these steps.
@@ -705,7 +705,7 @@ spec:html; type:element; text:link
         <dt><a>"<code>no-referrer</code>"</a></dt>
         <dd>Return <code>no referrer</code></dd>
 
-        <dt><a>"<code>origin-only</code>"</a></dt>
+        <dt><a>"<code>origin</code>"</a></dt>
         <dd>Return <var>referrerOrigin</var></dd>
 
         <dt><a>"<code>unsafe-url</code>"</a></dt>
@@ -815,7 +815,7 @@ spec:html; type:element; text:link
     </li>
     <li>
       If <var>token</var> is an <a>ASCII case-insensitive match</a> for the
-      string "<code>origin</code>", return <a>"<code>origin-only</code>"</a>.
+      string "<code>origin</code>", return <a>"<code>origin</code>"</a>.
     </li>
     <li>
       If <var>token</var> is <a>ASCII case-insensitive match</a> for the string
@@ -860,7 +860,7 @@ spec:html; type:element; text:link
 
   <h3 id="information-leakage">Information Leakage</h3>
 
-  The <a>referrer policies</a> <a>"<code>origin-only</code>"</a> and
+  The <a>referrer policies</a> <a>"<code>origin</code>"</a> and
   <a>"<code>unsafe-url</code>"</a> might leak the origin and the URL of
   a secure site respectively via insecure transport.
 
@@ -875,7 +875,7 @@ spec:html; type:element; text:link
   On the one hand, it is not clear which policy is more strict for all possible
   pairs of policies: While <a>"<code>no-referrer-when-downgrade</code>"</a> will
   not leak any information over insecure transport, and
-  <a>"<code>origin-only</code>"</a> will, the latter reveals less information
+  <a>"<code>origin</code>"</a> will, the latter reveals less information
   across cross-origin navigations.
 
   On the other hand, allowing for setting less strict policies enables authors
@@ -896,10 +896,10 @@ spec:html; type:element; text:link
   <div class="example">
   	Suppose older user agents don't understand
     the <a>"<code>unsafe-url</code>"</a> policy. A site can specify
-    an <a>"<code>origin-only</code>"</a> policy followed by an
+    an <a>"<code>origin</code>"</a> policy followed by an
     <a>"<code>unsafe-url</code>"</a> policy: older user agents will ignore the
     unknown <a>"<code>unsafe-url</code>"</a> value and use
-    <a>"<code>origin-only</code>"</a>, while newer user agents will use
+    <a>"<code>origin</code>"</a>, while newer user agents will use
     <a>"<code>unsafe-url</code>"</a> because it is the last to be processed.
   </div>
 </section>


### PR DESCRIPTION
This is the counterpart to https://github.com/whatwg/html/pull/1153, which removes the parts of the spec that are now defined in HTML: the content and IDL attributes on various elements, plus the `<meta http-equiv>` extension.

There is still much to do; I will open a separate issue detailing the plan.