### PR TITLE
Add the policy states safe-origin and safe-origin-when-cross-origin.

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -505,7 +505,7 @@ spec: FETCH; type: dfn; text: referrer policy; for: /;
     "Referrer-Policy:" 1#<a>policy-token</a>
   </pre>
   <pre>
-    <dfn export>policy-token</dfn>   = "no-referrer" / "no-referrer-when-downgrade" / "same-origin" / "origin" / "origin-when-cross-origin" / "unsafe-url"
+    <dfn export>policy-token</dfn>   = "no-referrer" / "no-referrer-when-downgrade" / "safe-origin" / "safe-origin-when-cross-origin" / "same-origin" / "origin" / "origin-when-cross-origin" / "unsafe-url"
   </pre>
 
   Note: The header name does not share the HTTP Referer header's misspelling.
@@ -757,6 +757,53 @@ spec: FETCH; type: dfn; text: referrer policy; for: /;
         <dt><a>"<code>unsafe-url</code>"</a></dt>
         <dd>Return <var>referrerURL</var>.</dd>
 
+        <dt><a>"<code>safe-origin</code>"</a></dt>
+        <dd>
+          <ol>
+            <li>
+              If |environment| is not null:
+              <ol>
+                <li>
+                  If |environment| is <a>TLS-protected</a> <em>and</em>
+                  the <a>origin</a>
+                  of <var>request</var>'s <a href="https://fetch.spec.whatwg.org/#concept-request-current-url">current
+                  URL</a> is not an <a><em>a priori</em> authenticated
+                  URL</a>, then return <code>no referrer</code>.
+                </li>
+              </ol>
+            </li>
+            <li>Return |referrerOrigin|.
+          </ol>
+        </dd>
+
+        <dt><a>"<code>safe-origin-when-cross-origin</code>"</a></dt>
+        <dt>the empty string</dt>
+        <dd>
+          <ol>
+            <li>
+              If |environment| is not null:
+              <ol>
+                <li>
+                  If |environment| is <a>TLS-protected</a> <em>and</em>
+                  the <a>origin</a>
+                  of <var>request</var>'s <a href="https://fetch.spec.whatwg.org/#concept-request-current-url">current
+                  URL</a> is not an <a><em>a priori</em> authenticated URL</a>
+                  <ol>
+                    <li>
+                      If <var>request</var> is a <a>same-origin request</a>, then
+                      return <var>referrerURL</var>.
+                    </li>
+                    <li>
+                      Otherwise, return <var>referrerOrigin</var>.
+                    </li>
+                  </ol>
+                </li>
+              </ol>
+            </li>
+            <li>Return <code>no referrer</code>.
+          </ol>
+        </dd>
+
         <dt><a>"<code>same-origin</code>"</a></dt>
         <dd>
           <ol>
@@ -878,6 +925,15 @@ spec: FETCH; type: dfn; text: referrer policy; for: /;
     </li>
     <li>
       If <var>token</var> is an <a>ASCII case-insensitive match</a> for the
+      string "<code>safe-origin</code>", return <a>"<code>safe-origin</code>"</a>.
+    </li>
+    <li>
+      If <var>token</var> is an <a>ASCII case-insensitive match</a> for the
+      string "<code>safe-origin-when-cross-origin</code>", return
+      <a>"<code>safe-origin-when-cross-origin</code>"</a>.
+    </li>
+    <li>
+      If <var>token</var> is an <a>ASCII case-insensitive match</a> for the
       string "<code>same-origin</code>", return <a>"<code>same-origin</code>"</a>.
     </li>
     <li>
@@ -932,7 +988,7 @@ spec: FETCH; type: dfn; text: referrer policy; for: /;
 
   Authors can use the policy states <a>"<code>safe-origin</code>"</a>,
   <a>"<code>safe-origin-when-cross-origin</code>"</a> and
-  <a>"<code>no-referrer</code>"</a> to preserve sensitive information from
+  <a>"<code>no-referrer</code>"</a> to prevent sensitive information from
   leaking via referrer headers. [[CAPABILITY-URLS]]
 
   <h3 id="downgrade">Downgrade to less strict policies</h3>

--- a/index.src.html
+++ b/index.src.html
@@ -927,8 +927,13 @@ spec: FETCH; type: dfn; text: referrer policy; for: /;
   <a>"<code>unsafe-url</code>"</a> might leak the origin and the URL of
   a secure site respectively via insecure transport.
 
-  Those two policies are include in the spec nevertheless to lower the friction
+  Those two policies are included in the spec nevertheless to lower the friction
   of sites adopting secure transport.
+
+  Authors can use the policy states <a>"<code>safe-origin</code>"</a>,
+  <a>"<code>safe-origin-when-cross-origin</code>"</a> and
+  <a>"<code>no-referrer</code>"</a> to preserve sensitive information from
+  leaking via referrer headers. [[CAPABILITY-URLS]]
 
   <h3 id="downgrade">Downgrade to less strict policies</h3>
 

--- a/index.src.html
+++ b/index.src.html
@@ -332,7 +332,7 @@ spec: FETCH; type: dfn; text: referrer policy; for: /;
     priori</em> authenticated URLs</a>.
   </div>
 
-  <h3 dfn export id="referrer-policy-safe-origin" oldids="referrer-policy-state-safe-origin">"<code>safe-origin</code></h3>
+  <h3 dfn export id="referrer-policy-safe-origin" oldids="referrer-policy-state-safe-origin">"<code>safe-origin</code>"</h3>
 
   The <a>"<code>safe-origin</code>"</a> policy sends the
   <a lt="ASCII serialization of an origin">ASCII serialization</a> of the
@@ -777,30 +777,27 @@ spec: FETCH; type: dfn; text: referrer policy; for: /;
         </dd>
 
         <dt><a>"<code>safe-origin-when-cross-origin</code>"</a></dt>
-        <dt>the empty string</dt>
         <dd>
           <ol>
+            <li>
+              If <var>request</var> is a <a>same-origin request</a>, then
+              return <var>referrerURL</var>.
+            </li>
             <li>
               If |environment| is not null:
               <ol>
                 <li>
                   If |environment| is <a>TLS-protected</a> <em>and</em>
-                  the <a>origin</a>
-                  of <var>request</var>'s <a href="https://fetch.spec.whatwg.org/#concept-request-current-url">current
+                  the <a>origin</a> of <var>request</var>'s
+                  <a href="https://fetch.spec.whatwg.org/#concept-request-current-url">current
                   URL</a> is not an <a><em>a priori</em> authenticated URL</a>
                   <ol>
-                    <li>
-                      If <var>request</var> is a <a>same-origin request</a>, then
-                      return <var>referrerURL</var>.
-                    </li>
-                    <li>
-                      Otherwise, return <var>referrerOrigin</var>.
-                    </li>
+                      <li>Return <code>no referrer</code>.
                   </ol>
                 </li>
               </ol>
             </li>
-            <li>Return <code>no referrer</code>.
+            <li>Return |referrerOrigin|.
           </ol>
         </dd>
 

--- a/index.src.html
+++ b/index.src.html
@@ -332,6 +332,32 @@ spec: FETCH; type: dfn; text: referrer policy; for: /;
     priori</em> authenticated URLs</a>.
   </div>
 
+  <h3 dfn export id="referrer-policy-safe-origin" oldids="referrer-policy-state-safe-origin">"<code>safe-origin</code></h3>
+
+  The <a>"<code>safe-origin</code>"</a> policy sends the
+  <a lt="ASCII serialization of an origin">ASCII serialization</a> of the
+  <a>origin</a> of the <a>request client</a> when making requests from
+  <a>TLS-protected</a> <a>environment settings object</a> to a
+  <a><em>a priori</em> authenticated URL</a>, and requests from
+  <a>request clients</a> which are <em>not</em> <a>TLS-protected</a> to any
+  <a>origin</a>.
+
+  Requests from <a>TLS-protected</a> <a>request clients</a> to non-<a><em>a
+  priori</em> authenticated URLs</a>, on the other hand, will contain no
+  referrer information. A <code><a>Referer</a></code> HTTP header will not be
+  sent.
+
+  <div class="example">
+    If a document at <code>https://example.com/page.html</code> sets a policy of
+    <a>"<code>safe-origin</code>"</a>, then navigations to
+    <code>https://<strong>not</strong>.eaxmple.com</code> would send a
+    <a><code>Referer</code></a> header with a value of
+    <code>https://example.com/</code>. This explicitly excludes navigations to
+    URLs that are not <a><em>a priori</em> authenticated URLs</a>.
+    Navigations to <code><strong>http://not</strong>.example.com</code> would
+    send no <a><code>Referer</code></a> header.
+  </div>
+
   <h3 dfn export id="referrer-policy-origin-when-cross-origin" oldids="referrer-policy-state-origin-when-cross-origin">"<code>origin-when-cross-origin</code>"</h3>
 
   The <a>"<code>origin-when-cross-origin</code>"</a> policy specifies that a
@@ -363,6 +389,38 @@ spec: FETCH; type: dfn; text: referrer policy; for: /;
     would send a <a><code>Referer</code></a> header with a value of
     <code>https://example.com/</code>, even to URLs that are not <a><em>a
     priori</em> authenticated URLs</a>.
+  </div>
+
+  <h3 dfn export id="referrer-policy-safe-origin-when-cross-origin" oldids="referrer-policy-state-safe-origin-when-cross-origin">"<code>safe-origin-when-cross-origin</code>"</h3>
+
+  The <a>"<code>safe-origin-when-cross-origin</code>"</a> policy specifies that a
+  full URL, <a href="#strip-url">stripped for use as a referrer</a>, is sent as
+  referrer information when making <a>same-origin requests</a> from a particular
+  <a>request client</a>, and only the
+  <a lt="ASCII serialization of an origin">ASCII serialization</a> of the
+  <a>origin</a> of the <a>request client</a> is sent as referrer information
+  when making <a>cross-origin requests</a> from a particular <a>request
+  client</a>.
+
+  Requests from <a>TLS-protected</a> <a>request clients</a> to non-<a><em>a
+  priori</em> authenticated URLs</a>, on the other hand, will contain no
+  referrer information. A <code><a>Referer</a></code> HTTP header will not be
+  sent.
+
+  <div class="example">
+    If a document at <code>https://example.com/page.html</code> sets a policy of
+    <a>"<code>safe-origin-when-cross-origin</code>"</a>, then navigations to
+    <code>https://example.com/not-page.html</code> would send a
+    <a><code>Referer</code></a> header with a value of
+    <code>https://example.com/page.html</code>.
+
+    Navigations from that same page to <code>https://not.example.com/</code>
+    would send a <a><code>Referer</code></a> header with a value of
+    <code>https://example.com/</code>.
+    This excludes URLs that are not <a><em>a priori</em> authenticated URLs</a>.
+    Navigations from that same page to
+    <code><strong>http://not</strong>.example.com/</code> would send no
+    <a><code>Referer</code></a> header.
   </div>
 
   <h3 dfn export id="referrer-policy-unsafe-url" oldids="referrer-policy-state-unsafe-url">"<code>unsafe-url</code>"</h3>


### PR DESCRIPTION
This is a follow-up of #19. It was already discussed in #50.

The web platform tests still need to be updated for the three new states (the third one being same-origin which has already been merged into the spec). We also want this upstreamed in Fetch and HTML.

Flagging @estark37 for review. @domenic and @annevk for HTML and Fetch respectively.