### PR TITLE
Add a missing "a"

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -259,7 +259,7 @@ spec: FETCH; type: dfn; text: referrer policy; for: /;
   <h3 dfn export id="referrer-policy-no-referrer-when-downgrade" oldids="referrer-policy-state-no-referrer-when-downgrade">"<code>no-referrer-when-downgrade</code>"</h3>
 
   The <a>"<code>no-referrer-when-downgrade</code>"</a> policy sends a full URL
-  along with requests from <a>TLS-protected</a> <a>environment settings
+  along with requests from a <a>TLS-protected</a> <a>environment settings
   object</a> to a <a><em>a priori</em> authenticated URL</a>, and requests from
   <a>request clients</a> which are <em>not</em> <a>TLS-protected</a> to any
   <a>origin</a>.


### PR DESCRIPTION
That was the source of the typo discovered by @estark37 in
https://github.com/w3c/webappsec-referrer-policy/pull/52/files/3bbd369b797abd3c51e4f7a3cb94f6349457ef12#r65738690