### PR TITLE
Remove a superfluous "any"

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -331,7 +331,7 @@ spec:html; type:element; text:link
 
   <div class="example">
     If a document at <code>https://example.com/page.html</code> sets a policy of
-    <a>"<code>origin-when-cross-origin</code>"</a>, then navigations to any
+    <a>"<code>origin-when-cross-origin</code>"</a>, then navigations to
     <code>https://example.com/not-page.html</code> would send a
     <a><code>Referer</code></a> header with a value of
     <code>https://example.com/page.html</code>.


### PR DESCRIPTION
That was the source of the typo discovered by @estark37 in
https://github.com/w3c/webappsec-referrer-policy/pull/19#discussion_r63733290