### PR TITLE
Redact origin according to policy

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,320 +1,55 @@
 <!doctype html><html lang="en">
  <head>
   <meta content="text/html; charset=utf-8" http-equiv="Content-Type">
-  <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport">
   <title>Referrer Policy</title>
-<style data-fill-with="stylesheet">/******************************************************************************
- *                   Style sheet for the W3C specifications                   *
- *
- * Special classes handled by this style sheet include:
- *
- * Indices
- *   - .toc for the Table of Contents (<ol class="toc">)
- *     + <span class="secno"> for the section numbers
- *   - #toc for the Table of Contents (<nav id="toc">)
- *   - ul.index for Indices (<a href="#ref">term</a><span>, in §N.M</span>)
- *   - table.index for Index Tables (e.g. for properties or elements)
- *
- * Structural Markup
- *   - table.data for general data tables
- *     -> use 'scope' attribute, <colgroup>, <thead>, and <tbody> for best results !
- *     -> use <table class='complex data'> for extra-complex tables
- *     -> use <td class='long'> for paragraph-length cell content
- *     -> use <td class='pre'> when manual line breaks/indentation would help readability
- *   - dl.switch for switch statements
- *   - ol.algorithm for algorithms (helps to visualize nesting)
- *   - .figure and .caption (HTML4) and figure and figcaption (HTML5)
- *     -> .sidefigure for right-floated figures
- *   - ins/del
- *
- * Code
- *   - pre and code
- *
- * Special Sections
- *   - .note       for informative notes             (div, p, span, aside, details)
- *   - .example    for informative examples          (div, p, pre, span)
- *   - .issue      for issues                        (div, p, span)
- *   - .assertion  for assertions                    (div, p, span)
- *   - .advisement for loud normative statements     (div, p, strong)
- *   - .annoying-warning for spec obsoletion notices (div, aside, details)
- *
- * Definition Boxes
- *   - pre.def   for WebIDL definitions
- *   - table.def for tables that define other entities (e.g. CSS properties)
- *   - dl.def    for definition lists that define other entitles (e.g. HTML elements)
- *
- * Numbering
- *   - .secno for section numbers in .toc and headings (<span class='secno'>3.2</span>)
- *   - .marker for source-inserted example/figure/issue numbers (<span class='marker'>Issue 4</span>)
- *   - ::before styled for CSS-generated issue/example/figure numbers:
- *     -> Documents wishing to use this only need to add
- *        figcaption::before,
- *        .caption::before { content: "Figure "  counter(figure) " ";  }
- *        .example::before { content: "Example " counter(example) " "; }
- *        .issue::before   { content: "Issue "   counter(issue) " ";   }
- *
- * Header Stuff (ignore, just don't conflict with these classes)
- *   - .head for the header
- *   - .copyright for the copyright
- *
- * Miscellaneous
- *   - .overlarge for things that should be as wide as possible, even if
- *     that overflows the body text area. This can be used on an item or
- *     on its container, depending on the effect desired.
- *     Note that this styling basically doesn't help at all when printing,
- *     since A4 paper isn't much wider than the max-width here.
- *     It's better to design things to fit into a narrower measure if possible.
- *   - js-added ToC jump links (see fixup.js)
- *
- ******************************************************************************/
-
-/******************************************************************************/
-/*                                   Body                                     */
-/******************************************************************************/
+<style data-fill-with="stylesheet">/* This section copied from the W3C's ED styles. */
 
 	body {
-		counter-reset: example figure issue;
-
-		/* Layout */
-		max-width: 50em;               /* limit line length to 50em for readability   */
-		margin: 0 auto;                /* center text within page                     */
-		padding: 1.6em 1.5em 2em 50px; /* assume 16px font size for downlevel clients */
-		padding: 1.6em 1.5em 2em calc(26px + 1.5em); /* leave space for status flag     */
-
-		/* Typography */
-		line-height: 1.5;
-		font-family: sans-serif;
-		widows: 2;
-		orphans: 2;
-		word-wrap: break-word;
-		overflow-wrap: break-word;
-		hyphens: auto;
-
-		/* Colors */
 		color: black;
-		background: white top left fixed no-repeat;
-		background-size: 25px auto;
+		font-family: sans-serif;
+		margin: 0 auto;
+		max-width: 50em;
+		padding: 2em 1em 2em 70px;
 	}
+	:link { color: #00C; background: transparent }
+	:visited { color: #609; background: transparent }
+	a[href]:active { color: #C00; background: transparent }
+	a[href]:hover { background: #ffa }
 
+	a[href] img { border-style: none }
 
-/******************************************************************************/
-/*                         Front Matter & Navigation                          */
-/******************************************************************************/
+	h1, h2, h3, h4, h5, h6 { text-align: left }
+	h1, h2, h3 { color: #005A9C; }
+	h1 { font: 170% sans-serif }
+	h2 { font: 140% sans-serif }
+	h3 { font: 120% sans-serif }
+	h4 { font: bold 100% sans-serif }
+	h5 { font: italic 100% sans-serif }
+	h6 { font: small-caps 100% sans-serif }
 
-/** Header ********************************************************************/
+	.hide { display: none }
 
 	div.head { margin-bottom: 1em }
-	div.head hr { border-style: solid; }
+	div.head h1 { margin-top: 2em; clear: both }
+	div.head table { margin-left: 2em; margin-top: 2em }
 
-	div.head h1 {
-		font-weight: bold;
-		margin: 0 0 .1em;
-		font-size: 220%;
-	}
-
-	div.head h2 { margin-bottom: 1.5em;}
-
-/** W3C Logo ******************************************************************/
-
-	.head .logo {
-		float: right;
-		margin: 0.4rem 0 0.2rem .4rem;
-	}
-
-	.head img[src*="logos/W3C"] {
-		display: block;
-		border: solid #1a5e9a;
-		border-width: .65rem .7rem .6rem;
-		border-radius: .4rem;
-		background: #1a5e9a;
-		color: white;
-		font-weight: bold;
-	}
-
-	.head a:hover > img[src*="logos/W3C"],
-	.head a:focus > img[src*="logos/W3C"] {
-		opacity: .8;
-	}
-
-	.head a:active > img[src*="logos/W3C"] {
-		background: #c00;
-		border-color: #c00;
-	}
-
-	/* see also additional rules in Link Styling section */
-
-/** Copyright *****************************************************************/
-
-	p.copyright,
+	p.copyright { font-size: small }
 	p.copyright small { font-size: small }
 
-/** Back to Top / ToC Toggle **************************************************/
+	pre { margin-left: 2em }
+	dt { font-weight: bold }
 
-	@media print {
-		#toc-nav {
-			display: none;
-		}
-	}
-	@media not print {
-		#toc-nav {
-			position: fixed;
-			z-index: 2;
-			bottom: 0; left: 0;
-			margin: 0;
-			min-width: 1.33em;
-			border-top-right-radius: 2rem;
-			box-shadow: 0 0 2px;
-			font-size: 1.5em;
-			color: black;
-		}
-		#toc-nav > a {
-			display: block;
-			white-space: nowrap;
-
-			height: 1.33em;
-			padding: .1em 0.3em;
-			margin: 0;
-
-			background: white;
-			box-shadow: 0 0 2px;
-			border: none;
-			border-top-right-radius: 1.33em;
-			background: white;
-		}
-		#toc-nav > #toc-jump {
-			padding-bottom: 2em;
-			margin-bottom: -1.9em;
-		}
-
-		#toc-nav > a:hover,
-		#toc-nav > a:focus {
-			background: #f8f8f8;
-		}
-		#toc-nav > a:not(:hover):not(:focus) {
-			color: #707070;
-		}
-
-		/* statusbar gets in the way on keyboard focus; remove once browsers fix */
-		#toc-nav > a[href="#toc"]:not(:hover):focus:last-child {
-			padding-bottom: 1.5rem;
-		}
-
-		#toc-nav:not(:hover) > a:not(:focus) > span + span {
-			/* Ideally this uses :focus-within on #toc-nav */
-			display: none;
-		}
-		#toc-nav > a > span + span {
-			padding-right: 0.2em;
-		}
-
-		#toc-toggle-inline {
-			vertical-align: 0.05em;
-			font-size: 80%;
-			color: gray;
-			color: hsla(203,20%,40%,.7);
-			border-style: none;
-			background: transparent;
-			position: relative;
-		}
-		#toc-toggle-inline:hover:not(:active),
-		#toc-toggle-inline:focus:not(:active) {
-			text-shadow: 1px 1px silver;
-			top: -1px;
-			left: -1px;
-		}
-
-		#toc-nav :active {
-			color: #C00;
-		}
+	ul.toc, ol.toc {
+		list-style: none;
 	}
 
-/** ToC Sidebar ***************************************************************/
+/* The rest copied from the CSSWG's default.css */
 
-	/* Floating sidebar */
-	@media screen {
-		body.toc-sidebar #toc {
-			position: fixed;
-			top: 0; bottom: 0;
-			left: 0;
-			width: 23.5em;
-			max-width: 80%;
-			max-width: calc(100% - 2em - 26px);
-			overflow: auto;
-			padding: 0 1em;
-			padding-left: 42px;
-			padding-left: calc(1em + 26px);
-			background: inherit;
-			background-color: #f7f8f9;
-			z-index: 1;
-			box-shadow: -.1em 0 .25em rgba(0,0,0,.1) inset;
-		}
-		body.toc-sidebar #toc h2 {
-			margin-top: .8rem;
-			font-variant: small-caps;
-			font-variant: all-small-caps;
-			text-transform: lowercase;
-			font-weight: bold;
-			color: gray;
-			color: hsla(203,20%,40%,.7);
-		}
-		body.toc-sidebar #toc-jump:not(:focus) {
-			width: 0;
-			height: 0;
-			padding: 0;
-			position: absolute;
-			overflow: hidden;
-		}
-	}
-	/* Hide main scroller when only the ToC is visible anyway */
-	@media screen and (max-width: 28em) {
-		body.toc-sidebar {
-			overflow: hidden;
-		}
-	}
-
-	/* Sidebar with its own space */
-	@media screen and (min-width: 78em) {
-		body:not(.toc-inline) #toc {
-			position: fixed;
-			top: 0; bottom: 0;
-			left: 0;
-			width: 23.5em;
-			overflow: auto;
-			padding: 0 1em;
-			padding-left: 42px;
-			padding-left: calc(1em + 26px);
-			background: inherit;
-			background-color: #f7f8f9;
-			z-index: 1;
-			box-shadow: -.1em 0 .25em rgba(0,0,0,.1) inset;
-		}
-		body:not(.toc-inline) #toc h2 {
-			margin-top: .8rem;
-			font-variant: small-caps;
-			font-variant: all-small-caps;
-			text-transform: lowercase;
-			font-weight: bold;
-			color: gray;
-			color: hsla(203,20%,40%,.7);
-		}
-
-		body:not(.toc-inline) {
-			padding-left: 29em;
-		}
-		/* See also Overflow section at the bottom */
-
-		body:not(.toc-inline) #toc-jump:not(:focus) {
-			width: 0;
-			height: 0;
-			padding: 0;
-			position: absolute;
-			overflow: hidden;
-		}
-	}
-	@media screen and (min-width: 90em) {
-		body:not(.toc-inline) {
-			margin: 0 4em;
-		}
+	body {
+		counter-reset: exampleno figure issue;
+		max-width: 50em;
+		margin: 0 auto !important;
+		line-height: 1.5;
 	}
 
 /******************************************************************************/
@@ -325,34 +60,19 @@
 
 	h1, h2, h3, h4, h5, h6, dt {
 		page-break-after: avoid;
-		page-break-inside: avoid;
-		font: 100% sans-serif;   /* Reset all font styling to clear out UA styles */
-		font-family: inherit;    /* Inherit the font family. */
-		line-height: 1.2;        /* Keep wrapped headings compact */
-		hyphens: manual;         /* Hyphenated headings look weird */
 	}
 
-	h2, h3, h4, h5, h6 {
-		margin-top: 3rem;
+	h2, h3, h5, h6 {
+		margin-top: 3em;
 	}
-
-	h1, h2, h3 {
-		color: #005A9C;
-		background: transparent;
+	h4 {
+		 margin-top: 4em;
 	}
-
-	h1 { font-size: 170%; }
-	h2 { font-size: 140%; }
-	h3 { font-size: 120%; }
-	h4 { font-weight: bold; }
-	h5 { font-style: italic; }
-	h6 { font-variant: small-caps; }
-	dt { font-weight: bold; }
 
 /** Subheadings ***************************************************************/
 
 	h1 + h2,
-	#subtitle {
+	#subtitle + h2 {
 		/* #subtitle is a subtitle in an H2 under the H1 */
 		margin-top: 0;
 	}
@@ -364,8 +84,8 @@
 	}
 
 /** Section divider ***********************************************************/
-
-	:not(.head) > hr {
+	/* <hr> used to separate TMI into the second half of a section              */
+	hr:not([title]) {
 		font-size: 1.5em;
 		text-align: center;
 		margin: 1em auto;
@@ -373,9 +93,10 @@
 		border: transparent solid 0;
 		background: transparent;
 	}
-	:not(.head) > hr::before {
-		content: "\2727\2003\2003\2727\2003\2003\2727";
+	hr:not([title])::before {
+		content: "\1F411\2003\2003\1F411\2003\2003\1F411";
 	}
+	/* note: <hr> with title separates document header from contents */
 
 /******************************************************************************/
 /*                            Paragraphs and Lists                            */
@@ -384,9 +105,8 @@
 	p {
 		margin: 1em 0;
 	}
-
-	dd > p:first-child,
-	li > p:first-child {
+	dd     > p:first-child,
+	li     > p:first-child {
 		margin-top: 0;
 	}
 
@@ -394,46 +114,33 @@
 		margin-left: 0;
 		padding-left: 2em;
 	}
-
 	li {
-		margin: 0.25em 0 0.5em;
-		padding: 0;
+		margin: 0.25em 2em 0.5em 0;
+		padding-left: 0;
 	}
 
 	dl dd {
-		margin: 0 0 .5em 2em;
+		margin: 0 0 1em 2em;
 	}
-
-	.head dd + dd { /* compact for header */
-		margin-top: -.5em;
+	.head dd {
+		margin-bottom: 0;
 	}
 
 	/* Style for algorithms */
-	ol.algorithm ol:not(.algorithm),
-	.algorithm > ol ol:not(.algorithm) {
-	 border-left: 0.5em solid #DEF;
+	ol.algorithm ol {
+	 border-left: 1px solid #90b8de;
+	 margin-left: 1em;
 	}
-
-	/* Put nice boxes around each algorithm. */
-	[data-algorithm]:not(.heading) {
-	  padding: .5em;
-	  border: thin solid #ddd; border-radius: .5em;
-	  margin: .5em 0;
-	}
-	[data-algorithm]:not(.heading) > :first-child {
-	  margin-top: 0;
-	}
-	[data-algorithm]:not(.heading) > :last-child {
-	  margin-bottom: 0;
+	ol.algorithm ol.algorithm {
+	 border-left: none;
+	 margin-left: 0;
 	}
 
 	/* Style for switch/case <dl>s */
-	dl.switch > dd > ol.only,
-	dl.switch > dd > .only > ol {
+	dl.switch > dd > ol.only {
 	 margin-left: 0;
 	}
-	dl.switch > dd > ol.algorithm,
-	dl.switch > dd > .algorithm > ol {
+	dl.switch > dd > ol.algorithm {
 	 margin-left: -2em;
 	}
 	dl.switch {
@@ -455,6 +162,32 @@
 	 line-height: 0.5em;
 	}
 
+	/* Style for paragraphs I know are in MD-genned lists */
+	[data-md] > :first-child {
+		margin-top: 0;
+	}
+	[data-md] > :last-child {
+		margin-bottom: 0;
+	}
+
+/** Inline Lists **************************************************************/
+	/* This is mostly to make the list inside the CR exit criteria more compact. */
+
+	ol.inline, ol.inline li {
+		display: inline;
+		padding: 0; margin: 0;
+	}
+	ol.inline {
+		counter-reset: list-item;
+	}
+	ol.inline li {
+		counter-increment: list-item;
+	}
+	ol.inline li::before {
+		content: "(" counter(list-item) ") ";
+		font-weight: bold;
+	}
+
 /** Terminology Markup ********************************************************/
 
 
@@ -470,7 +203,7 @@
 		font-style: normal;
 	}
 	dt dfn code, code.idl {
-		font-size: normal;
+		font-size: inherit;
 	}
 	dfn var {
 		font-style: normal;
@@ -494,27 +227,129 @@
 
 /** General monospace/pre rules ***********************************************/
 
-	pre, code, samp {
-		font-family: Menlo, Consolas, "DejaVu Sans Mono", Monaco, monospace;
+	pre, code {
+		font-family: Menlo, Consolas, "DejaVu Sans Mono", monospace;
 		font-size: .9em;
 		page-break-inside: avoid;
-		hyphens: none;
-		text-transform: none;
 	}
-	pre code,
-	code code {
-		font-size: 100%;
-	}
-
 	pre {
 		margin-top: 1em;
 		margin-bottom: 1em;
 		overflow: auto;
 	}
 
-/** Inline Code fragments *****************************************************/
+/** Syntax-Highlighted Code ***************************************************/
 
-  /* Do something nice. */
+	.example pre[class*="language-"],
+	.example [class*="language-"] pre,
+	.example pre[class*="lang-"],
+	.example [class*="lang-"] pre {
+		background: transparent; /* Prism applies a gray background that doesn't work well in the template. */
+	}
+
+/** Example Code **************************************************************/
+
+	div.html, div.xml,
+	pre.html, pre.xml {
+		padding: 0.5em;
+		margin: 1em 0;
+		position: relative;
+		clear: both;
+		color: #600;
+	}
+	pre.example,
+	pre.html,
+	pre.xml {
+		padding-top: 1.5em;
+	}
+
+	pre.illegal, .illegal pre
+	pre.deprecated, .deprecated pre {
+		color: red;
+	}
+
+/** IDL fragments *************************************************************/
+
+	pre.idl {
+		/* Match blue propdef boxes */
+		padding: .5em 1em;
+		background: #DEF;
+		margin: 1.2em 0;
+		border-left: 0.5em solid #8CCBF2;
+	}
+	pre.idl :link, pre.idl :visited {
+		color:inherit;
+		background:transparent;
+	}
+
+/** Inline CSS fragments ******************************************************/
+
+	.css.css, .property.property, .descriptor.descriptor {
+		color: #005a9c;
+		font-size: inherit;
+		font-family: inherit;
+	}
+	.css::before, .property::before, .descriptor::before {
+		content: "‘";
+	}
+	.css::after, .property::after, .descriptor::after {
+		content: "’";
+	}
+	.property, .descriptor {
+		/* Don't wrap property and descriptor names */
+		white-space: nowrap;
+	}
+	.type { /* CSS value <type> */
+	font-style: italic;
+	}
+	pre .property::before, pre .property::after {
+		content: "";
+	}
+
+/** Inline markup fragments ***************************************************/
+
+	code.html, code.xml {
+		color: #660000;
+	}
+
+/** Autolinks produced using Bikeshed *****************************************/
+
+	[data-link-type="property"]::before,
+	[data-link-type="propdesc"]::before,
+	[data-link-type="descriptor"]::before,
+	[data-link-type="value"]::before,
+	[data-link-type="function"]::before,
+	[data-link-type="at-rule"]::before,
+	[data-link-type="selector"]::before,
+	[data-link-type="maybe"]::before {
+		content: "‘";
+	}
+	[data-link-type="property"]::after,
+	[data-link-type="propdesc"]::after,
+	[data-link-type="descriptor"]::after,
+	[data-link-type="value"]::after,
+	[data-link-type="function"]::after,
+	[data-link-type="at-rule"]::after,
+	[data-link-type="selector"]::after,
+	[data-link-type="maybe"]::after {
+		content: "’";
+	}
+
+	[data-link-type].production::before,
+	[data-link-type].production::after,
+	.prod [data-link-type]::before,
+	.prod [data-link-type]::after {
+		content: "";
+	}
+
+	[data-link-type=element]         { font-family: monospace; }
+	[data-link-type=element]::before { content: "<" }
+	[data-link-type=element]::after  { content: ">" }
+
+	[data-link-type=biblio] {
+		white-space: pre;
+	}
+
 
 /******************************************************************************/
 /*                                    Links                                   */
@@ -523,38 +358,75 @@
 /** General Hyperlinks ********************************************************/
 
 	/* We hyperlink a lot, so make it less intrusive */
-	a[href] {
-		color: #034575;
+	a:link, a:visited {
+		color: inherit;
 		text-decoration: none;
-		border-bottom: 1px solid #707070;
-		/* Need a bit of extending for it to look okay */
-		padding: 0 1px 0;
-		margin: 0 -1px 0;
+		border-bottom: 1px solid silver;
 	}
-	a:visited {
-		border-bottom-color: #BBB;
-	}
-
-	/* Use distinguishing colors when user is interacting with the link */
-	a[href]:focus,
-	a[href]:hover {
-		background: #f8f8f8;
-		background: rgba(75%, 75%, 75%, .25);
-		border-bottom-width: 3px;
-		margin-bottom: -2px;
-	}
-	a[href]:active {
-		color: #C00;
-		border-color: #C00;
+	@supports (text-decoration-color: silver) {
+		a:link, a:visited {
+			border-bottom: none;
+			text-decoration: underline;
+			text-decoration-color: silver;
+		}
+		a:visited {
+			text-decoration-style: dotted;
+		}
 	}
 
-	/* Backout above styling for W3C logo */
-	.head .logo,
-	.head .logo a {
+	a.logo:link, a.logo:visited { /* backout above styling for W3C logo */
+		padding: 0;
 		border: none;
 		text-decoration: none;
-		background: transparent;
 	}
+
+/** Self-Links ****************************************************************/
+	/* Auto-generated links from an element to its own anchor, for usability */
+
+	.heading, .issue, .note, .example, li, dt {
+		position: relative;
+	}
+	a.self-link {
+		position: absolute;
+		top: 0;
+		left: -2.5em;
+		width: 2em;
+		height: 2em;
+		text-align: center;
+		border: none;
+		transition: opacity .2s;
+		opacity: .5;
+	}
+	a.self-link:hover {
+		opacity: 1;
+	}
+	.heading > a.self-link {
+		font-size: 83%;
+	}
+	li > a.self-link {
+		left: -3.5em;
+	}
+	dfn > a.self-link {
+		top: auto;
+		left: auto;
+		opacity: 0;
+		width: 1.5em;
+		height: 1.5em;
+		background: gray;
+		color: white;
+		font-style: normal;
+		transition: opacity .2s, background-color .2s, color .2s;
+	}
+	dfn:hover > a.self-link {
+		opacity: 1;
+	}
+	dfn > a.self-link:hover {
+		color: black;
+	}
+
+	a.self-link::before            { content: "¶"; }
+	.heading > a.self-link::before { content: "§"; }
+	dfn > a.self-link::before      { content: "#"; }
 
 /******************************************************************************/
 /*                                    Images                                  */
@@ -564,21 +436,15 @@
 		border-style: none;
 	}
 
-	/* For autogen numbers, add
-	   .caption::before, figcaption::before { content: "Figure " counter(figure) ". "; }
-	*/
-
-	figure, .figure, .sidefigure {
+	figure, div.figure, div.sidefigure {
 		page-break-inside: avoid;
+	}
+
+	div.figure, p.figure, div.sidefigure, figure {
 		text-align: center;
 		margin: 2.5em 0;
 	}
-	.figure img,    .sidefigure img,    figure img,
-	.figure object, .sidefigure object, figure object {
-		max-width: 100%;
-		margin: auto;
-	}
-	.figure pre, .sidefigure pre, figure pre {
+	div.figure pre, div.sidefigure pre, figure pre {
 		text-align: left;
 		display: table;
 		margin: 1em auto;
@@ -586,32 +452,55 @@
 	.figure table, figure table {
 		margin: auto;
 	}
-	@media screen and (min-width: 20em) {
-		.sidefigure {
-			float: right;
-			width: 50%;
-			margin: 0 0 0.5em 0.5em
-		}
+	div.sidefigure, figure.sidefigure {
+		float: right;
+		width: 50%;
+		margin: 0 0 0.5em 0.5em
 	}
-	.caption, figcaption, caption {
+	div.figure img, div.sidefigure img, figure img,
+	div.figure object, div.sidefigure object, figure object {
+		display: block;
+		margin: auto;
+		max-width: 100%
+	}
+	p.caption, figcaption, caption {
+		text-align: center;
 		font-style: italic;
 		font-size: 90%;
 	}
-	.caption::before, figcaption::before, figcaption > .marker {
+	p.caption:not(.no-marker)::before, figcaption:not(.no-marker)::before {
+		content: "Figure " counter(figure) ". ";
+	}
+	p.caption::before, figcaption::before, figcaption > .marker {
 		font-weight: bold;
 	}
-	.caption, figcaption {
+	p.caption, figcaption {
 		counter-increment: figure;
 	}
 
 	/* DL list is indented 2em, but figure inside it is not */
-	dd > .figure, dd > figure { margin-left: -2em }
+	dd > div.figure, dd > figure { margin-left: -2em }
+
+	pre.ascii-art {
+		display: table; /* shrinkwrap */
+		margin: 1em auto;
+	}
+
+	/* Displaying the output of text layout, particularly when
+		 line-breaking is being invoked, and thus having a
+		 visible width is good. */
+	pre.output {
+		margin: 1em;
+		border: solid thin silver;
+		padding: 0.25em;
+		display: table;
+	}
 
 /******************************************************************************/
 /*                             Colored Boxes                                  */
 /******************************************************************************/
 
-	.issue, .note, .example, .assertion, .advisement, blockquote {
+	.issue, .note, .example, .why, .advisement, blockquote {
 		padding: .5em;
 		border: .5em;
 		border-left-style: solid;
@@ -622,11 +511,10 @@
 		border-right-style: solid;
 	}
 
-	.issue,
-	.note,
-	.example,
-	.advisement,
-	.assertion,
+	div.issue,
+	div.note,
+	div.example,
+	details.why,
 	blockquote {
 		margin: 1em auto;
 	}
@@ -646,6 +534,7 @@
 	}
 
 /** Open issue ****************************************************************/
+	/* not intended for CR+ publication */
 
 	.issue {
 		border-color: #E05252;
@@ -653,65 +542,53 @@
 		counter-increment: issue;
 		overflow: auto;
 	}
-	.issue::before, .issue > .marker {
-		text-transform: uppercase;
-		color: #AE1E1E;
+	.issue:not(.no-marker)::before {
+		content: "ISSUE " counter(issue);
 		padding-right: 1em;
-		text-transform: uppercase;
 	}
-	/* Add .issue::before { content: "Issue " counter(issue) " "; } for autogen numbers,
-	   or use class="marker" to mark up the issue number in source. */
+	.issue::before, .issue > .marker {
+		color: #AE1E1E;
+	}
 
 /** Example *******************************************************************/
 
 	.example {
 		border-color: #E0CB52;
 		background: #FCFAEE;
-		counter-increment: example;
+		counter-increment: exampleno;
 		overflow: auto;
 		clear: both;
 	}
 	.example::before, .example > .marker {
-		text-transform: uppercase;
 		color: #827017;
+		font-family: sans-serif;
 		min-width: 7.5em;
 		display: block;
 	}
-	/* Add .example::before { content: "Example " counter(example) " "; } for autogen numbers,
-	   or use class="marker" to mark up the example number in source. */
+	.example:not(.no-marker)::before {
+		content: "EXAMPLE";
+		content: "EXAMPLE " counter(exampleno);
+	}
+	.invalid.example::before, .invalid.example > .marker,
+	.illegal.example::before, .illegal.example > .marker {
+		color: red;
+	}
+	.invalid.example:not(.no-marker)::before,
+	.illegal.example:not(.no-marker)::before {
+		content: "INVALID EXAMPLE";
+		content: "INVALID EXAMPLE" counter(exampleno);
+	}
 
 /** Non-normative Note ********************************************************/
 
-	.note {
+	.note, .why {
 		border-color: #52E052;
 		background: #E9FBE9;
 		overflow: auto;
 	}
-
-	.note::before, .note > .marker,
-	details.note > summary::before,
-	details.note > summary > .marker {
-		text-transform: uppercase;
+	.note::before, .note > .marker {
 		display: block;
 		color: hsl(120, 70%, 30%);
-	}
-	/* Add .note::before { content: "Note"; } for autogen label,
-	   or use class="marker" to mark up the label in source. */
-
-	details.note > summary {
-		display: block;
-		color: hsl(120, 70%, 30%);
-	}
-	details.note[open] > summary {
-		border-bottom: 1px silver solid;
-	}
-
-/** Assertion Box *************************************************************/
-	/*  for assertions in algorithms */
-
-	.assertion {
-		border-color: #AAA;
-		background: #EEE;
 	}
 
 /** Advisement Box ************************************************************/
@@ -721,40 +598,46 @@
 		border-color: orange;
 		border-style: none solid;
 		background: #FFEECC;
+		text-align: center;
 	}
 	strong.advisement {
 		display: block;
-		text-align: center;
 	}
-	.advisement > .marker {
-		color: #B35F00;
+	/*.advisement::before { color: #FF8800; } */
+
+/** ??? ***********************************************************************/
+
+	details.why {
+		border-color: #52E052;
+		background: #E9FBE9;
+		display: block;
+	}
+
+	details.why > summary {
+		font-style: italic;
+		display: block;
+	}
+
+	details.why[open] > summary {
+		border-bottom: 1px silver solid;
 	}
 
 /** Spec Obsoletion Notice ****************************************************/
 	/* obnoxious obsoletion notice for older/abandoned specs. */
 
-	details {
+	details.annoying-warning {
 		display: block;
 	}
-	summary {
-		font-weight: bolder;
-	}
 
-	.annoying-warning:not(details),
-	details.annoying-warning:not([open]) > summary,
 	details.annoying-warning[open] {
 		background: #fdd;
 		color: red;
 		font-weight: bold;
-		padding: .75em 1em;
-		border: thick red;
-		border-style: solid;
+		text-align: center;
+		padding: .5em;
+		border: thick solid red;
 		border-radius: 1em;
 	}
-	.annoying-warning :last-child {
-		margin-bottom: 0;
-	}
-
 @media not print {
 	details.annoying-warning[open] {
 		position: fixed;
@@ -766,52 +649,57 @@
 }
 
 	details.annoying-warning:not([open]) > summary {
+		background: #fdd;
+		color: red;
+		font-weight: bold;
 		text-align: center;
-	}
-
-/** Entity Definition Boxes ***************************************************/
-
-	.def {
-		padding: .5em 1em;
-		background: #DEF;
-		margin: 1.2em 0;
-		border-left: 0.5em solid #8CCBF2;
+		padding: .5em;
 	}
 
 /******************************************************************************/
 /*                                    Tables                                  */
 /******************************************************************************/
 
-	th, td {
-		text-align: left;
-		text-align: start;
-	}
-
 /** Property/Descriptor Definition Tables *************************************/
 
-	table.def {
-		/* inherits .def box styling, see above */
+	table.propdef, table.propdef-extra,
+	table.descdef, table.definition-table {
+		page-break-inside: avoid;
 		width: 100%;
+		margin: 1.2em 0;
+		border-left: 0.5em solid #8CCBF2;
+		padding: 0.5em 1em;
+		background: #DEF;
 		border-spacing: 0;
 	}
 
-	table.def td,
-	table.def th {
+	table.propdef td, table.propdef-extra td,
+	table.descdef td, table.definition-table td,
+	table.propdef th, table.propdef-extra th,
+	table.descdef th, table.definition-table th {
 		padding: 0.5em;
 		vertical-align: baseline;
 		border-bottom: 1px solid #bbd7e9;
 	}
-
-	table.def > tbody > tr:last-child th,
-	table.def > tbody > tr:last-child td {
+	table.propdef > tbody > tr:last-child th,
+	table.propdef-extra > tbody > tr:last-child th,
+	table.descdef > tbody > tr:last-child th,
+	table.definition-table > tbody > tr:last-child th,
+	table.propdef > tbody > tr:last-child td,
+	table.propdef-extra > tbody > tr:last-child td,
+	table.descdef > tbody > tr:last-child td,
+	table.definition-table > tbody > tr:last-child td {
 		border-bottom: 0;
 	}
 
-	table.def th {
+	table.propdef th,
+	table.propdef-extra th,
+	table.descdef th,
+	table.definition-table th {
 		font-style: italic;
 		font-weight: normal;
+		width: 8.3em;
 		padding-left: 1em;
-		width: 3em;
 	}
 
 	/* For when values are extra-complex and need formatting for readability */
@@ -819,11 +707,17 @@
 		white-space: pre-wrap;
 	}
 
-	/* A footnote at the bottom of a def table */
-	table.def           td.footnote {
+	/* A footnote at the bottom of a propdef */
+	table.propdef td.footnote,
+	table.propdef-extra td.footnote,
+	table.descdef td.footnote,
+	table.definition-table td.footnote {
 		padding-top: 0.6em;
 	}
-	table.def           td.footnote::before {
+	table.propdef td.footnote::before,
+	table.propdef-extra td.footnote::before,
+	table.descdef td.footnote::before,
+	table.definition-table td.footnote::before {
 		content: " ";
 		display: block;
 		height: 0.6em;
@@ -831,7 +725,22 @@
 		border-top: thin solid;
 	}
 
-/** Data tables (and properly marked-up index tables) *************************/
+/** Profile Tables ************************************************************/
+	/* table of required features in a CSS profile */
+
+	table.features th {
+		background: #00589f;
+		color: #fff;
+		text-align: left;
+		padding: 0.2em 0.2em 0.2em 0.5em;
+	}
+	table.features td {
+		vertical-align: top;
+		border-bottom: 1px solid #ccc;
+		padding: 0.3em 0.3em 0.3em 0.7em;
+	}
+
+/** Data tables (and properly marked-up proptables) ***************************/
 	/*
 		 <table class="data"> highlights structural relationships in a table
 		 when correct markup is used (e.g. thead/tbody, th vs. td, scope attribute)
@@ -841,117 +750,89 @@
 
 		 Use class="long" on table cells with paragraph-like contents
 		 (This will adjust text alignment accordingly.)
-		 Alternately use class="longlastcol" on tables, to have the last column assume "long".
 	*/
 
-	table {
-		word-wrap: normal;
-		overflow-wrap: normal;
-		hyphens: manual;
-	}
-
-	table.data,
-	table.index {
+	.data, .proptable {
 		margin: 1em auto;
 		border-collapse: collapse;
+		width: 100%;
 		border: hidden;
+	}
+	.data {
+		text-align: center;
+		width: auto;
+	}
+	.data caption {
 		width: 100%;
 	}
-	table.data caption,
-	table.index caption {
-		max-width: 50em;
-		margin: 0 auto 1em;
-	}
 
-	table.data td,  table.data th,
-	table.index td, table.index th {
-		padding: 0.5em 1em;
+	.data td, .data th,
+	.proptable td, .proptable th {
+		padding: 0.5em;
 		border-width: 1px;
 		border-color: silver;
 		border-top-style: solid;
 	}
 
-	table.data thead td:empty {
+	.data thead td:empty {
 		padding: 0;
 		border: 0;
 	}
 
-	table.data  thead,
-	table.index thead,
-	table.data  tbody,
-	table.index tbody {
+	.data thead th[scope="row"],
+	.proptable thead th[scope="row"] {
+		text-align: right;
+		color: inherit;
+	}
+
+	.data thead,
+	.proptable thead,
+	.data tbody,
+	.proptable tbody {
+		color: inherit;
 		border-bottom: 2px solid;
 	}
 
-	table.data colgroup,
-	table.index colgroup {
+	.data colgroup {
 		border-left: 2px solid;
 	}
 
-	table.data  tbody th:first-child,
-	table.index tbody th:first-child  {
+	.data tbody th:first-child,
+	.proptable tbody th:first-child ,
+	.data tbody td[scope="row"]:first-child,
+	.proptable tbody td[scope="row"]:first-child {
+		text-align: right;
+		color: inherit;
 		border-right: 2px solid;
 		border-top: 1px solid silver;
 		padding-right: 1em;
 	}
-
-	table.data th[colspan],
-	table.data td[colspan] {
-		text-align: center;
+	.data.define td:last-child {
+		text-align: left;
 	}
 
-	table.complex.data th,
-	table.complex.data td {
+	.data tbody th[rowspan],
+	.proptable tbody th[rowspan],
+	.data tbody td[rowspan],
+	.proptable tbody td[rowspan]{
+		border-left:  1px solid silver;
+		border-right: 1px solid silver;
+	}
+
+	.complex.data th,
+	.complex.data td {
 		border: 1px solid silver;
-		text-align: center;
 	}
 
-	table.data.longlastcol td:last-child,
-	table.data td.long {
+	.data td.long {
 	 vertical-align: baseline;
 	 text-align: left;
 	}
 
-	table.data img {
+	.data img {
 		vertical-align: middle;
 	}
 
-
-/*
-Alternate table alignment rules
-
-	table.data,
-	table.index {
-		text-align: center;
-	}
-
-	table.data  thead th[scope="row"],
-	table.index thead th[scope="row"] {
-		text-align: right;
-	}
-
-	table.data  tbody th:first-child,
-	table.index tbody th:first-child  {
-		text-align: right;
-	}
-
-Possible extra rowspan handling
-
-	table.data  tbody th[rowspan]:not([rowspan='1']),
-	table.index tbody th[rowspan]:not([rowspan='1']),
-	table.data  tbody td[rowspan]:not([rowspan='1']),
-	table.index tbody td[rowspan]:not([rowspan='1']) {
-		border-left: 1px solid silver;
-	}
-
-	table.data  tbody th[rowspan]:first-child,
-	table.index tbody th[rowspan]:first-child,
-	table.data  tbody td[rowspan]:first-child,
-	table.index tbody td[rowspan]:first-child{
-		border-left: 0;
-		border-right: 1px solid silver;
-	}
-*/
 
 /******************************************************************************/
 /*                                  Indices                                   */
@@ -960,116 +841,97 @@ Possible extra rowspan handling
 
 /** Table of Contents *********************************************************/
 
-	.toc a {
-		/* More spacing; use padding to make it part of the click target. */
-		padding-top: 0.1rem;
-		/* Larger, more consistently-sized click target */
-		display: block;
-		/* Reverse color scheme */
-		color: black;
-		border-color: #3980B5;
-	}
-	.toc a:visited {
-		border-color: #054572;
-	}
-	.toc a:not(:focus):not(:hover) {
-		/* Allow colors to cascade through from link styling */
-		border-bottom-color: transparent;
-	}
+	/* ToC not indented, but font style shows hierarchy */
+	ul.toc           { margin: 1em 0;     font-weight: bold; /*text-transform: uppercase;*/ }
+	ul.toc ul        { margin: 0;        font-weight: normal; text-transform: none; }
+	ul.toc ul ul     { margin: 0 0 0 2em; font-style: italic; }
+	ul.toc ul ul ul  { margin: 0; }
+	ul.toc > li      { margin: 1.5em 0; }
+	ul.toc ul.toc li { margin: 0.3em 0 0 0; }
 
-	.toc, .toc ol, .toc ul, .toc li {
-		list-style: none; /* Numbers must be inlined into source */
-		/* because generated content isn't search/selectable and markers can't do multilevel yet */
-		margin:  0;
-		padding: 0;
-		line-height: 1.1rem; /* consistent spacing */
+	ul.toc, ul.toc ul, ul.toc li { padding: 0; line-height: 1.3; }
+	ul.toc a { text-decoration: none; border-bottom-style: none; }
+	ul.toc a:hover, ul.toc a:focus  { border-bottom-style: solid; }
+	@supports (text-decoration-style: solid) {
+		ul.toc a:hover, ul.toc a:focus  {
+			border-bottom-style: none;
+			text-decoration-style: solid;
+		}
 	}
-
-	/* ToC not indented until third level, but font style & margins show hierarchy */
-	.toc > li             { font-weight: bold;   }
-	.toc > li li          { font-weight: normal; }
-	.toc > li li li       { font-size:   95%;    }
-	.toc > li li li li    { font-size:   90%;    }
-	.toc > li li li li li { font-size:   85%;    }
-
-	.toc > li             { margin: 1.5rem 0;    }
-	.toc > li li          { margin: 0.3rem 0;    }
-	.toc > li li li       { margin-left: 2rem;   }
+	/*
+	ul.toc li li li, ul.toc li li li ul {margin-left: 0; display: inline}
+	ul.toc li li li ul, ul.toc li li li ul li {margin-left: 0; display: inline}
+	*/
 
 	/* Section numbers in a column of their own */
-	.toc .secno {
+	ul.toc {
+		margin-left: 5em
+	}
+	ul.toc span.secno {
 		float: left;
-		width: 4rem;
-		white-space: nowrap;
+		width: 4em;
+		margin-left: -5em;
 	}
-	.toc > li li li li .secno {
-		font-size: 85%;
+	ul.toc ul ul span.secno {
+		margin-left: -7em;
 	}
-	.toc > li li li li li .secno {
-		font-size: 100%;
-	}
-
-	:not(li) > .toc              { margin-left:  5rem; }
-	.toc .secno                  { margin-left: -5rem; }
-	.toc > li li li .secno       { margin-left: -7rem; }
-	.toc > li li li li .secno    { margin-left: -9rem; }
-	.toc > li li li li li .secno { margin-left: -11rem; }
-
-	/* Tighten up indentation in narrow ToCs */
-	@media (max-width: 30em) {
-		:not(li) > .toc              { margin-left:  4rem; }
-		.toc .secno                  { margin-left: -4rem; }
-		.toc > li li li              { margin-left:  1rem; }
-		.toc > li li li .secno       { margin-left: -5rem; }
-		.toc > li li li li .secno    { margin-left: -6rem; }
-		.toc > li li li li li .secno { margin-left: -7rem; }
-	}
-	@media screen and (min-width: 78em) {
-		body:not(.toc-inline) :not(li) > .toc              { margin-left:  4rem; }
-		body:not(.toc-inline) .toc .secno                  { margin-left: -4rem; }
-		body:not(.toc-inline) .toc > li li li              { margin-left:  1rem; }
-		body:not(.toc-inline) .toc > li li li .secno       { margin-left: -5rem; }
-		body:not(.toc-inline) .toc > li li li li .secno    { margin-left: -6rem; }
-		body:not(.toc-inline) .toc > li li li li li .secno { margin-left: -7rem; }
-	}
-	body.toc-sidebar #toc :not(li) > .toc              { margin-left:  4rem; }
-	body.toc-sidebar #toc .toc .secno                  { margin-left: -4rem; }
-	body.toc-sidebar #toc .toc > li li li              { margin-left:  1rem; }
-	body.toc-sidebar #toc .toc > li li li .secno       { margin-left: -5rem; }
-	body.toc-sidebar #toc .toc > li li li li .secno    { margin-left: -6rem; }
-	body.toc-sidebar #toc .toc > li li li li li .secno { margin-left: -7rem; }
-
-	.toc li {
+	/*ul.toc span.secno {text-align: right}*/
+	ul.toc li {
 		clear: both;
 	}
+	/* If we had 'tab', floats would not be needed here:
+		 ul.toc span.secno {tab: 5em right; margin-right: 1em}
+		 ul.toc li {text-indent: 5em hanging}
+	 The second line in case items wrap
+	*/
 
+/** At-risk List **************************************************************/
+	/* Style for At Risk features (intended as editorial aid, not intended for publishing) */
+
+	.atrisk::before {
+	 float: right;
+	 margin-top: -0.25em;
+	 padding: 0.5em 1em 0.5em 0;
+	 text-indent: -0.9em;
+	 border: 1px solid;
+	 content: '\25C0    Not yet widely implemented';
+	 white-space: pre;
+	 font-size: small;
+	 background-color: white;
+	 color: gray;
+	 text-align: center;
+	}
+
+	.toc .atrisk::before { content:none }
 
 /** Index *********************************************************************/
 
 	/* Index Lists: Layout */
-	ul.index       { margin-left: 0; columns: 15em; text-indent: 1em hanging; }
-	ul.index li    { margin-left: 0; list-style: none; break-inside: avoid; }
-	ul.index li li { margin-left: 1em }
-	ul.index dl    { margin-top: 0; }
-	ul.index dt    { margin: .2em 0 .2em 20px;}
-	ul.index dd    { margin: .2em 0 .2em 40px;}
+	ul.indexlist       { margin-left: 0; columns: 15em; -webkit-columns: 15em; text-indent: 1em hanging; }
+	ul.indexlist li    { margin-left: 0; list-style: none; break-inside: avoid; word-break: break-word; }
+	ul.indexlist li li { margin-left: 1em }
+	ul.indexlist dl    { margin-top: 0; }
+	ul.indexlist dt    { margin: .2em 0 .2em 20px;}
+	ul.indexlist dd    { margin: .2em 0 .2em 40px;}
 	/* Index Lists: Typography */
-	ul.index ul,
-	ul.index dl { font-size: smaller; }
-	@media not print {
-		ul.index li span {
-			white-space: nowrap;
-			color: transparent; }
-		ul.index li a:hover + span,
-		ul.index li a:focus + span {
-			color: #707070;
-		}
+	ul.indexlist ul,
+	ul.indexlist dl { font-size: smaller; }
+	ul.indexlist li span {
+		white-space: nowrap;
+		position: absolute;
+		color: transparent; }
+	ul.indexlist li a:hover + span,
+	ul.indexlist li a:focus + span {
+		color: gray;
+	}
+	@media print {
+		ul.indexlist li span { color: gray; }
 	}
 
-/** Index Tables *****************************************************/
+/** Property Index Tables *****************************************************/
 	/* See also the data table styling section, which this effectively subclasses */
 
-	table.index {
+	table.proptable {
 		font-size: small;
 		border-collapse: collapse;
 		border-spacing: 0;
@@ -1077,19 +939,34 @@ Possible extra rowspan handling
 		margin: 1em 0;
 	}
 
-	table.index td,
-	table.index th {
+	table.proptable td,
+	table.proptable th {
 		padding: 0.4em;
+		text-align: center;
 	}
 
-	table.index tr:hover td:not([rowspan]),
-	table.index tr:hover th:not([rowspan]) {
-		background: #f7f8f9;
+	table.proptable tr:hover td {
+		background: #DEF;
 	}
-
+	.propdef th {
+		font-style: italic;
+		font-weight: normal;
+		text-align: left;
+		width: 3em;
+	}
 	/* The link in the first column in the property table (formerly a TD) */
-	table.index th:first-child a {
+	table.proptable td .property,
+	table.proptable th .property {
+		display: block;
+		text-align: left;
 		font-weight: bold;
+	}
+
+/** Extra-large Elements ******************************************************/
+
+	.big-element-wrapper {
+		max-width: 50em;
+		overflow-x: auto;
 	}
 
 /******************************************************************************/
@@ -1097,341 +974,101 @@ Possible extra rowspan handling
 /******************************************************************************/
 
 	@media print {
-		/* Pages have their own margins. */
 		html {
-			margin: 0;
-		}
-		/* Serif for print. */
+			margin: 0 !important; }
 		body {
-			font-family: serif;
-		}
+			font-family: serif; }
+		th, td {
+			font-family: inherit; }
+		a {
+			color: inherit !important; }
+
+		a:link, a:visited {
+			text-decoration: none !important }
+		a:link::after, a:visited::after { /* create a cross-ref "see..." */ }
+		.example::before {
+			font-family: serif !important; }
 	}
 	@page {
 		margin: 1.5cm 1.1cm;
 	}
 
-/******************************************************************************/
-/*                                    Legacy                                  */
-/******************************************************************************/
-
-	/* This rule is inherited from past style sheets. No idea what it's for. */
-	.hide { display: none }
-
-
-
-/******************************************************************************/
-/*                             Overflow Control                               */
-/******************************************************************************/
-
-	.figure .caption, .sidefigure .caption, figcaption {
-		/* in case figure is overlarge, limit caption to 50em */
-		max-width: 50rem;
-		margin-left: auto;
-		margin-right: auto;
-	}
-	.overlarge > table {
-		/* limit preferred width of table */
-		max-width: 50em;
-		margin-left: auto;
-		margin-right: auto;
-	}
-
-	@media (min-width: 55em) {
-		.overlarge {
-			margin-left: calc(13px + 26.5rem - 50vw);
-			margin-right: calc(13px + 26.5rem - 50vw);
-			max-width: none;
-		}
-	}
-	@media screen and (min-width: 78em) {
-		body:not(.toc-inline) .overlarge {
-			/* 30.5em body padding 50em content area */
-			margin-left: calc(40em - 50vw) !important;
-			margin-right: calc(40em - 50vw) !important;
-		}
-	}
-	@media screen and (min-width: 90em) {
-		body:not(.toc-inline) .overlarge {
-			/* 4em html margin 30.5em body padding 50em content area */
-			margin-left: 0 !important;
-			margin-right: calc(84.5em - 100vw) !important;
-		}
-	}
-
-	@media not print {
-		.overlarge {
-			overflow-x: auto;
-			/* See Lea Verou's explanation background-attachment:
-			 * http://lea.verou.me/2012/04/background-attachment-local/
-			 *
-			background: top left  / 4em 100% linear-gradient(to right,  #ffffff, rgba(255, 255, 255, 0)) local,
-			            top right / 4em 100% linear-gradient(to left, #ffffff, rgba(255, 255, 255, 0)) local,
-			            top left  / 1em 100% linear-gradient(to right,  #c3c3c5, rgba(195, 195, 197, 0)) scroll,
-			            top right / 1em 100% linear-gradient(to left, #c3c3c5, rgba(195, 195, 197, 0)) scroll,
-			            white;
-			background-repeat: no-repeat;
-			*/
-		}
-	}
 </style>
   <meta content="Bikeshed 1.0.0" name="generator">
-<style>/* style-md-lists */
-
-            /* This is a weird hack for me not yet following the commonmark spec
-               regarding paragraph and lists. */
-            [data-md] > :first-child {
-                margin-top: 0;
-            }
-            [data-md] > :last-child {
-                margin-bottom: 0;
-            }</style>
-<style>/* style-selflinks */
-
-            .heading, .issue, .note, .example, li, dt {
-                position: relative;
-            }
-            a.self-link {
-                position: absolute;
-                top: 0;
-                left: calc(-1 * (3.5rem - 26px));
-                width: calc(3.5rem - 26px);
-                height: 2em;
-                text-align: center;
-                border: none;
-                transition: opacity .2s;
-                opacity: .5;
-            }
-            a.self-link:hover {
-                opacity: 1;
-            }
-            .heading > a.self-link {
-                font-size: 83%;
-            }
-            li > a.self-link {
-                left: calc(-1 * (3.5rem - 26px) - 2em);
-            }
-            dfn > a.self-link {
-                top: auto;
-                left: auto;
-                opacity: 0;
-                width: 1.5em;
-                height: 1.5em;
-                background: gray;
-                color: white;
-                font-style: normal;
-                transition: opacity .2s, background-color .2s, color .2s;
-            }
-            dfn:hover > a.self-link {
-                opacity: 1;
-            }
-            dfn > a.self-link:hover {
-                color: black;
-            }
-
-            a.self-link::before            { content: "¶"; }
-            .heading > a.self-link::before { content: "§"; }
-            dfn > a.self-link::before      { content: "#"; }</style>
-<style>/* style-counters */
-
-            body {
-                counter-reset: example figure issue;
-            }
-            .issue {
-                counter-increment: issue;
-            }
-            .issue:not(.no-marker)::before {
-                content: "Issue " counter(issue);
-            }
-
-            .example {
-                counter-increment: example;
-            }
-            .example:not(.no-marker)::before {
-                content: "Example " counter(example);
-            }
-            .invalid.example:not(.no-marker)::before,
-            .illegal.example:not(.no-marker)::before {
-                content: "Invalid Example" counter(example);
-            }
-
-            figcaption {
-                counter-increment: figure;
-            }
-            figcaption:not(.no-marker)::before {
-                content: "Figure " counter(figure) " ";
-            }</style>
-<style>/* style-autolinks */
-
-            .css.css, .property.property, .descriptor.descriptor {
-                color: #005a9c;
-                font-size: inherit;
-                font-family: inherit;
-            }
-            .css::before, .property::before, .descriptor::before {
-                content: "‘";
-            }
-            .css::after, .property::after, .descriptor::after {
-                content: "’";
-            }
-            .property, .descriptor {
-                /* Don't wrap property and descriptor names */
-                white-space: nowrap;
-            }
-            .type { /* CSS value <type> */
-                font-style: italic;
-            }
-            pre .property::before, pre .property::after {
-                content: "";
-            }
-            [data-link-type="property"]::before,
-            [data-link-type="propdesc"]::before,
-            [data-link-type="descriptor"]::before,
-            [data-link-type="value"]::before,
-            [data-link-type="function"]::before,
-            [data-link-type="at-rule"]::before,
-            [data-link-type="selector"]::before,
-            [data-link-type="maybe"]::before {
-                content: "‘";
-            }
-            [data-link-type="property"]::after,
-            [data-link-type="propdesc"]::after,
-            [data-link-type="descriptor"]::after,
-            [data-link-type="value"]::after,
-            [data-link-type="function"]::after,
-            [data-link-type="at-rule"]::after,
-            [data-link-type="selector"]::after,
-            [data-link-type="maybe"]::after {
-                content: "’";
-            }
-
-            [data-link-type].production::before,
-            [data-link-type].production::after,
-            .prod [data-link-type]::before,
-            .prod [data-link-type]::after {
-                content: "";
-            }
-
-            [data-link-type=element],
-            [data-link-type=element-attr] {
-                font-family: Menlo, Consolas, "DejaVu Sans Mono", monospace;
-                font-size: .9em;
-            }
-            [data-link-type=element]::before { content: "<" }
-            [data-link-type=element]::after  { content: ">" }
-
-            [data-link-type=biblio] {
-                white-space: pre;
-            }</style>
-<style>/* style-dfn-panel */
-
-        .dfn-panel {
-            position: absolute;
-            z-index: 35;
-            height: auto;
-            width: -webkit-fit-content;
-            width: fit-content;
-            max-width: 300px;
-            max-height: 500px;
-            overflow: auto;
-            padding: 0.5em 0.75em;
-            font: small Helvetica Neue, sans-serif, Droid Sans Fallback;
-            background: #DDDDDD;
-            color: black;
-            border: outset 0.2em;
-        }
-        .dfn-panel:not(.on) { display: none; }
-        .dfn-panel * { margin: 0; padding: 0; text-indent: 0; }
-        .dfn-panel > b { display: block; }
-        .dfn-panel a { color: black; }
-        .dfn-panel a:not(:hover) { text-decoration: none !important; border-bottom: none !important; }
-        .dfn-panel > b + b { margin-top: 0.25em; }
-        .dfn-panel ul { padding: 0; }
-        .dfn-panel li { list-style: inside; }
-        .dfn-panel.activated {
-            display: inline-block;
-            position: fixed;
-            left: .5em;
-            bottom: 2em;
-            margin: 0 auto;
-            max-width: calc(100vw - 1.5em - .4em - .5em);
-            max-height: 30vh;
-        }
-
-        .dfn-paneled { cursor: pointer; }
-        </style>
-<style>/* style-syntax-highlighting */
-pre.idl.highlight { color: #708090; }
-        .highlight:not(.idl) { background: hsl(24, 20%, 95%); }
+<style>.highlight .hll { background-color: #ffffcc }
+.highlight  { background: #ffffff; }
+.highlight .c { color: #708090 } /* Comment */
+.highlight .k { color: #990055 } /* Keyword */
+.highlight .l { color: #669900 } /* Literal */
+.highlight .n { color: #0077aa } /* Name */
+.highlight .o { color: #999999 } /* Operator */
+.highlight .p { color: #999999 } /* Punctuation */
+.highlight .cm { color: #708090 } /* Comment.Multiline */
+.highlight .cp { color: #708090 } /* Comment.Preproc */
+.highlight .c1 { color: #708090 } /* Comment.Single */
+.highlight .cs { color: #708090 } /* Comment.Special */
+.highlight .kc { color: #990055 } /* Keyword.Constant */
+.highlight .kd { color: #990055 } /* Keyword.Declaration */
+.highlight .kn { color: #990055 } /* Keyword.Namespace */
+.highlight .kp { color: #990055 } /* Keyword.Pseudo */
+.highlight .kr { color: #990055 } /* Keyword.Reserved */
+.highlight .kt { color: #990055 } /* Keyword.Type */
+.highlight .ld { color: #669900 } /* Literal.Date */
+.highlight .m { color: #990055 } /* Literal.Number */
+.highlight .s { color: #669900 } /* Literal.String */
+.highlight .na { color: #0077aa } /* Name.Attribute */
+.highlight .nc { color: #0077aa } /* Name.Class */
+.highlight .no { color: #0077aa } /* Name.Constant */
+.highlight .nd { color: #0077aa } /* Name.Decorator */
+.highlight .ni { color: #0077aa } /* Name.Entity */
+.highlight .ne { color: #0077aa } /* Name.Exception */
+.highlight .nf { color: #0077aa } /* Name.Function */
+.highlight .nl { color: #0077aa } /* Name.Label */
+.highlight .nn { color: #0077aa } /* Name.Namespace */
+.highlight .py { color: #0077aa } /* Name.Property */
+.highlight .nt { color: #0077aa } /* Name.Tag */
+.highlight .nv { color: #0077aa } /* Name.Variable */
+.highlight .ow { color: #999999 } /* Operator.Word */
+.highlight .mb { color: #990055 } /* Literal.Number.Bin */
+.highlight .mf { color: #990055 } /* Literal.Number.Float */
+.highlight .mh { color: #990055 } /* Literal.Number.Hex */
+.highlight .mi { color: #990055 } /* Literal.Number.Integer */
+.highlight .mo { color: #990055 } /* Literal.Number.Oct */
+.highlight .sb { color: #669900 } /* Literal.String.Backtick */
+.highlight .sc { color: #669900 } /* Literal.String.Char */
+.highlight .sd { color: #669900 } /* Literal.String.Doc */
+.highlight .s2 { color: #669900 } /* Literal.String.Double */
+.highlight .se { color: #669900 } /* Literal.String.Escape */
+.highlight .sh { color: #669900 } /* Literal.String.Heredoc */
+.highlight .si { color: #669900 } /* Literal.String.Interpol */
+.highlight .sx { color: #669900 } /* Literal.String.Other */
+.highlight .sr { color: #669900 } /* Literal.String.Regex */
+.highlight .s1 { color: #669900 } /* Literal.String.Single */
+.highlight .ss { color: #669900 } /* Literal.String.Symbol */
+.highlight .vc { color: #0077aa } /* Name.Variable.Class */
+.highlight .vg { color: #0077aa } /* Name.Variable.Global */
+.highlight .vi { color: #0077aa } /* Name.Variable.Instance */
+.highlight .il { color: #990055 } /* Literal.Number.Integer.Long */
+        .highlight { background: hsl(24, 20%, 95%); }
         code.highlight { padding: .1em; border-radius: .3em; }
         pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em 0; overflow: auto; border-radius: 0; }
-        .highlight .c { color: #708090 } /* Comment */
-        .highlight .k { color: #990055 } /* Keyword */
-        .highlight .l { color: #000000 } /* Literal */
-        .highlight .n { color: #0077aa } /* Name */
-        .highlight .o { color: #999999 } /* Operator */
-        .highlight .p { color: #999999 } /* Punctuation */
-        .highlight .cm { color: #708090 } /* Comment.Multiline */
-        .highlight .cp { color: #708090 } /* Comment.Preproc */
-        .highlight .c1 { color: #708090 } /* Comment.Single */
-        .highlight .cs { color: #708090 } /* Comment.Special */
-        .highlight .kc { color: #990055 } /* Keyword.Constant */
-        .highlight .kd { color: #990055 } /* Keyword.Declaration */
-        .highlight .kn { color: #990055 } /* Keyword.Namespace */
-        .highlight .kp { color: #990055 } /* Keyword.Pseudo */
-        .highlight .kr { color: #990055 } /* Keyword.Reserved */
-        .highlight .kt { color: #990055 } /* Keyword.Type */
-        .highlight .ld { color: #000000 } /* Literal.Date */
-        .highlight .m { color: #000000 } /* Literal.Number */
-        .highlight .s { color: #a67f59 } /* Literal.String */
-        .highlight .na { color: #0077aa } /* Name.Attribute */
-        .highlight .nc { color: #0077aa } /* Name.Class */
-        .highlight .no { color: #0077aa } /* Name.Constant */
-        .highlight .nd { color: #0077aa } /* Name.Decorator */
-        .highlight .ni { color: #0077aa } /* Name.Entity */
-        .highlight .ne { color: #0077aa } /* Name.Exception */
-        .highlight .nf { color: #0077aa } /* Name.Function */
-        .highlight .nl { color: #0077aa } /* Name.Label */
-        .highlight .nn { color: #0077aa } /* Name.Namespace */
-        .highlight .py { color: #0077aa } /* Name.Property */
-        .highlight .nt { color: #669900 } /* Name.Tag */
-        .highlight .nv { color: #222222 } /* Name.Variable */
-        .highlight .ow { color: #999999 } /* Operator.Word */
-        .highlight .mb { color: #000000 } /* Literal.Number.Bin */
-        .highlight .mf { color: #000000 } /* Literal.Number.Float */
-        .highlight .mh { color: #000000 } /* Literal.Number.Hex */
-        .highlight .mi { color: #000000 } /* Literal.Number.Integer */
-        .highlight .mo { color: #000000 } /* Literal.Number.Oct */
-        .highlight .sb { color: #a67f59 } /* Literal.String.Backtick */
-        .highlight .sc { color: #a67f59 } /* Literal.String.Char */
-        .highlight .sd { color: #a67f59 } /* Literal.String.Doc */
-        .highlight .s2 { color: #a67f59 } /* Literal.String.Double */
-        .highlight .se { color: #a67f59 } /* Literal.String.Escape */
-        .highlight .sh { color: #a67f59 } /* Literal.String.Heredoc */
-        .highlight .si { color: #a67f59 } /* Literal.String.Interpol */
-        .highlight .sx { color: #a67f59 } /* Literal.String.Other */
-        .highlight .sr { color: #a67f59 } /* Literal.String.Regex */
-        .highlight .s1 { color: #a67f59 } /* Literal.String.Single */
-        .highlight .ss { color: #a67f59 } /* Literal.String.Symbol */
-        .highlight .vc { color: #0077aa } /* Name.Variable.Class */
-        .highlight .vg { color: #0077aa } /* Name.Variable.Global */
-        .highlight .vi { color: #0077aa } /* Name.Variable.Instance */
-        .highlight .il { color: #000000 } /* Literal.Number.Integer.Long */
         </style>
+ </head>
  <body class="h-entry">
   <div class="head">
-   <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
-   <h1>Referrer Policy</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2016-09-29">29 September 2016</time></span></h2>
+   <p data-fill-with="logo"><a class="logo" href="http://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/Icons/w3c_home" width="72"> </a> </p>
+   <h1 class="p-name no-ref" id="title">Referrer Policy</h1>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2016-10-15">15 October 2016</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
      <dd><a class="u-url" href="https://w3c.github.io/webappsec-referrer-policy/">https://w3c.github.io/webappsec-referrer-policy/</a>
-     <dt>Latest published version:
+     <dt>Latest version:
      <dd><a href="http://www.w3.org/TR/referrer-policy/">http://www.w3.org/TR/referrer-policy/</a>
      <dt>Version History:
      <dd><a href="https://github.com/w3c/webappsec-referrer-policy/commits/master/index.src.html">https://github.com/w3c/webappsec-referrer-policy/commits/master/index.src.html</a>
      <dt>Feedback:
-     <dd><span><a href="mailto:public-webappsec@w3.org?subject=%5BREFERRER%5D%20YOUR%20TOPIC%20HERE">public-webappsec@w3.org</a> with subject line “<kbd>[REFERRER] <i data-lt="">… message topic …</i></kbd>” (<a href="https://lists.w3.org/Archives/Public/public-webappsec/" rel="discussion">archives</a>)</span>
+     <dd><span><a href="mailto:public-webappsec@w3.org?subject=%5BREFERRER%5D%20YOUR%20TOPIC%20HERE">public-webappsec@w3.org</a> with subject line “<kbd>[REFERRER] <i data-lt="">… message topic …</i></kbd>” (<a href="http://lists.w3.org/Archives/Public/public-webappsec/" rel="discussion">archives</a>)</span>
      <dt>Issue Tracking:
      <dd><a href="https://github.com/w3c/webappsec-referrer-policy/issues/">GitHub</a>
      <dt class="editor">Editors:
@@ -1440,7 +1077,7 @@ pre.idl.highlight { color: #708090; }
     </dl>
    </div>
    <div data-fill-with="warning"></div>
-   <p class="copyright" data-fill-with="copyright"><a href="https://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 2016 <a href="https://www.w3.org/"><abbr title="World Wide Web Consortium">W3C</abbr></a><sup>®</sup> (<a href="https://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>, <a href="https://www.ercim.eu/"><abbr title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>, <a href="https://www.keio.ac.jp/">Keio</a>, <a href="http://ev.buaa.edu.cn/">Beihang</a>). W3C <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>, <a href="https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and <a href="https://www.w3.org/Consortium/Legal/copyright-documents">document use</a> rules apply. </p>
+   <p class="copyright" data-fill-with="copyright"><a href="http://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 2016 <a href="http://www.w3.org/"><abbr title="World Wide Web Consortium">W3C</abbr></a><sup>®</sup> (<a href="http://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>, <a href="http://www.ercim.eu/"><abbr title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>, <a href="http://www.keio.ac.jp/">Keio</a>, <a href="http://ev.buaa.edu.cn/">Beihang</a>). W3C <a href="http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>, <a href="http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and <a href="http://www.w3.org/Consortium/Legal/copyright-documents">document use</a> rules apply. </p>
    <hr title="Separator for header">
   </div>
   <h2 class="no-num no-toc no-ref heading settled" id="abstract"><span class="content">Abstract</span></h2>
@@ -1454,36 +1091,36 @@ pre.idl.highlight { color: #708090; }
 	Its publication here does not imply endorsement of its contents by W3C.
 	Don’t cite this document other than as work in progress. </p>
    <p> <strong>Changes to this document may be tracked at <a href="https://github.com/w3c/webappsec">https://github.com/w3c/webappsec</a>.</strong> </p>
-   <p> The (<a href="https://lists.w3.org/Archives/Public/public-webappsec/">archived</a>) public mailing list <a href="mailto:public-webappsec@w3.org?Subject=%5BREFERRER%5D%20PUT%20SUBJECT%20HERE">public-webappsec@w3.org</a> (see <a href="https://www.w3.org/Mail/Request">instructions</a>)
+   <p> The (<a href="http://lists.w3.org/Archives/Public/public-webappsec/">archived</a>) public mailing list <a href="mailto:public-webappsec@w3.org?Subject=%5BREFERRER%5D%20PUT%20SUBJECT%20HERE">public-webappsec@w3.org</a> (see <a href="http://www.w3.org/Mail/Request">instructions</a>)
 	is preferred for discussion of this specification.
 	When sending e-mail,
 	please put the text “REFERRER” in the subject,
 	preferably like this:
 	“[REFERRER] <em>…summary of comment…</em>” </p>
-   <p> This document was produced by the <a href="https://www.w3.org/2011/webappsec/">Web Application Security Working Group</a>. </p>
+   <p> This document was produced by the <a href="http://www.w3.org/2011/webappsec/">Web Application Security Working Group</a>. </p>
    <p> This document was produced by a group operating under
-	the <a href="https://www.w3.org/Consortium/Patent-Policy-20040205/">5 February 2004 W3C Patent Policy</a>.
-	W3C maintains a <a href="https://www.w3.org/2004/01/pp-impl/49309/status" rel="disclosure">public list of any patent disclosures</a> made in connection with the deliverables of the group;
+	the <a href="http://www.w3.org/Consortium/Patent-Policy-20040205/">5 February 2004 W3C Patent Policy</a>.
+	W3C maintains a <a href="http://www.w3.org/2004/01/pp-impl/49309/status" rel="disclosure">public list of any patent disclosures</a> made in connection with the deliverables of the group;
 	that page also includes instructions for disclosing a patent.
-	An individual who has actual knowledge of a patent which the individual believes contains <a href="https://www.w3.org/Consortium/Patent-Policy-20040205/#def-essential">Essential Claim(s)</a> must disclose the information in accordance with <a href="https://www.w3.org/Consortium/Patent-Policy-20040205/#sec-Disclosure">section 6 of the W3C Patent Policy</a>. </p>
-   <p> This document is governed by the <a href="https://www.w3.org/2015/Process-20150901/" id="w3c_process_revision">1 September 2015 W3C Process Document</a>. </p>
+	An individual who has actual knowledge of a patent which the individual believes contains <a href="http://www.w3.org/Consortium/Patent-Policy-20040205/#def-essential">Essential Claim(s)</a> must disclose the information in accordance with <a href="http://www.w3.org/Consortium/Patent-Policy-20040205/#sec-Disclosure">section 6 of the W3C Patent Policy</a>. </p>
+   <p> This document is governed by the <a href="http://www.w3.org/2015/Process-20150901/" id="w3c_process_revision">1 September 2015 W3C Process Document</a>. </p>
    <p></p>
   </div>
   <div data-fill-with="at-risk"></div>
-  <nav data-fill-with="table-of-contents" id="toc">
-   <h2 class="no-num no-toc no-ref" id="contents">Table of Contents</h2>
-   <ol class="toc" role="directory">
+  <h2 class="no-num no-toc no-ref heading settled" id="contents"><span class="content">Table of Contents</span></h2>
+  <div data-fill-with="table-of-contents" role="navigation">
+   <ul class="toc" role="directory">
     <li>
      <a href="#intro"><span class="secno">1</span> <span class="content">Introduction</span></a>
-     <ol class="toc">
+     <ul class="toc">
       <li><a href="#intro-privacy"><span class="secno">1.1</span> <span class="content">Privacy</span></a>
       <li><a href="#intro-security"><span class="secno">1.2</span> <span class="content">Security</span></a>
       <li><a href="#intro-trackback"><span class="secno">1.3</span> <span class="content">Trackback</span></a>
-     </ol>
+     </ul>
     <li><a href="#terms"><span class="secno">2</span> <span class="content">Key Concepts and Terminology</span></a>
     <li>
      <a href="#referrer-policies"><span class="secno">3</span> <span class="content">Referrer Policies</span></a>
-     <ol class="toc">
+     <ul class="toc">
       <li><a href="#referrer-policy-no-referrer"><span class="secno">3.1</span> <span class="content">"<code>no-referrer</code>"</span></a>
       <li><a href="#referrer-policy-no-referrer-when-downgrade"><span class="secno">3.2</span> <span class="content">"<code>no-referrer-when-downgrade</code>"</span></a>
       <li><a href="#referrer-policy-same-origin"><span class="secno">3.3</span> <span class="content">"<code>same-origin</code>"</span></a>
@@ -1493,69 +1130,69 @@ pre.idl.highlight { color: #708090; }
       <li><a href="#referrer-policy-strict-origin-when-cross-origin"><span class="secno">3.7</span> <span class="content">"<code>strict-origin-when-cross-origin</code>"</span></a>
       <li><a href="#referrer-policy-unsafe-url"><span class="secno">3.8</span> <span class="content">"<code>unsafe-url</code>"</span></a>
       <li><a href="#referrer-policy-empty-string"><span class="secno">3.9</span> <span class="content">The empty string</span></a>
-     </ol>
+     </ul>
     <li>
      <a href="#referrer-policy-delivery"><span class="secno">4</span> <span class="content">Referrer Policy Delivery</span></a>
-     <ol class="toc">
+     <ul class="toc">
       <li>
        <a href="#referrer-policy-header"><span class="secno">4.1</span> <span class="content">Delivery via Referrer-Policy header</span></a>
-       <ol class="toc">
+       <ul class="toc">
         <li><a href="#referrer-usage"><span class="secno">4.1.1</span> <span class="content">Usage</span></a>
-       </ol>
+       </ul>
       <li><a href="#referrer-policy-delivery-meta"><span class="secno">4.2</span> <span class="content">Delivery via <code><span>meta</span></code></span></a>
       <li><a href="#referrer-policy-delivery-referrer-attribute"><span class="secno">4.3</span> <span class="content">Delivery
     via a <code>referrerpolicy</code> content attribute</span></a>
       <li><a href="#referrer-policy-delivery-nested"><span class="secno">4.4</span> <span class="content">Nested browsing contexts</span></a>
-     </ol>
+     </ul>
     <li><a href="#integration-with-fetch"><span class="secno">5</span> <span class="content">Integration with Fetch</span></a>
     <li><a href="#integration-with-html"><span class="secno">6</span> <span class="content">Integration with HTML</span></a>
     <li><a href="#integration-with-css"><span class="secno">7</span> <span class="content">Integration with CSS</span></a>
     <li>
      <a href="#algorithms"><span class="secno">8</span> <span class="content">Algorithms</span></a>
-     <ol class="toc">
+     <ul class="toc">
       <li><a href="#parse-referrer-policy-from-header"><span class="secno">8.1</span> <span class="content"> Parse a referrer policy from a <span><code>Referrer-Policy</code></span> header </span></a>
       <li><a href="#set-requests-referrer-policy-on-redirect"><span class="secno">8.2</span> <span class="content"> Set <var>request</var>’s referrer policy on redirect </span></a>
       <li><a href="#determine-requests-referrer"><span class="secno">8.3</span> <span class="content"> Determine <var>request</var>’s Referrer </span></a>
       <li><a href="#strip-url"><span class="secno">8.4</span> <span class="content"> Strip <var>url</var> for use as a referrer </span></a>
-     </ol>
+     </ul>
     <li>
      <a href="#privacy"><span class="secno">9</span> <span class="content">Privacy Considerations</span></a>
-     <ol class="toc">
+     <ul class="toc">
       <li><a href="#user-controls"><span class="secno">9.1</span> <span class="content">User Controls</span></a>
-     </ol>
+     </ul>
     <li>
      <a href="#security"><span class="secno">10</span> <span class="content">Security Considerations</span></a>
-     <ol class="toc">
+     <ul class="toc">
       <li><a href="#information-leakage"><span class="secno">10.1</span> <span class="content">Information Leakage</span></a>
       <li><a href="#downgrade"><span class="secno">10.2</span> <span class="content">Downgrade to less strict policies</span></a>
-     </ol>
+     </ul>
     <li>
      <a href="#authoring"><span class="secno">11</span> <span class="content">Authoring Considerations</span></a>
-     <ol class="toc">
+     <ul class="toc">
       <li><a href="#unknown-policy-values"><span class="secno">11.1</span> <span class="content">Unknown Policy Values</span></a>
-     </ol>
+     </ul>
     <li><a href="#acknowledgements"><span class="secno">12</span> <span class="content">Acknowledgements</span></a>
     <li>
      <a href="#conformance"><span class="secno"></span> <span class="content">Conformance</span></a>
-     <ol class="toc">
+     <ul class="toc">
       <li><a href="#conventions"><span class="secno"></span> <span class="content">Document conventions</span></a>
       <li><a href="#conformant-algorithms"><span class="secno"></span> <span class="content">Conformant Algorithms</span></a>
-     </ol>
+     </ul>
     <li>
      <a href="#index"><span class="secno"></span> <span class="content">Index</span></a>
-     <ol class="toc">
+     <ul class="toc">
       <li><a href="#index-defined-here"><span class="secno"></span> <span class="content">Terms defined by this specification</span></a>
       <li><a href="#index-defined-elsewhere"><span class="secno"></span> <span class="content">Terms defined by reference</span></a>
-     </ol>
+     </ul>
     <li>
      <a href="#references"><span class="secno"></span> <span class="content">References</span></a>
-     <ol class="toc">
+     <ul class="toc">
       <li><a href="#normative"><span class="secno"></span> <span class="content">Normative References</span></a>
       <li><a href="#informative"><span class="secno"></span> <span class="content">Informative References</span></a>
-     </ol>
+     </ul>
     <li><a href="#idl-index"><span class="secno"></span> <span class="content">IDL Index</span></a>
-   </ol>
-  </nav>
+   </ul>
+  </div>
   <main>
    <section>
     <h2 class="heading settled" data-level="1" id="intro"><span class="secno">1. </span><span class="content">Introduction</span><a class="self-link" href="#intro"></a></h2>
@@ -1590,53 +1227,53 @@ pre.idl.highlight { color: #708090; }
    <section>
     <h2 class="heading settled" data-level="2" id="terms"><span class="secno">2. </span><span class="content">Key Concepts and Terminology</span><a class="self-link" href="#terms"></a></h2>
     <dl>
-     <dt> <a data-link-type="dfn" href="#referrer-policy" id="ref-for-referrer-policy-1">referrer policy</a> 
+     <dt> <a data-link-type="dfn" href="#referrer-policy">referrer policy</a> 
      <dd>
-       A <a data-link-type="dfn" href="#referrer-policy" id="ref-for-referrer-policy-2">referrer policy</a> modifies the algorithm used to populate the <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc7231#section-5.5.2"><code>Referer</code></a> header when <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#fetching">fetching</a> subresources,
+       A <a data-link-type="dfn" href="#referrer-policy">referrer policy</a> modifies the algorithm used to populate the <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc7231#section-5.5.2"><code>Referer</code></a> header when <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#fetching">fetching</a> subresources,
       prefetching, or performing navigations. This document defines the various
-      behaviors for each <a data-link-type="dfn" href="#referrer-policy" id="ref-for-referrer-policy-3">referrer policy</a>. 
-      <p>Every <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">environment settings object</a> has an algorithm for obtaining a <a data-link-type="dfn" href="#referrer-policy" id="ref-for-referrer-policy-4">referrer policy</a>, which is used by default for all <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">requests</a> with that <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">environment settings object</a> as their <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client">request
+      behaviors for each <a data-link-type="dfn" href="#referrer-policy">referrer policy</a>. 
+      <p>Every <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">environment settings object</a> has an algorithm for obtaining a <a data-link-type="dfn" href="#referrer-policy">referrer policy</a>, which is used by default for all <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">requests</a> with that <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">environment settings object</a> as their <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client">request
       client</a>.</p>
-     <dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="same-origin-request">same-origin request</dfn>
+     <dt><dfn data-dfn-type="dfn" data-noexport="" id="same-origin-request">same-origin request<a class="self-link" href="#same-origin-request"></a></dfn>
      <dd> A <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#request">Request</a></code> <var>request</var> is a <strong>same-origin request</strong> if <var>request</var>’s <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#concept-request-origin">origin</a></code> and the <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc6454#section-3.2">origin</a> of <var>request</var>’s <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#concept-request-url">url</a></code> are <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc6454#section-5"><code>the same</code></a>. 
-     <dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="cross-origin-request">cross-origin request</dfn>
-     <dd> A <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#request">Request</a></code> is a <strong>cross-origin request</strong> if it is <em>not</em> <a data-link-type="dfn" href="#same-origin-request" id="ref-for-same-origin-request-1">same-origin</a>. 
+     <dt><dfn data-dfn-type="dfn" data-noexport="" id="cross-origin-request">cross-origin request<a class="self-link" href="#cross-origin-request"></a></dfn>
+     <dd> A <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#request">Request</a></code> is a <strong>cross-origin request</strong> if it is <em>not</em> <a data-link-type="dfn" href="#same-origin-request">same-origin</a>. 
     </dl>
    </section>
    <section>
     <h2 class="heading settled" data-level="3" id="referrer-policies"><span class="secno">3. </span><span class="content">Referrer Policies</span><span id="referrer-policy-states"></span><a class="self-link" href="#referrer-policies"></a></h2>
-    <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="referrer-policy" title="concept-referrer-policy">referrer policy</dfn> is the empty string, "<code>no-referrer</code>",
+    <p>A <dfn data-dfn-type="dfn" data-export="" id="referrer-policy" title="concept-referrer-policy">referrer policy<a class="self-link" href="#referrer-policy"></a></dfn> is the empty string, "<code>no-referrer</code>",
   "<code>no-referrer-when-downgrade</code>", "<code>same-origin</code>",
   "<code>origin</code>", "<code>strict-origin</code>",
   "<code>origin-when-cross-origin</code>",
   "<code>strict-origin-when-cross-origin</code>", or
   "<code>unsafe-url</code>".</p>
-<pre class="idl highlight def"><span class="kt">enum</span> <dfn class="nv idl-code" data-dfn-type="enum" data-export="" id="enumdef-referrerpolicy">ReferrerPolicy<a class="self-link" href="#enumdef-referrerpolicy"></a></dfn> {
-  <dfn class="s idl-code" data-dfn-for="ReferrerPolicy" data-dfn-type="enum-value" data-export="" data-lt="&quot;&quot;|" id="dom-referrerpolicy">""<a class="self-link" href="#dom-referrerpolicy"></a></dfn>,
-  <dfn class="s idl-code" data-dfn-for="ReferrerPolicy" data-dfn-type="enum-value" data-export="" data-lt="&quot;no-referrer&quot;|no-referrer" id="dom-referrerpolicy-no-referrer">"no-referrer"<a class="self-link" href="#dom-referrerpolicy-no-referrer"></a></dfn>,
-  <dfn class="s idl-code" data-dfn-for="ReferrerPolicy" data-dfn-type="enum-value" data-export="" data-lt="&quot;no-referrer-when-downgrade&quot;|no-referrer-when-downgrade" id="dom-referrerpolicy-no-referrer-when-downgrade">"no-referrer-when-downgrade"<a class="self-link" href="#dom-referrerpolicy-no-referrer-when-downgrade"></a></dfn>,
-  <dfn class="s idl-code" data-dfn-for="ReferrerPolicy" data-dfn-type="enum-value" data-export="" data-lt="&quot;same-origin&quot;|same-origin" id="dom-referrerpolicy-same-origin">"same-origin"<a class="self-link" href="#dom-referrerpolicy-same-origin"></a></dfn>,
-  <dfn class="s idl-code" data-dfn-for="ReferrerPolicy" data-dfn-type="enum-value" data-export="" data-lt="&quot;origin&quot;|origin" id="dom-referrerpolicy-origin">"origin"<a class="self-link" href="#dom-referrerpolicy-origin"></a></dfn>,
-  <dfn class="s idl-code" data-dfn-for="ReferrerPolicy" data-dfn-type="enum-value" data-export="" data-lt="&quot;strict-origin&quot;|strict-origin" id="dom-referrerpolicy-strict-origin">"strict-origin"<a class="self-link" href="#dom-referrerpolicy-strict-origin"></a></dfn>,
-  <dfn class="s idl-code" data-dfn-for="ReferrerPolicy" data-dfn-type="enum-value" data-export="" data-lt="&quot;origin-when-cross-origin&quot;|origin-when-cross-origin" id="dom-referrerpolicy-origin-when-cross-origin">"origin-when-cross-origin"<a class="self-link" href="#dom-referrerpolicy-origin-when-cross-origin"></a></dfn>,
-  <dfn class="s idl-code" data-dfn-for="ReferrerPolicy" data-dfn-type="enum-value" data-export="" data-lt="&quot;strict-origin-when-cross-origin&quot;|strict-origin-when-cross-origin" id="dom-referrerpolicy-strict-origin-when-cross-origin">"strict-origin-when-cross-origin"<a class="self-link" href="#dom-referrerpolicy-strict-origin-when-cross-origin"></a></dfn>,
-  <dfn class="s idl-code" data-dfn-for="ReferrerPolicy" data-dfn-type="enum-value" data-export="" data-lt="&quot;unsafe-url&quot;|unsafe-url" id="dom-referrerpolicy-unsafe-url">"unsafe-url"<a class="self-link" href="#dom-referrerpolicy-unsafe-url"></a></dfn>
+<pre class="idl">enum <dfn class="idl-code" data-dfn-type="enum" data-export="" id="enumdef-referrerpolicy">ReferrerPolicy<a class="self-link" href="#enumdef-referrerpolicy"></a></dfn> {
+  "",
+  "no-referrer",
+  "no-referrer-when-downgrade",
+  "same-origin",
+  "origin",
+  "strict-origin",
+  "origin-when-cross-origin",
+  "strict-origin-when-cross-origin",
+  "unsafe-url"
 };
 </pre>
-    <p>Each possible <a data-link-type="dfn" href="#referrer-policy" id="ref-for-referrer-policy-5">referrer policy</a> is explained below. A detailed
+    <p>Each possible <a data-link-type="dfn" href="#referrer-policy">referrer policy</a> is explained below. A detailed
   algorithm for evaluating their effect is given in the <a href="#integration-with-fetch">§5 Integration with Fetch</a> and <a href="#algorithms">§8 Algorithms</a> sections.</p>
     <p class="note" role="note">Note: The referrer policy for an <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">environment settings object</a> provides a
   default baseline policy for requests when that <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">environment settings
   object</a> is used as a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client">request client</a>. This policy may be tightened
   for specific requests via mechanisms like the <code><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/semantics.html#link-type-noreferrer">noreferrer</a></code> link type.</p>
-    <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-export="" data-level="3.1" data-lt="&quot;no-referrer&quot;" id="referrer-policy-no-referrer"><span class="secno">3.1. </span><span class="content">"<code>no-referrer</code>"</span><span id="referrer-policy-state-no-referrer"></span></h3>
-    <p>The simplest policy is <a data-link-type="dfn" href="#referrer-policy-no-referrer" id="ref-for-referrer-policy-no-referrer-1">"<code>no-referrer</code>"</a>, which specifies
+    <h3 class="heading settled" data-dfn-type="dfn" data-export="" data-level="3.1" data-lt="&quot;no-referrer&quot;" id="referrer-policy-no-referrer"><span class="secno">3.1. </span><span class="content">"<code>no-referrer</code>"</span><span id="referrer-policy-state-no-referrer"></span><a class="self-link" href="#referrer-policy-no-referrer"></a></h3>
+    <p>The simplest policy is <a data-link-type="dfn" href="#referrer-policy-no-referrer">"<code>no-referrer</code>"</a>, which specifies
   that no referrer information is to be sent along with requests made from a
   particular <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client">request client</a> to any <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc6454#section-3.2">origin</a>. The header will be
   omitted entirely.</p>
-    <div class="example" id="example-df4273ed"><a class="self-link" href="#example-df4273ed"></a> If a document at <code>https://example.com/page.html</code> sets a policy of <a data-link-type="dfn" href="#referrer-policy-no-referrer" id="ref-for-referrer-policy-no-referrer-2">"<code>no-referrer</code>"</a>, then navigations to <code>https://example.com/</code> (or any other URL) would send no <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc7231#section-5.5.2"><code>Referer</code></a> header. </div>
-    <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-export="" data-level="3.2" data-lt="&quot;no-referrer-when-downgrade&quot;" id="referrer-policy-no-referrer-when-downgrade"><span class="secno">3.2. </span><span class="content">"<code>no-referrer-when-downgrade</code>"</span><span id="referrer-policy-state-no-referrer-when-downgrade"></span></h3>
-    <p>The <a data-link-type="dfn" href="#referrer-policy-no-referrer-when-downgrade" id="ref-for-referrer-policy-no-referrer-when-downgrade-1">"<code>no-referrer-when-downgrade</code>"</a> policy sends a full URL
+    <div class="example" id="example-df4273ed"><a class="self-link" href="#example-df4273ed"></a> If a document at <code>https://example.com/page.html</code> sets a policy of <a data-link-type="dfn" href="#referrer-policy-no-referrer">"<code>no-referrer</code>"</a>, then navigations to <code>https://example.com/</code> (or any other URL) would send no <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc7231#section-5.5.2"><code>Referer</code></a> header. </div>
+    <h3 class="heading settled" data-dfn-type="dfn" data-export="" data-level="3.2" data-lt="&quot;no-referrer-when-downgrade&quot;" id="referrer-policy-no-referrer-when-downgrade"><span class="secno">3.2. </span><span class="content">"<code>no-referrer-when-downgrade</code>"</span><span id="referrer-policy-state-no-referrer-when-downgrade"></span><a class="self-link" href="#referrer-policy-no-referrer-when-downgrade"></a></h3>
+    <p>The <a data-link-type="dfn" href="#referrer-policy-no-referrer-when-downgrade">"<code>no-referrer-when-downgrade</code>"</a> policy sends a full URL
   along with requests from a <a data-link-type="dfn" href="http://www.w3.org/TR/2010/REC-wsc-ui-20100812/#typesoftls">TLS-protected</a> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">environment settings
   object</a> to a <a data-link-type="dfn" href="https://w3c.github.io/webappsec/specs/mixedcontent/#a-priori-authenticated-url"><em>a priori</em> authenticated URL</a>, and requests from <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client">request clients</a> which are <em>not</em> <a data-link-type="dfn" href="http://www.w3.org/TR/2010/REC-wsc-ui-20100812/#typesoftls">TLS-protected</a> to any <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc6454#section-3.2">origin</a>.</p>
     <p>Requests from <a data-link-type="dfn" href="http://www.w3.org/TR/2010/REC-wsc-ui-20100812/#typesoftls">TLS-protected</a> <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client">request clients</a> to non-<a data-link-type="dfn" href="https://w3c.github.io/webappsec/specs/mixedcontent/#a-priori-authenticated-url"><em>a
@@ -1644,36 +1281,36 @@ pre.idl.highlight { color: #708090; }
   referrer information. A <code><a data-link-type="dfn" href="https://tools.ietf.org/html/rfc7231#section-5.5.2">Referer</a></code> HTTP header will not be
   sent.</p>
     <div class="example" id="example-0323e875">
-     <a class="self-link" href="#example-0323e875"></a> If a document at <code>https://example.com/page.html</code> sets a policy of <a data-link-type="dfn" href="#referrer-policy-no-referrer-when-downgrade" id="ref-for-referrer-policy-no-referrer-when-downgrade-2">"<code>no-referrer-when-downgrade</code>"</a>, then navigations to <code>https://not.example.com/</code> would send a <code><a data-link-type="dfn" href="https://tools.ietf.org/html/rfc7231#section-5.5.2">Referer</a></code> HTTP header with a value of <code>https://example.com/page.html</code>, as neither resource’s origin is an
+     <a class="self-link" href="#example-0323e875"></a> If a document at <code>https://example.com/page.html</code> sets a policy of <a data-link-type="dfn" href="#referrer-policy-no-referrer-when-downgrade">"<code>no-referrer-when-downgrade</code>"</a>, then navigations to <code>https://not.example.com/</code> would send a <code><a data-link-type="dfn" href="https://tools.ietf.org/html/rfc7231#section-5.5.2">Referer</a></code> HTTP header with a value of <code>https://example.com/page.html</code>, as neither resource’s origin is an
     non-<a data-link-type="dfn" href="https://w3c.github.io/webappsec/specs/mixedcontent/#a-priori-authenticated-url"><em>a priori</em> authenticated URL</a>. 
      <p>Navigations from that same page to <code><strong>http</strong>://not.example.com/</code> would send no <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc7231#section-5.5.2"><code>Referer</code></a> header.</p>
     </div>
     <p>This is a user agent’s default behavior, if no policy is otherwise specified.</p>
-    <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-export="" data-level="3.3" data-lt="&quot;same-origin&quot;" id="referrer-policy-same-origin"><span class="secno">3.3. </span><span class="content">"<code>same-origin</code>"</span></h3>
-    <p>The <a data-link-type="dfn" href="#referrer-policy-same-origin" id="ref-for-referrer-policy-same-origin-1">"<code>same-origin</code>"</a> policy specifies that a
+    <h3 class="heading settled" data-dfn-type="dfn" data-export="" data-level="3.3" data-lt="&quot;same-origin&quot;" id="referrer-policy-same-origin"><span class="secno">3.3. </span><span class="content">"<code>same-origin</code>"</span><a class="self-link" href="#referrer-policy-same-origin"></a></h3>
+    <p>The <a data-link-type="dfn" href="#referrer-policy-same-origin">"<code>same-origin</code>"</a> policy specifies that a
   full URL, <a href="#strip-url">stripped for use as a referrer</a>, is sent as
-  referrer information when making <a data-link-type="dfn" href="#same-origin-request" id="ref-for-same-origin-request-2">same-origin requests</a> from a particular <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client">request client</a>.</p>
-    <p><a data-link-type="dfn" href="#cross-origin-request" id="ref-for-cross-origin-request-1">Cross-origin requests</a>, on the other hand, will contain no
+  referrer information when making <a data-link-type="dfn" href="#same-origin-request">same-origin requests</a> from a particular <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client">request client</a>.</p>
+    <p><a data-link-type="dfn" href="#cross-origin-request">Cross-origin requests</a>, on the other hand, will contain no
   referrer information. A <code><a data-link-type="dfn" href="https://tools.ietf.org/html/rfc7231#section-5.5.2">Referer</a></code> HTTP header will not be
   sent.</p>
     <div class="example" id="example-af6c3f8c">
-     <a class="self-link" href="#example-af6c3f8c"></a> If a document at <code>https://example.com/page.html</code> sets a policy of <a data-link-type="dfn" href="#referrer-policy-same-origin" id="ref-for-referrer-policy-same-origin-2">"<code>same-origin</code>"</a>, then navigations to <code>https://example.com/not-page.html</code> would send a <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc7231#section-5.5.2"><code>Referer</code></a> header with a value of <code>https://example.com/page.html</code>. 
+     <a class="self-link" href="#example-af6c3f8c"></a> If a document at <code>https://example.com/page.html</code> sets a policy of <a data-link-type="dfn" href="#referrer-policy-same-origin">"<code>same-origin</code>"</a>, then navigations to <code>https://example.com/not-page.html</code> would send a <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc7231#section-5.5.2"><code>Referer</code></a> header with a value of <code>https://example.com/page.html</code>. 
      <p>Navigations from that same page to <code>https://<strong>not</strong>.example.com/</code> would send no <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc7231#section-5.5.2"><code>Referer</code></a> header.</p>
     </div>
-    <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-export="" data-level="3.4" data-lt="&quot;origin&quot;" id="referrer-policy-origin"><span class="secno">3.4. </span><span class="content">"<code>origin</code>"</span><span id="referrer-policy-state-origin"></span></h3>
-    <p>The <a data-link-type="dfn" href="#referrer-policy-origin" id="ref-for-referrer-policy-origin-1">"<code>origin</code>"</a> policy specifies that only the <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc6454#section-6.2">ASCII serialization</a> of the <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc6454#section-3.2">origin</a> of the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client">request client</a> is sent as referrer information
-  when making both <a data-link-type="dfn" href="#same-origin-request" id="ref-for-same-origin-request-3">same-origin requests</a> and <a data-link-type="dfn" href="#cross-origin-request" id="ref-for-cross-origin-request-2">cross-origin requests</a> from a particular <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client">request client</a>.</p>
+    <h3 class="heading settled" data-dfn-type="dfn" data-export="" data-level="3.4" data-lt="&quot;origin&quot;" id="referrer-policy-origin"><span class="secno">3.4. </span><span class="content">"<code>origin</code>"</span><span id="referrer-policy-state-origin"></span><a class="self-link" href="#referrer-policy-origin"></a></h3>
+    <p>The <a data-link-type="dfn" href="#referrer-policy-origin">"<code>origin</code>"</a> policy specifies that only the <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc6454#section-6.2">ASCII serialization</a> of the <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc6454#section-3.2">origin</a> of the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client">request client</a> is sent as referrer information
+  when making both <a data-link-type="dfn" href="#same-origin-request">same-origin requests</a> and <a data-link-type="dfn" href="#cross-origin-request">cross-origin requests</a> from a particular <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client">request client</a>.</p>
     <p class="note" role="note">Note: The serialization of an origin looks like <code>https://example.com</code>. To ensure that a valid URL is sent in the
   `<code>Referer</code>` header, user agents will append a U+002F SOLIDUS
   ("<code>/</code>") character to the origin (e.g. <code>https://example.com/</code>).</p>
-    <p class="note" role="note">Note: The <a data-link-type="dfn" href="#referrer-policy-origin" id="ref-for-referrer-policy-origin-2">"<code>origin</code>"</a> policy causes the origin of HTTPS
+    <p class="note" role="note">Note: The <a data-link-type="dfn" href="#referrer-policy-origin">"<code>origin</code>"</a> policy causes the origin of HTTPS
   referrers to be sent over the network as part of unencrypted HTTP requests.
-  The <a data-link-type="dfn" href="#referrer-policy-strict-origin" id="ref-for-referrer-policy-strict-origin-1">"<code>strict-origin</code>"</a> policy addresses this concern.</p>
-    <div class="example" id="example-b2aaf663"><a class="self-link" href="#example-b2aaf663"></a> If a document at <code>https://example.com/page.html</code> sets a policy of <a data-link-type="dfn" href="#referrer-policy-origin" id="ref-for-referrer-policy-origin-3">"<code>origin</code>"</a>, then navigations to any <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc6454#section-3.2">origin</a> would send a <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc7231#section-5.5.2"><code>Referer</code></a> header with a value
+  The <a data-link-type="dfn" href="#referrer-policy-strict-origin">"<code>strict-origin</code>"</a> policy addresses this concern.</p>
+    <div class="example" id="example-b2aaf663"><a class="self-link" href="#example-b2aaf663"></a> If a document at <code>https://example.com/page.html</code> sets a policy of <a data-link-type="dfn" href="#referrer-policy-origin">"<code>origin</code>"</a>, then navigations to any <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc6454#section-3.2">origin</a> would send a <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc7231#section-5.5.2"><code>Referer</code></a> header with a value
     of <code>https://example.com/</code>, even to URLs that are not <a data-link-type="dfn" href="https://w3c.github.io/webappsec/specs/mixedcontent/#a-priori-authenticated-url"><em>a
     priori</em> authenticated URLs</a>. </div>
-    <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-export="" data-level="3.5" data-lt="&quot;strict-origin&quot;" id="referrer-policy-strict-origin"><span class="secno">3.5. </span><span class="content">"<code>strict-origin</code>"</span></h3>
-    <p>The <a data-link-type="dfn" href="#referrer-policy-strict-origin" id="ref-for-referrer-policy-strict-origin-2">"<code>strict-origin</code>"</a> policy sends the <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc6454#section-6.2">ASCII serialization</a> of the <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc6454#section-3.2">origin</a> of the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client">request client</a> when making requests:</p>
+    <h3 class="heading settled" data-dfn-type="dfn" data-export="" data-level="3.5" data-lt="&quot;strict-origin&quot;" id="referrer-policy-strict-origin"><span class="secno">3.5. </span><span class="content">"<code>strict-origin</code>"</span><a class="self-link" href="#referrer-policy-strict-origin"></a></h3>
+    <p>The <a data-link-type="dfn" href="#referrer-policy-strict-origin">"<code>strict-origin</code>"</a> policy sends the <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc6454#section-6.2">ASCII serialization</a> of the <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc6454#section-3.2">origin</a> of the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client">request client</a> when making requests:</p>
     <ul>
      <li>from a <a data-link-type="dfn" href="http://www.w3.org/TR/2010/REC-wsc-ui-20100812/#typesoftls">TLS-protected</a> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">environment settings object</a> to a <a data-link-type="dfn" href="https://w3c.github.io/webappsec/specs/mixedcontent/#a-priori-authenticated-url"><em>a priori</em> authenticated URL</a>, and
      <li>from <em>non-</em><a data-link-type="dfn" href="http://www.w3.org/TR/2010/REC-wsc-ui-20100812/#typesoftls">TLS-protected</a> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">environment settings objects</a> to
@@ -1684,31 +1321,31 @@ pre.idl.highlight { color: #708090; }
   referrer information. A <code><a data-link-type="dfn" href="https://tools.ietf.org/html/rfc7231#section-5.5.2">Referer</a></code> HTTP header will not be
   sent.</p>
     <div class="example" id="example-e6df45e4">
-     <a class="self-link" href="#example-e6df45e4"></a> If a document at <code>https://example.com/page.html</code> sets a policy of <a data-link-type="dfn" href="#referrer-policy-strict-origin" id="ref-for-referrer-policy-strict-origin-3">"<code>strict-origin</code>"</a>, then navigations to <code>https://<strong>not</strong>.example.com</code> would send a <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc7231#section-5.5.2"><code>Referer</code></a> header with a value of <code>https://example.com/</code>. 
+     <a class="self-link" href="#example-e6df45e4"></a> If a document at <code>https://example.com/page.html</code> sets a policy of <a data-link-type="dfn" href="#referrer-policy-strict-origin">"<code>strict-origin</code>"</a>, then navigations to <code>https://<strong>not</strong>.example.com</code> would send a <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc7231#section-5.5.2"><code>Referer</code></a> header with a value of <code>https://example.com/</code>. 
      <p>Navigations from that same page to <code><strong>http://</strong>not.example.com</code> would send no <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc7231#section-5.5.2"><code>Referer</code></a> header.</p>
     </div>
-    <div class="example" id="example-e2f29a9f"><a class="self-link" href="#example-e2f29a9f"></a> If a document at <code>http://example.com/page.html</code> sets a policy of <a data-link-type="dfn" href="#referrer-policy-strict-origin" id="ref-for-referrer-policy-strict-origin-4">"<code>strict-origin</code>"</a>, then navigations to <code>http://<strong>not</strong>.example.com</code> or <code><strong>https</strong>://example.com</code> would send a <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc7231#section-5.5.2"><code>Referer</code></a> header with a value of <code>http://example.com/</code>. </div>
-    <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-export="" data-level="3.6" data-lt="&quot;origin-when-cross-origin&quot;" id="referrer-policy-origin-when-cross-origin"><span class="secno">3.6. </span><span class="content">"<code>origin-when-cross-origin</code>"</span><span id="referrer-policy-state-origin-when-cross-origin"></span></h3>
-    <p>The <a data-link-type="dfn" href="#referrer-policy-origin-when-cross-origin" id="ref-for-referrer-policy-origin-when-cross-origin-1">"<code>origin-when-cross-origin</code>"</a> policy specifies that a
+    <div class="example" id="example-e2f29a9f"><a class="self-link" href="#example-e2f29a9f"></a> If a document at <code>http://example.com/page.html</code> sets a policy of <a data-link-type="dfn" href="#referrer-policy-strict-origin">"<code>strict-origin</code>"</a>, then navigations to <code>http://<strong>not</strong>.example.com</code> or <code><strong>https</strong>://example.com</code> would send a <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc7231#section-5.5.2"><code>Referer</code></a> header with a value of <code>http://example.com/</code>. </div>
+    <h3 class="heading settled" data-dfn-type="dfn" data-export="" data-level="3.6" data-lt="&quot;origin-when-cross-origin&quot;" id="referrer-policy-origin-when-cross-origin"><span class="secno">3.6. </span><span class="content">"<code>origin-when-cross-origin</code>"</span><span id="referrer-policy-state-origin-when-cross-origin"></span><a class="self-link" href="#referrer-policy-origin-when-cross-origin"></a></h3>
+    <p>The <a data-link-type="dfn" href="#referrer-policy-origin-when-cross-origin">"<code>origin-when-cross-origin</code>"</a> policy specifies that a
   full URL, <a href="#strip-url">stripped for use as a referrer</a>, is sent as
-  referrer information when making <a data-link-type="dfn" href="#same-origin-request" id="ref-for-same-origin-request-4">same-origin requests</a> from a particular <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client">request client</a>, and only the <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc6454#section-6.2">ASCII serialization</a> of the <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc6454#section-3.2">origin</a> of the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client">request client</a> is sent as referrer information
-  when making <a data-link-type="dfn" href="#cross-origin-request" id="ref-for-cross-origin-request-3">cross-origin requests</a> from a particular <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client">request
+  referrer information when making <a data-link-type="dfn" href="#same-origin-request">same-origin requests</a> from a particular <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client">request client</a>, and only the <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc6454#section-6.2">ASCII serialization</a> of the <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc6454#section-3.2">origin</a> of the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client">request client</a> is sent as referrer information
+  when making <a data-link-type="dfn" href="#cross-origin-request">cross-origin requests</a> from a particular <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client">request
   client</a>.</p>
-    <p class="note" role="note">Note: For the <a data-link-type="dfn" href="#referrer-policy-origin-when-cross-origin" id="ref-for-referrer-policy-origin-when-cross-origin-2">"<code>origin-when-cross-origin</code>"</a> policy, we also
-  consider protocol upgrades, e.g. requests from <code>http://example.com/</code> to <code>https://example.com/</code>, to be <a data-link-type="dfn" href="#cross-origin-request" id="ref-for-cross-origin-request-4">cross-origin requests</a>.</p>
-    <p class="note" role="note">Note: The <a data-link-type="dfn" href="#referrer-policy-origin-when-cross-origin" id="ref-for-referrer-policy-origin-when-cross-origin-3">"<code>origin-when-cross-origin</code>"</a> policy causes the
+    <p class="note" role="note">Note: For the <a data-link-type="dfn" href="#referrer-policy-origin-when-cross-origin">"<code>origin-when-cross-origin</code>"</a> policy, we also
+  consider protocol upgrades, e.g. requests from <code>http://example.com/</code> to <code>https://example.com/</code>, to be <a data-link-type="dfn" href="#cross-origin-request">cross-origin requests</a>.</p>
+    <p class="note" role="note">Note: The <a data-link-type="dfn" href="#referrer-policy-origin-when-cross-origin">"<code>origin-when-cross-origin</code>"</a> policy causes the
   origin of HTTPS referrers to be sent over the network as part of unencrypted
-  HTTP requests. The <a data-link-type="dfn" href="#referrer-policy-strict-origin-when-cross-origin" id="ref-for-referrer-policy-strict-origin-when-cross-origin-1">"<code>strict-origin-when-cross-origin</code>"</a> policy
+  HTTP requests. The <a data-link-type="dfn" href="#referrer-policy-strict-origin-when-cross-origin">"<code>strict-origin-when-cross-origin</code>"</a> policy
   addresses this concern.</p>
     <div class="example" id="example-5fad2266">
-     <a class="self-link" href="#example-5fad2266"></a> If a document at <code>https://example.com/page.html</code> sets a policy of <a data-link-type="dfn" href="#referrer-policy-origin-when-cross-origin" id="ref-for-referrer-policy-origin-when-cross-origin-4">"<code>origin-when-cross-origin</code>"</a>, then navigations to <code>https://example.com/not-page.html</code> would send a <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc7231#section-5.5.2"><code>Referer</code></a> header with a value of <code>https://example.com/page.html</code>. 
+     <a class="self-link" href="#example-5fad2266"></a> If a document at <code>https://example.com/page.html</code> sets a policy of <a data-link-type="dfn" href="#referrer-policy-origin-when-cross-origin">"<code>origin-when-cross-origin</code>"</a>, then navigations to <code>https://example.com/not-page.html</code> would send a <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc7231#section-5.5.2"><code>Referer</code></a> header with a value of <code>https://example.com/page.html</code>. 
      <p>Navigations from that same page to <code>https://not.example.com/</code> would send a <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc7231#section-5.5.2"><code>Referer</code></a> header with a value of <code>https://example.com/</code>, even to URLs that are not <a data-link-type="dfn" href="https://w3c.github.io/webappsec/specs/mixedcontent/#a-priori-authenticated-url"><em>a
     priori</em> authenticated URLs</a>.</p>
     </div>
-    <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-export="" data-level="3.7" data-lt="&quot;strict-origin-when-cross-origin&quot;" id="referrer-policy-strict-origin-when-cross-origin"><span class="secno">3.7. </span><span class="content">"<code>strict-origin-when-cross-origin</code>"</span></h3>
-    <p>The <a data-link-type="dfn" href="#referrer-policy-strict-origin-when-cross-origin" id="ref-for-referrer-policy-strict-origin-when-cross-origin-2">"<code>strict-origin-when-cross-origin</code>"</a> policy specifies that a
+    <h3 class="heading settled" data-dfn-type="dfn" data-export="" data-level="3.7" data-lt="&quot;strict-origin-when-cross-origin&quot;" id="referrer-policy-strict-origin-when-cross-origin"><span class="secno">3.7. </span><span class="content">"<code>strict-origin-when-cross-origin</code>"</span><a class="self-link" href="#referrer-policy-strict-origin-when-cross-origin"></a></h3>
+    <p>The <a data-link-type="dfn" href="#referrer-policy-strict-origin-when-cross-origin">"<code>strict-origin-when-cross-origin</code>"</a> policy specifies that a
   full URL, <a href="#strip-url">stripped for use as a referrer</a>, is sent as
-  referrer information when making <a data-link-type="dfn" href="#same-origin-request" id="ref-for-same-origin-request-5">same-origin requests</a> from a particular <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client">request client</a>, and only the <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc6454#section-6.2">ASCII serialization</a> of the <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc6454#section-3.2">origin</a> of the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client">request client</a> when making <a data-link-type="dfn" href="#cross-origin-request" id="ref-for-cross-origin-request-5">cross-origin requests</a>:</p>
+  referrer information when making <a data-link-type="dfn" href="#same-origin-request">same-origin requests</a> from a particular <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client">request client</a>, and only the <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc6454#section-6.2">ASCII serialization</a> of the <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc6454#section-3.2">origin</a> of the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client">request client</a> when making <a data-link-type="dfn" href="#cross-origin-request">cross-origin requests</a>:</p>
     <ul>
      <li>from a <a data-link-type="dfn" href="http://www.w3.org/TR/2010/REC-wsc-ui-20100812/#typesoftls">TLS-protected</a> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">environment settings object</a> to a <a data-link-type="dfn" href="https://w3c.github.io/webappsec/specs/mixedcontent/#a-priori-authenticated-url"><em>a priori</em> authenticated URL</a>, and
      <li>from <em>non-</em><a data-link-type="dfn" href="http://www.w3.org/TR/2010/REC-wsc-ui-20100812/#typesoftls">TLS-protected</a> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">environment settings objects</a> to
@@ -1719,30 +1356,31 @@ pre.idl.highlight { color: #708090; }
   referrer information. A <code><a data-link-type="dfn" href="https://tools.ietf.org/html/rfc7231#section-5.5.2">Referer</a></code> HTTP header will not be
   sent.</p>
     <div class="example" id="example-2269af87">
-     <a class="self-link" href="#example-2269af87"></a> If a document at <code>https://example.com/page.html</code> sets a policy of <a data-link-type="dfn" href="#referrer-policy-strict-origin-when-cross-origin" id="ref-for-referrer-policy-strict-origin-when-cross-origin-3">"<code>strict-origin-when-cross-origin</code>"</a>, then navigations to <code>https://example.com/not-page.html</code> would send a <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc7231#section-5.5.2"><code>Referer</code></a> header with a value of <code>https://example.com/page.html</code>. 
+     <a class="self-link" href="#example-2269af87"></a> If a document at <code>https://example.com/page.html</code> sets a policy of <a data-link-type="dfn" href="#referrer-policy-strict-origin-when-cross-origin">"<code>strict-origin-when-cross-origin</code>"</a>, then navigations to <code>https://example.com/not-page.html</code> would send a <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc7231#section-5.5.2"><code>Referer</code></a> header with a value of <code>https://example.com/page.html</code>. 
      <p>Navigations from that same page to <code>https://not.example.com/</code> would send a <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc7231#section-5.5.2"><code>Referer</code></a> header with a value of <code>https://example.com/</code>.</p>
      <p>Navigations from that same page to <code><strong>http://</strong>not.example.com/</code> would send no <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc7231#section-5.5.2"><code>Referer</code></a> header.</p>
     </div>
-    <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-export="" data-level="3.8" data-lt="&quot;unsafe-url&quot;" id="referrer-policy-unsafe-url"><span class="secno">3.8. </span><span class="content">"<code>unsafe-url</code>"</span><span id="referrer-policy-state-unsafe-url"></span></h3>
-    <p>The <a data-link-type="dfn" href="#referrer-policy-unsafe-url" id="ref-for-referrer-policy-unsafe-url-1">"<code>unsafe-url</code>"</a> policy specifies that a full URL, <a href="#strip-url">stripped for use as a referrer</a>, is sent along with
-  both <a data-link-type="dfn" href="#cross-origin-request" id="ref-for-cross-origin-request-6">cross-origin requests</a> and <a data-link-type="dfn" href="#same-origin-request" id="ref-for-same-origin-request-6">same-origin requests</a> made from
+    <h3 class="heading settled" data-dfn-type="dfn" data-export="" data-level="3.8" data-lt="&quot;unsafe-url&quot;" id="referrer-policy-unsafe-url"><span class="secno">3.8. </span><span class="content">"<code>unsafe-url</code>"</span><span id="referrer-policy-state-unsafe-url"></span><a class="self-link" href="#referrer-policy-unsafe-url"></a></h3>
+    <p>The <a data-link-type="dfn" href="#referrer-policy-unsafe-url">"<code>unsafe-url</code>"</a> policy specifies that a full URL, <a href="#strip-url">stripped for use as a referrer</a>, is sent along with
+  both <a data-link-type="dfn" href="#cross-origin-request">cross-origin requests</a> and <a data-link-type="dfn" href="#same-origin-request">same-origin requests</a> made from
   a particular <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client">request client</a>.</p>
     <div class="example" id="example-32de6eb8"><a class="self-link" href="#example-32de6eb8"></a> If a document at <code>https://example.com/sekrit.html</code> sets a policy
-    of <a data-link-type="dfn" href="#referrer-policy-unsafe-url" id="ref-for-referrer-policy-unsafe-url-2">"<code>unsafe-url</code>"</a>, then navigations to <code>http://not.example.com/</code> (and every other origin) would send a <code><a data-link-type="dfn" href="https://tools.ietf.org/html/rfc7231#section-5.5.2">Referer</a></code> HTTP header with a value of <code>https://example.com/sekrit.html</code>. </div>
+    of <a data-link-type="dfn" href="#referrer-policy-unsafe-url">"<code>unsafe-url</code>"</a>, then navigations to <code>http://not.example.com/</code> (and every other origin) would send a <code><a data-link-type="dfn" href="https://tools.ietf.org/html/rfc7231#section-5.5.2">Referer</a></code> HTTP header with a value of <code>https://example.com/sekrit.html</code>. </div>
     <p class="note" role="note">Note: The policy’s name doesn’t lie; it is unsafe. This policy will leak
   origins and paths from <a data-link-type="dfn" href="http://www.w3.org/TR/2010/REC-wsc-ui-20100812/#typesoftls">TLS-protected</a> resources to insecure origins.
   Carefully consider the impact of setting such a policy for potentially
   sensitive documents.</p>
     <h3 class="heading settled" data-dfn-type="dfn" data-export="" data-level="3.9" data-lt="The empty string" id="referrer-policy-empty-string"><span class="secno">3.9. </span><span class="content">The empty string</span><a class="self-link" href="#referrer-policy-empty-string"></a></h3>
-    <p>The empty string "" corresponds to no <a data-link-type="dfn" href="#referrer-policy" id="ref-for-referrer-policy-6">referrer policy</a>, causing a
-  fallback to a <a data-link-type="dfn" href="#referrer-policy" id="ref-for-referrer-policy-7">referrer policy</a> defined elsewhere, or in the case where
-  no such higher-level policy is available, defaulting to <a data-link-type="dfn" href="#referrer-policy-no-referrer-when-downgrade" id="ref-for-referrer-policy-no-referrer-when-downgrade-3">"<code>no-referrer-when-downgrade</code>"</a>. This defaulting happens in
+    <p>The empty string "" corresponds to no <a data-link-type="dfn" href="#referrer-policy">referrer policy</a>, causing a
+  fallback to a <a data-link-type="dfn" href="#referrer-policy">referrer policy</a> defined elsewhere, or in the case where
+  no such higher-level policy is available, defaulting to <a data-link-type="dfn" href="#referrer-policy-no-referrer-when-downgrade">"<code>no-referrer-when-downgrade</code>"</a>. This defaulting happens in
   the <a href="#determine-requests-referrer">§8.3 Determine request’s Referrer</a> algorithm.</p>
-    <div class="example" id="example-27ee7725"><a class="self-link" href="#example-27ee7725"></a> Given a HTML <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-a-element">a</a></code> element without any declared <code><a data-link-type="element-sub" href="https://html.spec.whatwg.org/multipage/semantics.html#attr-a-referrerpolicy">referrerpolicy</a></code> attribute, its referrer policy is the empty string. Thus, navigation
+    <div class="example" id="example-1c0fffaa"><a class="self-link" href="#example-1c0fffaa"></a> Given a HTML <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-a-element">a</a></code> element without any declared <code><a data-link-type="element-attr" href="https://html.spec.whatwg.org/multipage/semantics.html#attr-a-referrerpolicy">referrerpolicy</a></code> attribute, its referrer policy is the empty string. Thus, navigation
     requests initiated by clicking on that <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-a-element">a</a></code> element will be sent
+    
     with the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#concept-document-referrer-policy">referrer
     policy</a> of the <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-a-element">a</a></code> element’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-node-document">node document</a>. If that <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/dom.html#document">Document</a></code> has the empty string as its referrer policy, the <a href="#determine-requests-referrer">§8.3 Determine request’s Referrer</a> algorithm will treat the empty
-    string the same as <a data-link-type="dfn" href="#referrer-policy-no-referrer-when-downgrade" id="ref-for-referrer-policy-no-referrer-when-downgrade-4">"<code>no-referrer-when-downgrade</code>"</a>. </div>
+    string the same as <a data-link-type="dfn" href="#referrer-policy-no-referrer-when-downgrade">"<code>no-referrer-when-downgrade</code>"</a>. </div>
    </section>
    <section>
     <h2 class="heading settled" data-level="4" id="referrer-policy-delivery"><span class="secno">4. </span><span class="content">Referrer Policy Delivery</span><a class="self-link" href="#referrer-policy-delivery"></a></h2>
@@ -1750,21 +1388,21 @@ pre.idl.highlight { color: #708090; }
     <ul>
      <li> Via the <code>Referrer-Policy</code> HTTP header (defined
       in <a href="#referrer-policy-header">§4.1 Delivery via Referrer-Policy header</a>). 
-     <li> Via a <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#meta">meta</a></code> element with a <code><a data-link-type="element-sub" href="https://html.spec.whatwg.org/multipage/semantics.html#attr-meta-name">name</a></code> of <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/semantics.html#meta-referrer"><code>referrer</code></a>. 
+     <li> Via a <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#meta">meta</a></code> element with a <code><a data-link-type="element-attr" href="https://html.spec.whatwg.org/multipage/semantics.html#attr-meta-name">name</a></code> of <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/semantics.html#meta-referrer"><code>referrer</code></a>. 
      <li> Via a <code>referrerpolicy</code> content attribute on an <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-a-element">a</a></code>, <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-area-element">area</a></code>, <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element">img</a></code>, <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-iframe-element">iframe</a></code>, or <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-link-element">link</a></code> element. 
      <li> Via the <code><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/semantics.html#link-type-noreferrer">noreferrer</a></code> link relation on an <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-a-element">a</a></code>, <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-area-element">area</a></code>, or <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-link-element">link</a></code> element. 
      <li> Implicitly, via inheritance. 
     </ul>
     <h3 class="heading settled" data-level="4.1" id="referrer-policy-header"><span class="secno">4.1. </span><span class="content">Delivery via Referrer-Policy header</span><a class="self-link" href="#referrer-policy-header"></a></h3>
-    <p>The <code><dfn class="dfn-paneled" data-dfn-type="dfn" data-local-lt="referrer-policy header" data-noexport="" id="referrer-policy-header-dfn">Referrer-Policy</dfn></code> HTTP
+    <p>The <code><dfn data-dfn-type="dfn" data-local-lt="referrer-policy header" data-noexport="" id="referrer-policy-header-dfn">Referrer-Policy<a class="self-link" href="#referrer-policy-header-dfn"></a></dfn></code> HTTP
   header specifies the referrer policy that the user agent applies when
   determining what referrer information should be included with requests
-  made, and with <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#concept-document-bc">browsing contexts</a> created from the context of the protected resource.
+  made, and with <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context">browsing contexts</a> created from the context of the protected resource.
   The syntax for the name and value of the header are described by the
   following ABNF grammar:</p>
-<pre>"Referrer-Policy:" 1#<a data-link-type="dfn" href="#policy-token" id="ref-for-policy-token-1">policy-token</a>
+<pre>"Referrer-Policy:" 1#<a data-link-type="dfn" href="#policy-token">policy-token</a>
 </pre>
-<pre><dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="policy-token">policy-token</dfn>   = "no-referrer" / "no-referrer-when-downgrade" / "strict-origin" / "strict-origin-when-cross-origin" / "same-origin" / "origin" / "origin-when-cross-origin" / "unsafe-url"
+<pre><dfn data-dfn-type="dfn" data-export="" id="policy-token">policy-token<a class="self-link" href="#policy-token"></a></dfn>   = "no-referrer" / "no-referrer-when-downgrade" / "strict-origin" / "strict-origin-when-cross-origin" / "same-origin" / "origin" / "origin-when-cross-origin" / "unsafe-url"
 </pre>
     <p class="note" role="note">Note: The header name does not share the HTTP Referer header’s misspelling.</p>
     <p><a href="#integration-with-fetch">§5 Integration with Fetch</a> and <a href="#integration-with-html">§6 Integration with HTML</a> describe
@@ -1781,7 +1419,7 @@ pre.idl.highlight { color: #708090; }
     <section class="informative">
      <h3 class="heading settled" data-level="4.2" id="referrer-policy-delivery-meta"><span class="secno">4.2. </span><span class="content">Delivery via <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#meta">meta</a></code></span><a class="self-link" href="#referrer-policy-delivery-meta"></a></h3>
      <p><em>This section is not normative.</em></p>
-     <p>The HTML Standard defines the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/semantics.html#meta-referrer"><code>referrer</code></a> keyword for the <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#meta">meta</a></code> element, which allows setting the <a data-link-type="dfn" href="#referrer-policy" id="ref-for-referrer-policy-8">referrer
+     <p>The HTML Standard defines the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/semantics.html#meta-referrer"><code>referrer</code></a> keyword for the <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#meta">meta</a></code> element, which allows setting the <a data-link-type="dfn" href="#referrer-policy">referrer
     policy</a> via markup.</p>
     </section>
     <section class="informative">
@@ -1790,16 +1428,15 @@ pre.idl.highlight { color: #708090; }
      <p><em>This section is not normative.</em></p>
      <p>The HTML Standard defines the concept of <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#referrer-policy-attribute">referrer policy
     attributes</a> which applies to several of its elements, for example:</p>
-<pre class="example" id="example-4214a796"><a class="self-link" href="#example-4214a796"></a><code class="lang-html highlight"><span class="nt">&lt;a</span> <span class="na">href=</span><span class="s">"http://example.com"</span> <span class="na">referrerpolicy=</span><span class="s">"origin"</span><span class="nt">></span>
-</code></pre>
+<pre class="example" id="example-4214a796"><a class="self-link" href="#example-4214a796"></a><code class="lang-html highlight"><span class="nt">&lt;a</span> <span class="na">href=</span><span class="s">"http://example.com"</span> <span class="na">referrerpolicy=</span><span class="s">"origin"</span><span class="nt">></span></code></pre>
     </section>
     <section class="informative">
      <h3 class="heading settled" data-level="4.4" id="referrer-policy-delivery-nested"><span class="secno">4.4. </span><span class="content">Nested browsing contexts</span><span id="referrer-policy-delivery-implicit"></span><a class="self-link" href="#referrer-policy-delivery-nested"></a></h3>
      <p><em>This section is not normative.</em></p>
      <p>The HTML Standard and Fetch Standard define how nested browsing contexts
     that are not created from <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">responses</a>, such as <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-iframe-element">iframe</a></code> elements with
-    their <code><a data-link-type="element-sub" href="https://html.spec.whatwg.org/multipage/embedded-content.html#attr-iframe-srcdoc">srcdoc</a></code> attribute set, or created from a blob URL, inherit
-    their <a data-link-type="dfn" href="#referrer-policy" id="ref-for-referrer-policy-9">referrer policy</a> from the creator browsing context or blob URL.</p>
+    their <code><a data-link-type="element-attr" href="https://html.spec.whatwg.org/multipage/embedded-content.html#attr-iframe-srcdoc">srcdoc</a></code> attribute set, or created from a blob URL, inherit
+    their <a data-link-type="dfn" href="#referrer-policy">referrer policy</a> from the creator browsing context or blob URL.</p>
     </section>
    </section>
    <section class="informative">
@@ -1815,7 +1452,7 @@ pre.idl.highlight { color: #708090; }
    <section class="informative">
     <h2 class="heading settled" data-level="6" id="integration-with-html"><span class="secno">6. </span><span class="content">Integration with HTML</span><a class="self-link" href="#integration-with-html"></a></h2>
     <p><em>This section is not normative.</em></p>
-    <p>The HTML Standard determines the <a data-link-type="dfn" href="#referrer-policy" id="ref-for-referrer-policy-10">referrer policy</a> of any response
+    <p>The HTML Standard determines the <a data-link-type="dfn" href="#referrer-policy">referrer policy</a> of any response
   received during <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#navigate">navigation</a> or while <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/workers.html#run a worker">running a worker</a>, and uses
   the result to set the resulting <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/dom.html#document">Document</a></code> or <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#workerglobalscope">WorkerGlobalScope</a></code>'s
   referrer policy. This is later used by the corresponding <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">environment
@@ -1833,10 +1470,10 @@ pre.idl.highlight { color: #708090; }
     <p>Implementations should keep track of a referrer policy for each stylesheet
   that should be used to create requests for resources from the respective
   stylesheet.</p>
-    <p>For external stylesheets, the referrer policy should be <a data-link-type="dfn" href="#referrer-policy-no-referrer-when-downgrade" id="ref-for-referrer-policy-no-referrer-when-downgrade-5">"<code>no-referrer-when-downgrade</code>"</a> unless overwritten by an
+    <p>For external stylesheets, the referrer policy should be <a data-link-type="dfn" href="#referrer-policy-no-referrer-when-downgrade">"<code>no-referrer-when-downgrade</code>"</a> unless overwritten by an
   `<code>Referrer-Policy</code>` header.</p>
     <p class="note" role="note">Note: If the stylesheet was loaded via a HTML <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-link-element">link</a></code> element with a
-  declared <code><a data-link-type="element-sub" href="https://html.spec.whatwg.org/multipage/semantics.html#attr-link-referrerpolicy">referrerpolicy</a></code>, this referrer policy will not affect the
+  declared <code><a data-link-type="element-attr" href="https://html.spec.whatwg.org/multipage/semantics.html#attr-link-referrerpolicy">referrerpolicy</a></code>, this referrer policy will not affect the
   requests for resources referenced from the stylesheet.</p>
     <p>For inline stylesheets, and styles applied via an <code>style</code> attribute on an element, the referrer policy is the containing <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/dom.html#document">Document</a></code>'s
   referrer policy.  Both the value of the referrer and the value of the
@@ -1844,13 +1481,13 @@ pre.idl.highlight { color: #708090; }
    </section>
    <section>
     <h2 class="heading settled" data-level="8" id="algorithms"><span class="secno">8. </span><span class="content">Algorithms</span><a class="self-link" href="#algorithms"></a></h2>
-    <h3 class="heading settled" data-level="8.1" id="parse-referrer-policy-from-header"><span class="secno">8.1. </span><span class="content"> Parse a referrer policy from a <a data-link-type="dfn" href="#referrer-policy-header-dfn" id="ref-for-referrer-policy-header-dfn-1"><code>Referrer-Policy</code></a> header </span><a class="self-link" href="#parse-referrer-policy-from-header"></a></h3>
-    <p>Given a <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#response">Response</a></code> <var>response</var>, the following steps return a <a data-link-type="dfn" href="#referrer-policy" id="ref-for-referrer-policy-11">referrer policy</a> according to <var>response</var>’s `<code>Referrer-Policy</code>` header:</p>
+    <h3 class="heading settled" data-level="8.1" id="parse-referrer-policy-from-header"><span class="secno">8.1. </span><span class="content"> Parse a referrer policy from a <a data-link-type="dfn" href="#referrer-policy-header-dfn"><code>Referrer-Policy</code></a> header </span><a class="self-link" href="#parse-referrer-policy-from-header"></a></h3>
+    <p>Given a <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#response">Response</a></code> <var>response</var>, the following steps return a <a data-link-type="dfn" href="#referrer-policy">referrer policy</a> according to <var>response</var>’s `<code>Referrer-Policy</code>` header:</p>
     <ol>
      <li> Let <var>policy-tokens</var> be the result of <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-header-parse">parsing</a> `<code>Referrer-Policy</code>` in <var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-header-list">header list</a>. 
      <li> Let <var>policy</var> be the empty string. 
      <li>
-       For each <var>token</var> in <var>policy-tokens</var>, if <var>token</var> is a <a data-link-type="dfn" href="#referrer-policy" id="ref-for-referrer-policy-12">referrer
+       For each <var>token</var> in <var>policy-tokens</var>, if <var>token</var> is a <a data-link-type="dfn" href="#referrer-policy">referrer
       policy</a> and <var>token</var> is not the empty string, then set <var>policy</var> to <var>token</var>. 
       <p class="note" role="note">Note: This algorithm loops over multiple policy values to allow
 	  deployment of new policy values with fallbacks for older user
@@ -1900,17 +1537,17 @@ pre.idl.highlight { color: #708090; }
       "<code>no-referrer</code>", Fetch will not call into this algorithm.</p>
      <li> Let <var>referrerURL</var> be the result of <a href="#strip-url">stripping <var>referrerSource</var> for use as a referrer.</a> 
      <li> Let <var>referrerOrigin</var> be the result of <a href="#strip-url">stripping <var>referrerSource</var> for use as a
-      referrer</a>, with the <code><a data-link-type="dfn" href="#origin-only-flag" id="ref-for-origin-only-flag-1">origin-only flag</a></code> set to <code>true</code>. 
+      referrer</a>, with the <code><a data-link-type="dfn" href="#origin-only-flag">origin-only flag</a></code> set to <code>true</code>. 
      <li>
        Execute the statements corresponding to the value of <var>policy</var>: 
       <dl class="switch">
-       <dt><a data-link-type="dfn" href="#referrer-policy-no-referrer" id="ref-for-referrer-policy-no-referrer-3">"<code>no-referrer</code>"</a>
+       <dt><a data-link-type="dfn" href="#referrer-policy-no-referrer">"<code>no-referrer</code>"</a>
        <dd>Return <code>no referrer</code>
-       <dt><a data-link-type="dfn" href="#referrer-policy-origin" id="ref-for-referrer-policy-origin-4">"<code>origin</code>"</a>
+       <dt><a data-link-type="dfn" href="#referrer-policy-origin">"<code>origin</code>"</a>
        <dd>Return <var>referrerOrigin</var>
-       <dt><a data-link-type="dfn" href="#referrer-policy-unsafe-url" id="ref-for-referrer-policy-unsafe-url-3">"<code>unsafe-url</code>"</a>
+       <dt><a data-link-type="dfn" href="#referrer-policy-unsafe-url">"<code>unsafe-url</code>"</a>
        <dd>Return <var>referrerURL</var>.
-       <dt><a data-link-type="dfn" href="#referrer-policy-strict-origin" id="ref-for-referrer-policy-strict-origin-5">"<code>strict-origin</code>"</a>
+       <dt><a data-link-type="dfn" href="#referrer-policy-strict-origin">"<code>strict-origin</code>"</a>
        <dd>
         <ol>
          <li>
@@ -1922,10 +1559,10 @@ pre.idl.highlight { color: #708090; }
           </ol>
          <li>Return <var>referrerOrigin</var>. 
         </ol>
-       <dt><a data-link-type="dfn" href="#referrer-policy-strict-origin-when-cross-origin" id="ref-for-referrer-policy-strict-origin-when-cross-origin-4">"<code>strict-origin-when-cross-origin</code>"</a>
+       <dt><a data-link-type="dfn" href="#referrer-policy-strict-origin-when-cross-origin">"<code>strict-origin-when-cross-origin</code>"</a>
        <dd>
         <ol>
-         <li> If <var>request</var> is a <a data-link-type="dfn" href="#same-origin-request" id="ref-for-same-origin-request-7">same-origin request</a>, then
+         <li> If <var>request</var> is a <a data-link-type="dfn" href="#same-origin-request">same-origin request</a>, then
               return <var>referrerURL</var>. 
          <li>
            If <var>environment</var> is not null: 
@@ -1939,21 +1576,21 @@ pre.idl.highlight { color: #708090; }
           </ol>
          <li>Return <var>referrerOrigin</var>. 
         </ol>
-       <dt><a data-link-type="dfn" href="#referrer-policy-same-origin" id="ref-for-referrer-policy-same-origin-3">"<code>same-origin</code>"</a>
+       <dt><a data-link-type="dfn" href="#referrer-policy-same-origin">"<code>same-origin</code>"</a>
        <dd>
         <ol>
-         <li> If <var>request</var> is a <a data-link-type="dfn" href="#same-origin-request" id="ref-for-same-origin-request-8">same-origin request</a>, then
+         <li> If <var>request</var> is a <a data-link-type="dfn" href="#same-origin-request">same-origin request</a>, then
               return <var>referrerURL</var>. 
          <li> Otherwise, return <code>no referrer</code>. 
         </ol>
-       <dt><a data-link-type="dfn" href="#referrer-policy-origin-when-cross-origin" id="ref-for-referrer-policy-origin-when-cross-origin-5">"<code>origin-when-cross-origin</code>"</a>
+       <dt><a data-link-type="dfn" href="#referrer-policy-origin-when-cross-origin">"<code>origin-when-cross-origin</code>"</a>
        <dd>
         <ol>
-         <li> If <var>request</var> is a <a data-link-type="dfn" href="#cross-origin-request" id="ref-for-cross-origin-request-7">cross-origin request</a>, then
+         <li> If <var>request</var> is a <a data-link-type="dfn" href="#cross-origin-request">cross-origin request</a>, then
               return <var>referrerOrigin</var>. 
          <li> Otherwise, return <var>referrerURL</var>. 
         </ol>
-       <dt><a data-link-type="dfn" href="#referrer-policy-no-referrer-when-downgrade" id="ref-for-referrer-policy-no-referrer-when-downgrade-6">"<code>no-referrer-when-downgrade</code>"</a>
+       <dt><a data-link-type="dfn" href="#referrer-policy-no-referrer-when-downgrade">"<code>no-referrer-when-downgrade</code>"</a>
        <dd>
         <ol>
          <li>
@@ -1966,14 +1603,14 @@ pre.idl.highlight { color: #708090; }
          <li>Return <var>referrerURL</var>. 
         </ol>
       </dl>
-      <p class="note" role="note">Note: Fetch will ensure <var>request</var>’s <a data-link-type="dfn" href="#referrer-policy" id="ref-for-referrer-policy-13">referrer policy</a> is not the
+      <p class="note" role="note">Note: Fetch will ensure <var>request</var>’s <a data-link-type="dfn" href="#referrer-policy">referrer policy</a> is not the
       empty string before calling this algorithm.</p>
     </ol>
     <h3 class="heading settled" data-level="8.4" id="strip-url"><span class="secno">8.4. </span><span class="content"> Strip <var>url</var> for use as a referrer </span><a class="self-link" href="#strip-url"></a></h3>
     <p>Certain portions of URLs MUST not be included when sending a URL as the value
   of a `<code>Referer</code>` header: a URLs fragment, username, and password
   components should be stripped from the URL before it’s sent out. This
-  algorithm accepts a <code><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="origin-only-flag">origin-only flag</dfn></code>, which defaults
+  algorithm accepts a <code><dfn data-dfn-type="dfn" data-noexport="" id="origin-only-flag">origin-only flag<a class="self-link" href="#origin-only-flag"></a></dfn></code>, which defaults
   to <code>false</code>. If set to <code>true</code>, the algorithm will
   additionally remove the URL’s path and query components, leaving only the
   scheme, host, and port.</p>
@@ -1985,7 +1622,7 @@ pre.idl.highlight { color: #708090; }
      <li> Set <var>url</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-password">password</a> to <code>null</code>. 
      <li> Set <var>url</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#concept-url-fragment">fragment</a> to <code>null</code>. 
      <li>
-       If the <code><a data-link-type="dfn" href="#origin-only-flag" id="ref-for-origin-only-flag-2">origin-only flag</a></code> is <code>true</code>,
+       If the <code><a data-link-type="dfn" href="#origin-only-flag">origin-only flag</a></code> is <code>true</code>,
       then: 
       <ol>
        <li> Set <var>url</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-path">path</a> to <code>null</code>. 
@@ -2001,22 +1638,22 @@ pre.idl.highlight { color: #708090; }
   agents from offering options to users which would change the information
   sent out via a `<code>Referer</code>` header. For instance, user agents
   MAY allow users to suppress the referrer header entirely, regardless of the
-  active <a data-link-type="dfn" href="#referrer-policy" id="ref-for-referrer-policy-14">referrer policy</a> on a page.</p>
+  active <a data-link-type="dfn" href="#referrer-policy">referrer policy</a> on a page.</p>
    </section>
    <section>
     <h2 class="heading settled" data-level="10" id="security"><span class="secno">10. </span><span class="content">Security Considerations</span><a class="self-link" href="#security"></a></h2>
     <h3 class="heading settled" data-level="10.1" id="information-leakage"><span class="secno">10.1. </span><span class="content">Information Leakage</span><a class="self-link" href="#information-leakage"></a></h3>
-    <p>The <a data-link-type="dfn" href="#referrer-policy" id="ref-for-referrer-policy-15">referrer policies</a> <a data-link-type="dfn" href="#referrer-policy-origin" id="ref-for-referrer-policy-origin-5">"<code>origin</code>"</a>, <a data-link-type="dfn" href="#referrer-policy-origin-when-cross-origin" id="ref-for-referrer-policy-origin-when-cross-origin-6">"<code>origin-when-cross-origin</code>"</a> and <a data-link-type="dfn" href="#referrer-policy-unsafe-url" id="ref-for-referrer-policy-unsafe-url-4">"<code>unsafe-url</code>"</a> might leak the origin and the URL of
+    <p>The <a data-link-type="dfn" href="#referrer-policy">referrer policies</a> <a data-link-type="dfn" href="#referrer-policy-origin">"<code>origin</code>"</a>, <a data-link-type="dfn" href="#referrer-policy-origin-when-cross-origin">"<code>origin-when-cross-origin</code>"</a> and <a data-link-type="dfn" href="#referrer-policy-unsafe-url">"<code>unsafe-url</code>"</a> might leak the origin and the URL of
   a secure site respectively via insecure transport.</p>
     <p>Those three policies are included in the spec nevertheless to lower the friction
   of sites adopting secure transport.</p>
     <p>Authors wanting to ensure that they do not leak any more information than
-  the default policy should instead use the policy states <a data-link-type="dfn" href="#referrer-policy-same-origin" id="ref-for-referrer-policy-same-origin-4">"<code>same-origin</code>"</a>, <a data-link-type="dfn" href="#referrer-policy-strict-origin" id="ref-for-referrer-policy-strict-origin-6">"<code>strict-origin</code>"</a>, <a data-link-type="dfn" href="#referrer-policy-strict-origin-when-cross-origin" id="ref-for-referrer-policy-strict-origin-when-cross-origin-5">"<code>strict-origin-when-cross-origin</code>"</a> or <a data-link-type="dfn" href="#referrer-policy-no-referrer" id="ref-for-referrer-policy-no-referrer-4">"<code>no-referrer</code>"</a>.</p>
+  the default policy should instead use the policy states <a data-link-type="dfn" href="#referrer-policy-same-origin">"<code>same-origin</code>"</a>, <a data-link-type="dfn" href="#referrer-policy-strict-origin">"<code>strict-origin</code>"</a>, <a data-link-type="dfn" href="#referrer-policy-strict-origin-when-cross-origin">"<code>strict-origin-when-cross-origin</code>"</a> or <a data-link-type="dfn" href="#referrer-policy-no-referrer">"<code>no-referrer</code>"</a>.</p>
     <h3 class="heading settled" data-level="10.2" id="downgrade"><span class="secno">10.2. </span><span class="content">Downgrade to less strict policies</span><a class="self-link" href="#downgrade"></a></h3>
-    <p>The spec does not forbid downgrading to less strict policies, e.g., from <a data-link-type="dfn" href="#referrer-policy-no-referrer" id="ref-for-referrer-policy-no-referrer-5">"<code>no-referrer</code>"</a> to <a data-link-type="dfn" href="#referrer-policy-unsafe-url" id="ref-for-referrer-policy-unsafe-url-5">"<code>unsafe-url</code>"</a>.</p>
+    <p>The spec does not forbid downgrading to less strict policies, e.g., from <a data-link-type="dfn" href="#referrer-policy-no-referrer">"<code>no-referrer</code>"</a> to <a data-link-type="dfn" href="#referrer-policy-unsafe-url">"<code>unsafe-url</code>"</a>.</p>
     <p>On the one hand, it is not clear which policy is more strict for all possible
-  pairs of policies: While <a data-link-type="dfn" href="#referrer-policy-no-referrer-when-downgrade" id="ref-for-referrer-policy-no-referrer-when-downgrade-7">"<code>no-referrer-when-downgrade</code>"</a> will
-  not leak any information over insecure transport, and <a data-link-type="dfn" href="#referrer-policy-origin" id="ref-for-referrer-policy-origin-6">"<code>origin</code>"</a> will, the latter reveals less information
+  pairs of policies: While <a data-link-type="dfn" href="#referrer-policy-no-referrer-when-downgrade">"<code>no-referrer-when-downgrade</code>"</a> will
+  not leak any information over insecure transport, and <a data-link-type="dfn" href="#referrer-policy-origin">"<code>origin</code>"</a> will, the latter reveals less information
   across cross-origin navigations.</p>
     <p>On the other hand, allowing for setting less strict policies enables authors
   to define safe fallbacks as described in <a href="#unknown-policy-values">§11.1 Unknown Policy Values</a>.</p>
@@ -2029,9 +1666,9 @@ pre.idl.highlight { color: #708090; }
   referrer policy, the value of the latest one will be used. This makes
   it possible to deploy new policy values.</p>
     <div class="example" id="example-e42fe91b"><a class="self-link" href="#example-e42fe91b"></a> Suppose older user agents don’t understand
-    the <a data-link-type="dfn" href="#referrer-policy-unsafe-url" id="ref-for-referrer-policy-unsafe-url-6">"<code>unsafe-url</code>"</a> policy. A site can specify
-    an <a data-link-type="dfn" href="#referrer-policy-origin" id="ref-for-referrer-policy-origin-7">"<code>origin</code>"</a> policy followed by an <a data-link-type="dfn" href="#referrer-policy-unsafe-url" id="ref-for-referrer-policy-unsafe-url-7">"<code>unsafe-url</code>"</a> policy: older user agents will ignore the
-    unknown <a data-link-type="dfn" href="#referrer-policy-unsafe-url" id="ref-for-referrer-policy-unsafe-url-8">"<code>unsafe-url</code>"</a> value and use <a data-link-type="dfn" href="#referrer-policy-origin" id="ref-for-referrer-policy-origin-8">"<code>origin</code>"</a>, while newer user agents will use <a data-link-type="dfn" href="#referrer-policy-unsafe-url" id="ref-for-referrer-policy-unsafe-url-9">"<code>unsafe-url</code>"</a> because it is the last to be processed. </div>
+    the <a data-link-type="dfn" href="#referrer-policy-unsafe-url">"<code>unsafe-url</code>"</a> policy. A site can specify
+    an <a data-link-type="dfn" href="#referrer-policy-origin">"<code>origin</code>"</a> policy followed by an <a data-link-type="dfn" href="#referrer-policy-unsafe-url">"<code>unsafe-url</code>"</a> policy: older user agents will ignore the
+    unknown <a data-link-type="dfn" href="#referrer-policy-unsafe-url">"<code>unsafe-url</code>"</a> value and use <a data-link-type="dfn" href="#referrer-policy-origin">"<code>origin</code>"</a>, while newer user agents will use <a data-link-type="dfn" href="#referrer-policy-unsafe-url">"<code>unsafe-url</code>"</a> because it is the last to be processed. </div>
     <p>This behavior does not, however, apply to
   the <code>referrerpolicy</code> attribute. Authors may dynamically set
   and get the <code>referrerpolicy</code> attribute to detect whether a
@@ -2045,22 +1682,22 @@ pre.idl.highlight { color: #708090; }
   <h2 class="no-ref no-num heading settled" id="conformance"><span class="content">Conformance</span><a class="self-link" href="#conformance"></a></h2>
   <h3 class="no-ref no-num heading settled" id="conventions"><span class="content">Document conventions</span><a class="self-link" href="#conventions"></a></h3>
   <p>Conformance requirements are expressed with a combination of
-    descriptive assertions and RFC 2119 terminology. The key words “MUST”,
-    “MUST NOT”, “REQUIRED”, “SHALL”, “SHALL NOT”, “SHOULD”, “SHOULD NOT”,
-    “RECOMMENDED”, “MAY”, and “OPTIONAL” in the normative parts of this
+    descriptive assertions and RFC 2119 terminology. The key words "MUST",
+    "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT",
+    "RECOMMENDED", "MAY", and "OPTIONAL" in the normative parts of this
     document are to be interpreted as described in RFC 2119.
     However, for readability, these words do not appear in all uppercase
     letters in this specification. </p>
   <p>All of the text of this specification is normative except sections
     explicitly marked as non-normative, examples, and notes. <a data-link-type="biblio" href="#biblio-rfc2119">[RFC2119]</a></p>
-  <p>Examples in this specification are introduced with the words “for example”
+  <p>Examples in this specification are introduced with the words "for example"
     or are set apart from the normative text with <code>class="example"</code>,
     like this: </p>
   <div class="example" id="example-f839f6c8">
    <a class="self-link" href="#example-f839f6c8"></a> 
    <p>This is an example of an informative example.</p>
   </div>
-  <p>Informative notes begin with the word “Note” and are set apart from the
+  <p>Informative notes begin with the word "Note" and are set apart from the
     normative text with <code>class="note"</code>, like this: </p>
   <p class="note" role="note">Note, this is an informative note.</p>
   <h3 class="no-ref no-num heading settled" id="conformant-algorithms"><span class="content">Conformant Algorithms</span><a class="self-link" href="#conformant-algorithms"></a></h3>
@@ -2073,87 +1710,31 @@ pre.idl.highlight { color: #708090; }
     particular, the algorithms defined in this specification are intended to
     be easy to understand and are not intended to be performant. Implementers
     are encouraged to optimize.</p>
-<script src="https://www.w3.org/scripts/TR/2016/fixup.js"></script>
-  <h2 class="no-num no-ref heading settled" id="index"><span class="content">Index</span><a class="self-link" href="#index"></a></h2>
-  <h3 class="no-num no-ref heading settled" id="index-defined-here"><span class="content">Terms defined by this specification</span><a class="self-link" href="#index-defined-here"></a></h3>
-  <ul class="index">
-   <li><a href="#dom-referrerpolicy">""</a><span>, in §3</span>
+  <h2 class="no-num heading settled" id="index"><span class="content">Index</span><a class="self-link" href="#index"></a></h2>
+  <h3 class="no-num heading settled" id="index-defined-here"><span class="content">Terms defined by this specification</span><a class="self-link" href="#index-defined-here"></a></h3>
+  <ul class="indexlist">
    <li><a href="#cross-origin-request">cross-origin request</a><span>, in §2</span>
-   <li>
-    "no-referrer"
-    <ul>
-     <li><a href="#dom-referrerpolicy-no-referrer">enum-value for ReferrerPolicy</a><span>, in §3</span>
-     <li><a href="#referrer-policy-no-referrer">definition of</a><span>, in §3</span>
-    </ul>
-   <li><a href="#dom-referrerpolicy-no-referrer">no-referrer</a><span>, in §3</span>
-   <li><a href="#dom-referrerpolicy-no-referrer-when-downgrade">no-referrer-when-downgrade</a><span>, in §3</span>
-   <li>
-    "no-referrer-when-downgrade"
-    <ul>
-     <li><a href="#dom-referrerpolicy-no-referrer-when-downgrade">enum-value for ReferrerPolicy</a><span>, in §3</span>
-     <li><a href="#referrer-policy-no-referrer-when-downgrade">definition of</a><span>, in §3.1</span>
-    </ul>
-   <li><a href="#dom-referrerpolicy-origin">origin</a><span>, in §3</span>
-   <li>
-    "origin"
-    <ul>
-     <li><a href="#dom-referrerpolicy-origin">enum-value for ReferrerPolicy</a><span>, in §3</span>
-     <li><a href="#referrer-policy-origin">definition of</a><span>, in §3.3</span>
-    </ul>
+   <li><a href="#referrer-policy-no-referrer">"no-referrer"</a><span>, in §3</span>
+   <li><a href="#referrer-policy-no-referrer-when-downgrade">"no-referrer-when-downgrade"</a><span>, in §3.1</span>
+   <li><a href="#referrer-policy-origin">"origin"</a><span>, in §3.3</span>
    <li><a href="#origin-only-flag">origin-only flag</a><span>, in §8.4</span>
-   <li><a href="#dom-referrerpolicy-origin-when-cross-origin">origin-when-cross-origin</a><span>, in §3</span>
-   <li>
-    "origin-when-cross-origin"
-    <ul>
-     <li><a href="#dom-referrerpolicy-origin-when-cross-origin">enum-value for ReferrerPolicy</a><span>, in §3</span>
-     <li><a href="#referrer-policy-origin-when-cross-origin">definition of</a><span>, in §3.5</span>
-    </ul>
+   <li><a href="#referrer-policy-origin-when-cross-origin">"origin-when-cross-origin"</a><span>, in §3.5</span>
    <li><a href="#policy-token">policy-token</a><span>, in §4.1</span>
    <li><a href="#enumdef-referrerpolicy">ReferrerPolicy</a><span>, in §3</span>
-   <li><a href="#referrer-policy">referrer policy</a><span>, in §3</span>
    <li><a href="#referrer-policy-header-dfn">Referrer-Policy</a><span>, in §4.1</span>
+   <li><a href="#referrer-policy">referrer policy</a><span>, in §3</span>
    <li><a href="#referrer-policy-header-dfn">referrer-policy header</a><span>, in §4.1</span>
-   <li>
-    "same-origin"
-    <ul>
-     <li><a href="#dom-referrerpolicy-same-origin">enum-value for ReferrerPolicy</a><span>, in §3</span>
-     <li><a href="#referrer-policy-same-origin">definition of</a><span>, in §3.2</span>
-    </ul>
-   <li><a href="#dom-referrerpolicy-same-origin">same-origin</a><span>, in §3</span>
+   <li><a href="#referrer-policy-same-origin">"same-origin"</a><span>, in §3.2</span>
    <li><a href="#same-origin-request">same-origin request</a><span>, in §2</span>
-   <li><a href="#dom-referrerpolicy-strict-origin">strict-origin</a><span>, in §3</span>
-   <li>
-    "strict-origin"
-    <ul>
-     <li><a href="#dom-referrerpolicy-strict-origin">enum-value for ReferrerPolicy</a><span>, in §3</span>
-     <li><a href="#referrer-policy-strict-origin">definition of</a><span>, in §3.4</span>
-    </ul>
-   <li>
-    "strict-origin-when-cross-origin"
-    <ul>
-     <li><a href="#dom-referrerpolicy-strict-origin-when-cross-origin">enum-value for ReferrerPolicy</a><span>, in §3</span>
-     <li><a href="#referrer-policy-strict-origin-when-cross-origin">definition of</a><span>, in §3.6</span>
-    </ul>
-   <li><a href="#dom-referrerpolicy-strict-origin-when-cross-origin">strict-origin-when-cross-origin</a><span>, in §3</span>
+   <li><a href="#referrer-policy-strict-origin">"strict-origin"</a><span>, in §3.4</span>
+   <li><a href="#referrer-policy-strict-origin-when-cross-origin">"strict-origin-when-cross-origin"</a><span>, in §3.6</span>
    <li><a href="#referrer-policy-empty-string">The empty string</a><span>, in §3.8</span>
-   <li><a href="#dom-referrerpolicy-unsafe-url">unsafe-url</a><span>, in §3</span>
-   <li>
-    "unsafe-url"
-    <ul>
-     <li><a href="#dom-referrerpolicy-unsafe-url">enum-value for ReferrerPolicy</a><span>, in §3</span>
-     <li><a href="#referrer-policy-unsafe-url">definition of</a><span>, in §3.7</span>
-    </ul>
+   <li><a href="#referrer-policy-unsafe-url">"unsafe-url"</a><span>, in §3.7</span>
   </ul>
-  <h3 class="no-num no-ref heading settled" id="index-defined-elsewhere"><span class="content">Terms defined by reference</span><a class="self-link" href="#index-defined-elsewhere"></a></h3>
-  <ul class="index">
+  <h3 class="no-num heading settled" id="index-defined-elsewhere"><span class="content">Terms defined by reference</span><a class="self-link" href="#index-defined-elsewhere"></a></h3>
+  <ul class="indexlist">
    <li>
-    <a data-link-type="biblio">[WHATWG-DOM]</a> defines the following terms:
-    <ul>
-     <li><a href="https://dom.spec.whatwg.org/#concept-node-document">node document</a>
-     <li><a href="https://dom.spec.whatwg.org/#concept-document-url">url</a>
-    </ul>
-   <li>
-    <a data-link-type="biblio">[FETCH]</a> defines the following terms:
+    <a data-link-type="biblio" href="#biblio-fetch">[FETCH]</a> defines the following terms:
     <ul>
      <li><a href="https://fetch.spec.whatwg.org/#request">Request</a>
      <li><a href="https://fetch.spec.whatwg.org/#response">Response</a>
@@ -2168,26 +1749,20 @@ pre.idl.highlight { color: #708090; }
      <li><a href="https://fetch.spec.whatwg.org/#concept-request-url">url</a>
     </ul>
    <li>
-    <a data-link-type="biblio">[HTML]</a> defines the following terms:
+    <a data-link-type="biblio" href="#biblio-html">[HTML]</a> defines the following terms:
     <ul>
      <li><a href="https://html.spec.whatwg.org/multipage/dom.html#document">Document</a>
-     <li><a href="https://html.spec.whatwg.org/multipage/browsers.html#window">Window</a>
-     <li><a href="https://html.spec.whatwg.org/multipage/workers.html#workerglobalscope">WorkerGlobalScope</a>
      <li><a href="https://html.spec.whatwg.org/multipage/semantics.html#the-a-element">a</a>
      <li><a href="https://html.spec.whatwg.org/multipage/embedded-content.html#an-iframe-srcdoc-document">an iframe srcdoc document</a>
-     <li><a href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-area-element">area</a>
      <li><a href="https://html.spec.whatwg.org/multipage/browsers.html#concept-document-window">associated document</a>
-     <li><a href="https://html.spec.whatwg.org/multipage/browsers.html#concept-document-bc">browsing context</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context">browsing context</a>
      <li><a href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context-container">browsing context container</a>
      <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#creation-url">creation url</a>
      <li><a href="https://html.spec.whatwg.org/multipage/dom.html#concept-document-referrer-policy">document referrer policy</a>
      <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">environment settings object</a>
      <li><a href="https://html.spec.whatwg.org/multipage/infrastructure.html#concept-url-fragment">fragment</a>
      <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global">global object</a>
-     <li><a href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-iframe-element">iframe</a>
-     <li><a href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element">img</a>
      <li><a href="https://html.spec.whatwg.org/multipage/semantics.html#the-link-element">link</a>
-     <li><a href="https://html.spec.whatwg.org/multipage/semantics.html#meta">meta</a>
      <li><a href="https://html.spec.whatwg.org/multipage/semantics.html#attr-meta-name">name</a>
      <li><a href="https://html.spec.whatwg.org/multipage/browsers.html#navigate">navigation</a>
      <li><a href="https://html.spec.whatwg.org/multipage/semantics.html#link-type-noreferrer">noreferrer</a>
@@ -2196,282 +1771,102 @@ pre.idl.highlight { color: #708090; }
      <li><a href="https://html.spec.whatwg.org/multipage/infrastructure.html#referrer-policy-attribute">referrer policy attribute</a>
      <li><a href="https://html.spec.whatwg.org/multipage/semantics.html#attr-a-referrerpolicy">referrerpolicy</a>
      <li><a href="https://html.spec.whatwg.org/multipage/workers.html#run a worker">running a worker</a>
-     <li><a href="https://html.spec.whatwg.org/multipage/embedded-content.html#attr-iframe-srcdoc">srcdoc</a>
     </ul>
    <li>
-    <a data-link-type="biblio">[MIX]</a> defines the following terms:
+    <a data-link-type="biblio" href="#biblio-mix">[MIX]</a> defines the following terms:
     <ul>
      <li><a href="https://w3c.github.io/webappsec/specs/mixedcontent/#a-priori-authenticated-url">a priori authenticated url</a>
     </ul>
    <li>
-    <a data-link-type="biblio">[RFC6454]</a> defines the following terms:
+    <a data-link-type="biblio" href="#biblio-rfc6454">[RFC6454]</a> defines the following terms:
     <ul>
      <li><a href="https://tools.ietf.org/html/rfc6454#section-6.2">ascii serialization of an origin</a>
      <li><a href="https://tools.ietf.org/html/rfc6454#section-3.2">origin</a>
      <li><a href="https://tools.ietf.org/html/rfc6454#section-5">the same</a>
     </ul>
    <li>
-    <a data-link-type="biblio">[RFC7231]</a> defines the following terms:
+    <a data-link-type="biblio" href="#biblio-rfc7231">[RFC7231]</a> defines the following terms:
     <ul>
      <li><a href="https://tools.ietf.org/html/rfc7231#section-5.5.2">referer</a>
     </ul>
    <li>
-    <a data-link-type="biblio">[WHATWG-URL]</a> defines the following terms:
+    <a data-link-type="biblio" href="#biblio-url">[url]</a> defines the following terms:
     <ul>
      <li><a href="https://url.spec.whatwg.org#local-scheme">local scheme</a>
+     <li><a href="https://url.spec.whatwg.org#url">url</a>
+    </ul>
+   <li>
+    <a data-link-type="biblio" href="#biblio-wsc-ui">[wsc-ui]</a> defines the following terms:
+    <ul>
+     <li><a href="http://www.w3.org/TR/2010/REC-wsc-ui-20100812/#typesoftls">tls-protected</a>
+    </ul>
+   <li>
+    <a data-link-type="biblio" href="#biblio-dom-ls">[dom-ls]</a> defines the following terms:
+    <ul>
+     <li><a href="https://dom.spec.whatwg.org/#concept-node-document">node document</a>
+     <li><a href="https://dom.spec.whatwg.org/#concept-document-url">url</a>
+    </ul>
+   <li>
+    <a data-link-type="biblio" href="#biblio-html">[HTML]</a> defines the following terms:
+    <ul>
+     <li><a href="https://html.spec.whatwg.org/multipage/browsers.html#window">Window</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/workers.html#workerglobalscope">WorkerGlobalScope</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-area-element">area</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-iframe-element">iframe</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element">img</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/semantics.html#meta">meta</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/embedded-content.html#attr-iframe-srcdoc">srcdoc</a>
+    </ul>
+   <li>
+    <a data-link-type="biblio" href="#biblio-url">[url]</a> defines the following terms:
+    <ul>
      <li><a href="https://url.spec.whatwg.org/#concept-url-password">password</a>
      <li><a href="https://url.spec.whatwg.org/#concept-url-path">path</a>
      <li><a href="https://url.spec.whatwg.org/#concept-url-query">query</a>
      <li><a href="https://url.spec.whatwg.org/#concept-url-scheme">scheme</a>
-     <li><a href="https://url.spec.whatwg.org#url">url</a>
      <li><a href="https://url.spec.whatwg.org/#concept-url-username">username</a>
     </ul>
-   <li>
-    <a data-link-type="biblio">[wsc-ui]</a> defines the following terms:
-    <ul>
-     <li><a href="http://www.w3.org/TR/2010/REC-wsc-ui-20100812/#typesoftls">tls-protected</a>
-    </ul>
   </ul>
-  <h2 class="no-num no-ref heading settled" id="references"><span class="content">References</span><a class="self-link" href="#references"></a></h2>
-  <h3 class="no-num no-ref heading settled" id="normative"><span class="content">Normative References</span><a class="self-link" href="#normative"></a></h3>
+  <h2 class="no-num heading settled" id="references"><span class="content">References</span><a class="self-link" href="#references"></a></h2>
+  <h3 class="no-num heading settled" id="normative"><span class="content">Normative References</span><a class="self-link" href="#normative"></a></h3>
   <dl>
-   <dt id="biblio-fetch">[FETCH]
+   <dt id="biblio-fetch"><a class="self-link" href="#biblio-fetch"></a>[FETCH]
    <dd>Anne van Kesteren. <a href="http://fetch.spec.whatwg.org/">Fetch</a>. Living Standard. URL: <a href="http://fetch.spec.whatwg.org/">http://fetch.spec.whatwg.org/</a>
-   <dt id="biblio-html">[HTML]
+   <dt id="biblio-html"><a class="self-link" href="#biblio-html"></a>[HTML]
    <dd>Ian Hickson. <a href="https://html.spec.whatwg.org/multipage/">HTML Standard</a>. Living Standard. URL: <a href="https://html.spec.whatwg.org/multipage/">https://html.spec.whatwg.org/multipage/</a>
-   <dt id="biblio-mix">[MIX]
+   <dt id="biblio-mix"><a class="self-link" href="#biblio-mix"></a>[MIX]
    <dd>Mike West. <a href="https://w3c.github.io/webappsec/specs/mixedcontent/">Mixed Content</a>. ED. URL: <a href="https://w3c.github.io/webappsec/specs/mixedcontent/">https://w3c.github.io/webappsec/specs/mixedcontent/</a>
-   <dt id="biblio-rfc2119">[RFC2119]
-   <dd>S. Bradner. <a href="https://tools.ietf.org/html/rfc2119">Key words for use in RFCs to Indicate Requirement Levels</a>. March 1997. Best Current Practice. URL: <a href="https://tools.ietf.org/html/rfc2119">https://tools.ietf.org/html/rfc2119</a>
-   <dt id="biblio-rfc6454">[RFC6454]
+   <dt id="biblio-rfc6454"><a class="self-link" href="#biblio-rfc6454"></a>[RFC6454]
    <dd>Adam Barth. <a href="http://www.ietf.org/rfc/rfc6454.txt">The Web Origin Concept</a>. RFC. URL: <a href="http://www.ietf.org/rfc/rfc6454.txt">http://www.ietf.org/rfc/rfc6454.txt</a>
-   <dt id="biblio-rfc7231">[RFC7231]
+   <dt id="biblio-rfc7231"><a class="self-link" href="#biblio-rfc7231"></a>[RFC7231]
    <dd>Roy T. Fielding; Julian F. Reschke. <a href="http://www.ietf.org/rfc/rfc7231.txt">HTTP/1.1 Semantics and Content</a>. RFC. URL: <a href="http://www.ietf.org/rfc/rfc7231.txt">http://www.ietf.org/rfc/rfc7231.txt</a>
-   <dt id="biblio-whatwg-dom">[WHATWG-DOM]
-   <dd>Anne van Kesteren. <a href="https://dom.spec.whatwg.org/">DOM Standard</a>. Living Standard. URL: <a href="https://dom.spec.whatwg.org/">https://dom.spec.whatwg.org/</a>
-   <dt id="biblio-whatwg-url">[WHATWG-URL]
-   <dd>Anne van Kesteren. <a href="https://url.spec.whatwg.org/">URL Standard</a>. Living Standard. URL: <a href="https://url.spec.whatwg.org/">https://url.spec.whatwg.org/</a>
-   <dt id="biblio-wsc-ui">[WSC-UI]
-   <dd>Thomas Roessler; Anil Saldhana. <a href="https://www.w3.org/TR/wsc-ui/">Web Security Context: User Interface Guidelines</a>. 12 August 2010. REC. URL: <a href="https://www.w3.org/TR/wsc-ui/">https://www.w3.org/TR/wsc-ui/</a>
+   <dt id="biblio-dom-ls"><a class="self-link" href="#biblio-dom-ls"></a>[DOM-LS]
+   <dd>Document Object Model URL: <a href="https://dom.spec.whatwg.org/">https://dom.spec.whatwg.org/</a>
+   <dt id="biblio-rfc2119"><a class="self-link" href="#biblio-rfc2119"></a>[RFC2119]
+   <dd>S. Bradner. <a href="https://tools.ietf.org/html/rfc2119">Key words for use in RFCs to Indicate Requirement Levels</a>. March 1997. Best Current Practice. URL: <a href="https://tools.ietf.org/html/rfc2119">https://tools.ietf.org/html/rfc2119</a>
+   <dt id="biblio-url"><a class="self-link" href="#biblio-url"></a>[URL]
+   <dd>Anne van Kesteren; Sam Ruby. <a href="http://www.w3.org/TR/url-1/">URL</a>. 9 December 2014. WD. URL: <a href="http://www.w3.org/TR/url-1/">http://www.w3.org/TR/url-1/</a>
+   <dt id="biblio-wsc-ui"><a class="self-link" href="#biblio-wsc-ui"></a>[WSC-UI]
+   <dd>Thomas Roessler; Anil Saldhana. <a href="http://www.w3.org/TR/wsc-ui/">Web Security Context: User Interface Guidelines</a>. 12 August 2010. REC. URL: <a href="http://www.w3.org/TR/wsc-ui/">http://www.w3.org/TR/wsc-ui/</a>
   </dl>
-  <h3 class="no-num no-ref heading settled" id="informative"><span class="content">Informative References</span><a class="self-link" href="#informative"></a></h3>
+  <h3 class="no-num heading settled" id="informative"><span class="content">Informative References</span><a class="self-link" href="#informative"></a></h3>
   <dl>
-   <dt id="biblio-capability-urls">[CAPABILITY-URLS]
+   <dt id="biblio-capability-urls"><a class="self-link" href="#biblio-capability-urls"></a>[CAPABILITY-URLS]
    <dd>Jenni Tennison. <a href="http://www.w3.org/TR/capability-urls/">Capability URLs</a>. WD. URL: <a href="http://www.w3.org/TR/capability-urls/">http://www.w3.org/TR/capability-urls/</a>
   </dl>
-  <h2 class="no-num no-ref heading settled" id="idl-index"><span class="content">IDL Index</span><a class="self-link" href="#idl-index"></a></h2>
-<pre class="idl def"><span class="kt">enum</span> <a class="nv" href="#enumdef-referrerpolicy">ReferrerPolicy</a> {
-  <a class="s" href="#dom-referrerpolicy">""</a>,
-  <a class="s" href="#dom-referrerpolicy-no-referrer">"no-referrer"</a>,
-  <a class="s" href="#dom-referrerpolicy-no-referrer-when-downgrade">"no-referrer-when-downgrade"</a>,
-  <a class="s" href="#dom-referrerpolicy-same-origin">"same-origin"</a>,
-  <a class="s" href="#dom-referrerpolicy-origin">"origin"</a>,
-  <a class="s" href="#dom-referrerpolicy-strict-origin">"strict-origin"</a>,
-  <a class="s" href="#dom-referrerpolicy-origin-when-cross-origin">"origin-when-cross-origin"</a>,
-  <a class="s" href="#dom-referrerpolicy-strict-origin-when-cross-origin">"strict-origin-when-cross-origin"</a>,
-  <a class="s" href="#dom-referrerpolicy-unsafe-url">"unsafe-url"</a>
+  <h2 class="no-num heading settled" id="idl-index"><span class="content">IDL Index</span><a class="self-link" href="#idl-index"></a></h2>
+<pre class="idl">enum <a href="#enumdef-referrerpolicy">ReferrerPolicy</a> {
+  "",
+  "no-referrer",
+  "no-referrer-when-downgrade",
+  "same-origin",
+  "origin",
+  "strict-origin",
+  "origin-when-cross-origin",
+  "strict-origin-when-cross-origin",
+  "unsafe-url"
 };
 
 </pre>
-  <aside class="dfn-panel" data-for="same-origin-request">
-   <b><a href="#same-origin-request">#same-origin-request</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-same-origin-request-1">2. Key Concepts and Terminology</a>
-    <li><a href="#ref-for-same-origin-request-2">3.3. "same-origin"</a>
-    <li><a href="#ref-for-same-origin-request-3">3.4. "origin"</a>
-    <li><a href="#ref-for-same-origin-request-4">3.6. "origin-when-cross-origin"</a>
-    <li><a href="#ref-for-same-origin-request-5">3.7. "strict-origin-when-cross-origin"</a>
-    <li><a href="#ref-for-same-origin-request-6">3.8. "unsafe-url"</a>
-    <li><a href="#ref-for-same-origin-request-7">8.3. 
-    Determine request’s Referrer </a> <a href="#ref-for-same-origin-request-8">(2)</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="cross-origin-request">
-   <b><a href="#cross-origin-request">#cross-origin-request</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-cross-origin-request-1">3.3. "same-origin"</a>
-    <li><a href="#ref-for-cross-origin-request-2">3.4. "origin"</a>
-    <li><a href="#ref-for-cross-origin-request-3">3.6. "origin-when-cross-origin"</a> <a href="#ref-for-cross-origin-request-4">(2)</a>
-    <li><a href="#ref-for-cross-origin-request-5">3.7. "strict-origin-when-cross-origin"</a>
-    <li><a href="#ref-for-cross-origin-request-6">3.8. "unsafe-url"</a>
-    <li><a href="#ref-for-cross-origin-request-7">8.3. 
-    Determine request’s Referrer </a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="referrer-policy">
-   <b><a href="#referrer-policy">#referrer-policy</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-referrer-policy-1">2. Key Concepts and Terminology</a> <a href="#ref-for-referrer-policy-2">(2)</a> <a href="#ref-for-referrer-policy-3">(3)</a> <a href="#ref-for-referrer-policy-4">(4)</a>
-    <li><a href="#ref-for-referrer-policy-5">3. Referrer Policies</a>
-    <li><a href="#ref-for-referrer-policy-6">3.9. The empty string</a> <a href="#ref-for-referrer-policy-7">(2)</a>
-    <li><a href="#ref-for-referrer-policy-8">4.2. Delivery via meta</a>
-    <li><a href="#ref-for-referrer-policy-9">4.4. Nested browsing contexts</a>
-    <li><a href="#ref-for-referrer-policy-10">6. Integration with HTML</a>
-    <li><a href="#ref-for-referrer-policy-11">8.1. 
-    Parse a referrer policy from a Referrer-Policy header </a> <a href="#ref-for-referrer-policy-12">(2)</a>
-    <li><a href="#ref-for-referrer-policy-13">8.3. 
-    Determine request’s Referrer </a>
-    <li><a href="#ref-for-referrer-policy-14">9.1. User Controls</a>
-    <li><a href="#ref-for-referrer-policy-15">10.1. Information Leakage</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="referrer-policy-no-referrer">
-   <b><a href="#referrer-policy-no-referrer">#referrer-policy-no-referrer</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-referrer-policy-no-referrer-1">3.1. "no-referrer"</a> <a href="#ref-for-referrer-policy-no-referrer-2">(2)</a>
-    <li><a href="#ref-for-referrer-policy-no-referrer-3">8.3. 
-    Determine request’s Referrer </a>
-    <li><a href="#ref-for-referrer-policy-no-referrer-4">10.1. Information Leakage</a>
-    <li><a href="#ref-for-referrer-policy-no-referrer-5">10.2. Downgrade to less strict policies</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="referrer-policy-no-referrer-when-downgrade">
-   <b><a href="#referrer-policy-no-referrer-when-downgrade">#referrer-policy-no-referrer-when-downgrade</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-referrer-policy-no-referrer-when-downgrade-1">3.2. "no-referrer-when-downgrade"</a> <a href="#ref-for-referrer-policy-no-referrer-when-downgrade-2">(2)</a>
-    <li><a href="#ref-for-referrer-policy-no-referrer-when-downgrade-3">3.9. The empty string</a> <a href="#ref-for-referrer-policy-no-referrer-when-downgrade-4">(2)</a>
-    <li><a href="#ref-for-referrer-policy-no-referrer-when-downgrade-5">7. Integration with CSS</a>
-    <li><a href="#ref-for-referrer-policy-no-referrer-when-downgrade-6">8.3. 
-    Determine request’s Referrer </a>
-    <li><a href="#ref-for-referrer-policy-no-referrer-when-downgrade-7">10.2. Downgrade to less strict policies</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="referrer-policy-same-origin">
-   <b><a href="#referrer-policy-same-origin">#referrer-policy-same-origin</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-referrer-policy-same-origin-1">3.3. "same-origin"</a> <a href="#ref-for-referrer-policy-same-origin-2">(2)</a>
-    <li><a href="#ref-for-referrer-policy-same-origin-3">8.3. 
-    Determine request’s Referrer </a>
-    <li><a href="#ref-for-referrer-policy-same-origin-4">10.1. Information Leakage</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="referrer-policy-origin">
-   <b><a href="#referrer-policy-origin">#referrer-policy-origin</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-referrer-policy-origin-1">3.4. "origin"</a> <a href="#ref-for-referrer-policy-origin-2">(2)</a> <a href="#ref-for-referrer-policy-origin-3">(3)</a>
-    <li><a href="#ref-for-referrer-policy-origin-4">8.3. 
-    Determine request’s Referrer </a>
-    <li><a href="#ref-for-referrer-policy-origin-5">10.1. Information Leakage</a>
-    <li><a href="#ref-for-referrer-policy-origin-6">10.2. Downgrade to less strict policies</a>
-    <li><a href="#ref-for-referrer-policy-origin-7">11.1. Unknown Policy Values</a> <a href="#ref-for-referrer-policy-origin-8">(2)</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="referrer-policy-strict-origin">
-   <b><a href="#referrer-policy-strict-origin">#referrer-policy-strict-origin</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-referrer-policy-strict-origin-1">3.4. "origin"</a>
-    <li><a href="#ref-for-referrer-policy-strict-origin-2">3.5. "strict-origin"</a> <a href="#ref-for-referrer-policy-strict-origin-3">(2)</a> <a href="#ref-for-referrer-policy-strict-origin-4">(3)</a>
-    <li><a href="#ref-for-referrer-policy-strict-origin-5">8.3. 
-    Determine request’s Referrer </a>
-    <li><a href="#ref-for-referrer-policy-strict-origin-6">10.1. Information Leakage</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="referrer-policy-origin-when-cross-origin">
-   <b><a href="#referrer-policy-origin-when-cross-origin">#referrer-policy-origin-when-cross-origin</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-referrer-policy-origin-when-cross-origin-1">3.6. "origin-when-cross-origin"</a> <a href="#ref-for-referrer-policy-origin-when-cross-origin-2">(2)</a> <a href="#ref-for-referrer-policy-origin-when-cross-origin-3">(3)</a> <a href="#ref-for-referrer-policy-origin-when-cross-origin-4">(4)</a>
-    <li><a href="#ref-for-referrer-policy-origin-when-cross-origin-5">8.3. 
-    Determine request’s Referrer </a>
-    <li><a href="#ref-for-referrer-policy-origin-when-cross-origin-6">10.1. Information Leakage</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="referrer-policy-strict-origin-when-cross-origin">
-   <b><a href="#referrer-policy-strict-origin-when-cross-origin">#referrer-policy-strict-origin-when-cross-origin</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-referrer-policy-strict-origin-when-cross-origin-1">3.6. "origin-when-cross-origin"</a>
-    <li><a href="#ref-for-referrer-policy-strict-origin-when-cross-origin-2">3.7. "strict-origin-when-cross-origin"</a> <a href="#ref-for-referrer-policy-strict-origin-when-cross-origin-3">(2)</a>
-    <li><a href="#ref-for-referrer-policy-strict-origin-when-cross-origin-4">8.3. 
-    Determine request’s Referrer </a>
-    <li><a href="#ref-for-referrer-policy-strict-origin-when-cross-origin-5">10.1. Information Leakage</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="referrer-policy-unsafe-url">
-   <b><a href="#referrer-policy-unsafe-url">#referrer-policy-unsafe-url</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-referrer-policy-unsafe-url-1">3.8. "unsafe-url"</a> <a href="#ref-for-referrer-policy-unsafe-url-2">(2)</a>
-    <li><a href="#ref-for-referrer-policy-unsafe-url-3">8.3. 
-    Determine request’s Referrer </a>
-    <li><a href="#ref-for-referrer-policy-unsafe-url-4">10.1. Information Leakage</a>
-    <li><a href="#ref-for-referrer-policy-unsafe-url-5">10.2. Downgrade to less strict policies</a>
-    <li><a href="#ref-for-referrer-policy-unsafe-url-6">11.1. Unknown Policy Values</a> <a href="#ref-for-referrer-policy-unsafe-url-7">(2)</a> <a href="#ref-for-referrer-policy-unsafe-url-8">(3)</a> <a href="#ref-for-referrer-policy-unsafe-url-9">(4)</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="referrer-policy-header-dfn">
-   <b><a href="#referrer-policy-header-dfn">#referrer-policy-header-dfn</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-referrer-policy-header-dfn-1">8.1. 
-    Parse a referrer policy from a Referrer-Policy header </a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="policy-token">
-   <b><a href="#policy-token">#policy-token</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-policy-token-1">4.1. Delivery via Referrer-Policy header</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="origin-only-flag">
-   <b><a href="#origin-only-flag">#origin-only-flag</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-origin-only-flag-1">8.3. 
-    Determine request’s Referrer </a>
-    <li><a href="#ref-for-origin-only-flag-2">8.4. 
-    Strip url for use as a referrer </a>
-   </ul>
-  </aside>
-<script>/* script-dfn-panel */
-
-        document.body.addEventListener("click", function(e) {
-            var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-            // Find the dfn element or panel, if any, that was clicked on.
-            var el = e.target;
-            var target;
-            var hitALink = false;
-            while(el.parentElement) {
-                if(el.tagName == "A") {
-                    // Clicking on a link in a <dfn> shouldn't summon the panel
-                    hitALink = true;
-                }
-                if(el.classList.contains("dfn-paneled")) {
-                    target = "dfn";
-                    break;
-                }
-                if(el.classList.contains("dfn-panel")) {
-                    target = "dfn-panel";
-                    break;
-                }
-                el = el.parentElement;
-            }
-            if(target != "dfn-panel") {
-                // Turn off any currently "on" or "activated" panels.
-                queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-                    el.classList.remove("on");
-                    el.classList.remove("activated");
-                });
-            }
-            if(target == "dfn" && !hitALink) {
-                // open the panel
-                var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-                if(dfnPanel) {
-                    console.log(dfnPanel);
-                    dfnPanel.classList.add("on");
-                    var rect = el.getBoundingClientRect();
-                    dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-                    dfnPanel.style.top = window.scrollY + rect.top + "px";
-                    var panelRect = dfnPanel.getBoundingClientRect();
-                    var panelWidth = panelRect.right - panelRect.left;
-                    if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                        // Reposition, because the panel is overflowing
-                        dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-                    }
-                } else {
-                    console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-                }
-            } else if(target == "dfn-panel") {
-                // Switch it to "activated" state, which pins it.
-                el.classList.add("activated");
-                el.style.left = null;
-                el.style.top = null;
-            }
-
-        });
-        </script>
+ </body>
+</html>

--- a/index.html
+++ b/index.html
@@ -1495,7 +1495,7 @@ Possible extra rowspan handling
       <li><a href="#set-requests-referrer-policy-on-redirect"><span class="secno">8.2</span> <span class="content"> Set <var>request</var>’s referrer policy on redirect </span></a>
       <li><a href="#determine-requests-referrer"><span class="secno">8.3</span> <span class="content"> Determine <var>request</var>’s Referrer </span></a>
       <li><a href="#strip-url"><span class="secno">8.4</span> <span class="content"> Strip <var>url</var> for use as a referrer </span></a>
-      <li><a href="#ancestor-origin"><span class="secno">8.5</span> <span class="content"> Determine the Ancestor Origin availble to a Location </span></a>
+      <li><a href="#origin-for-location"><span class="secno">8.5</span> <span class="content"> Determine the origin serialization available to a Location </span></a>
      </ol>
     <li>
      <a href="#privacy"><span class="secno">9</span> <span class="content">Privacy Considerations</span></a>
@@ -1971,14 +1971,15 @@ Possible extra rowspan handling
       </ol>
      <li> Return <var>url</var>. 
     </ol>
-    <h3 class="heading settled" data-level="8.5" id="ancestor-origin"><span class="secno">8.5. </span><span class="content"> Determine the Ancestor Origin availble to a Location </span><a class="self-link" href="#ancestor-origin"></a></h3>
-     Given a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#location">Location</a> <var>location</var> and a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context">browsing context</a> <var>context</var> we can determine what origin information for <var>context</var> should be included in <var>location</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#concept-location-ancestor-origins-array">ancestor origins array</a>. 
+    <h3 class="heading settled" data-level="8.5" id="origin-for-location"><span class="secno">8.5. </span><span class="content"> Determine the origin serialization available to a Location </span><a class="self-link" href="#origin-for-location"></a></h3>
+     Given a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#location">Location</a> <var>location</var> and a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context">browsing context</a> <var>context</var>,
+  determine what serialized <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc6454#section-3.2">origin</a> <var>context</var>’s <a data-link-type="dfn" href="#referrer-policy" id="ref-for-referrer-policy-14">referrer policy</a> allows exposing to <var>location</var>. 
     <ol>
      <li>Let <var>document</var> be <var>context</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#active-document">active document</a>.
      <li>Let <var>documentOrigin</var> be <var>document</var>’s <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc6454#section-3.2">origin</a>.
      <li>If <var>documentOrigin</var> is an <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin-opaque">opaque origin</a>, return <code>"null"</code>. 
      <li>Let <var>locationOrigin</var> be <var>location</var>’s relevant <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document">Document</a>’s <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc6454#section-3.2">origin</a>. 
-     <li>Let <var>policy</var> be <var>document</var>’s <a data-link-type="dfn" href="#referrer-policy" id="ref-for-referrer-policy-14">referrer policy</a>.
+     <li>Let <var>policy</var> be <var>document</var>’s <a data-link-type="dfn" href="#referrer-policy" id="ref-for-referrer-policy-15">referrer policy</a>.
      <li>
        Execute the statements corresponding to the value of <var>policy</var>: 
       <dl class="switch">
@@ -2031,12 +2032,12 @@ Possible extra rowspan handling
   agents from offering options to users which would change the information
   sent out via a `<code>Referer</code>` header. For instance, user agents
   MAY allow users to suppress the referrer header entirely, regardless of the
-  active <a data-link-type="dfn" href="#referrer-policy" id="ref-for-referrer-policy-15">referrer policy</a> on a page.</p>
+  active <a data-link-type="dfn" href="#referrer-policy" id="ref-for-referrer-policy-16">referrer policy</a> on a page.</p>
    </section>
    <section>
     <h2 class="heading settled" data-level="10" id="security"><span class="secno">10. </span><span class="content">Security Considerations</span><a class="self-link" href="#security"></a></h2>
     <h3 class="heading settled" data-level="10.1" id="information-leakage"><span class="secno">10.1. </span><span class="content">Information Leakage</span><a class="self-link" href="#information-leakage"></a></h3>
-    <p>The <a data-link-type="dfn" href="#referrer-policy" id="ref-for-referrer-policy-16">referrer policies</a> <a data-link-type="dfn" href="#referrer-policy-origin" id="ref-for-referrer-policy-origin-6">"<code>origin</code>"</a>, <a data-link-type="dfn" href="#referrer-policy-origin-when-cross-origin" id="ref-for-referrer-policy-origin-when-cross-origin-7">"<code>origin-when-cross-origin</code>"</a> and <a data-link-type="dfn" href="#referrer-policy-unsafe-url" id="ref-for-referrer-policy-unsafe-url-5">"<code>unsafe-url</code>"</a> might leak the origin and the URL of
+    <p>The <a data-link-type="dfn" href="#referrer-policy" id="ref-for-referrer-policy-17">referrer policies</a> <a data-link-type="dfn" href="#referrer-policy-origin" id="ref-for-referrer-policy-origin-6">"<code>origin</code>"</a>, <a data-link-type="dfn" href="#referrer-policy-origin-when-cross-origin" id="ref-for-referrer-policy-origin-when-cross-origin-7">"<code>origin-when-cross-origin</code>"</a> and <a data-link-type="dfn" href="#referrer-policy-unsafe-url" id="ref-for-referrer-policy-unsafe-url-5">"<code>unsafe-url</code>"</a> might leak the origin and the URL of
   a secure site respectively via insecure transport.</p>
     <p>Those three policies are included in the spec nevertheless to lower the friction
   of sites adopting secure transport.</p>
@@ -2198,7 +2199,6 @@ Possible extra rowspan handling
      <li><a href="https://html.spec.whatwg.org/multipage/semantics.html#the-a-element">a</a>
      <li><a href="https://html.spec.whatwg.org/multipage/browsers.html#active-document">active document</a>
      <li><a href="https://html.spec.whatwg.org/multipage/embedded-content.html#an-iframe-srcdoc-document">an iframe srcdoc document</a>
-     <li><a href="https://html.spec.whatwg.org/multipage/infrastructure.html#concept-location-ancestor-origins-array">ancestor origins array</a>
      <li><a href="https://html.spec.whatwg.org/multipage/browsers.html#concept-document-window">associated document</a>
      <li><a href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context">browsing context</a>
      <li><a href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context-container">browsing context container</a>
@@ -2355,9 +2355,9 @@ Possible extra rowspan handling
     <li><a href="#ref-for-referrer-policy-13">8.3. 
     Determine request’s Referrer </a>
     <li><a href="#ref-for-referrer-policy-14">8.5. 
-    Determine the Ancestor Origin availble to a Location </a>
-    <li><a href="#ref-for-referrer-policy-15">9.1. User Controls</a>
-    <li><a href="#ref-for-referrer-policy-16">10.1. Information Leakage</a>
+    Determine the origin serialization available to a Location </a> <a href="#ref-for-referrer-policy-15">(2)</a>
+    <li><a href="#ref-for-referrer-policy-16">9.1. User Controls</a>
+    <li><a href="#ref-for-referrer-policy-17">10.1. Information Leakage</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="referrer-policy-no-referrer">
@@ -2367,7 +2367,7 @@ Possible extra rowspan handling
     <li><a href="#ref-for-referrer-policy-no-referrer-3">8.3. 
     Determine request’s Referrer </a>
     <li><a href="#ref-for-referrer-policy-no-referrer-4">8.5. 
-    Determine the Ancestor Origin availble to a Location </a>
+    Determine the origin serialization available to a Location </a>
     <li><a href="#ref-for-referrer-policy-no-referrer-5">10.1. Information Leakage</a>
     <li><a href="#ref-for-referrer-policy-no-referrer-6">10.2. Downgrade to less strict policies</a>
    </ul>
@@ -2381,7 +2381,7 @@ Possible extra rowspan handling
     <li><a href="#ref-for-referrer-policy-no-referrer-when-downgrade-6">8.3. 
     Determine request’s Referrer </a>
     <li><a href="#ref-for-referrer-policy-no-referrer-when-downgrade-7">8.5. 
-    Determine the Ancestor Origin availble to a Location </a>
+    Determine the origin serialization available to a Location </a>
     <li><a href="#ref-for-referrer-policy-no-referrer-when-downgrade-8">10.2. Downgrade to less strict policies</a>
    </ul>
   </aside>
@@ -2392,7 +2392,7 @@ Possible extra rowspan handling
     <li><a href="#ref-for-referrer-policy-same-origin-3">8.3. 
     Determine request’s Referrer </a>
     <li><a href="#ref-for-referrer-policy-same-origin-4">8.5. 
-    Determine the Ancestor Origin availble to a Location </a>
+    Determine the origin serialization available to a Location </a>
     <li><a href="#ref-for-referrer-policy-same-origin-5">10.1. Information Leakage</a>
    </ul>
   </aside>
@@ -2403,7 +2403,7 @@ Possible extra rowspan handling
     <li><a href="#ref-for-referrer-policy-origin-4">8.3. 
     Determine request’s Referrer </a>
     <li><a href="#ref-for-referrer-policy-origin-5">8.5. 
-    Determine the Ancestor Origin availble to a Location </a>
+    Determine the origin serialization available to a Location </a>
     <li><a href="#ref-for-referrer-policy-origin-6">10.1. Information Leakage</a>
     <li><a href="#ref-for-referrer-policy-origin-7">10.2. Downgrade to less strict policies</a>
     <li><a href="#ref-for-referrer-policy-origin-8">11.1. Unknown Policy Values</a> <a href="#ref-for-referrer-policy-origin-9">(2)</a>
@@ -2417,7 +2417,7 @@ Possible extra rowspan handling
     <li><a href="#ref-for-referrer-policy-strict-origin-5">8.3. 
     Determine request’s Referrer </a>
     <li><a href="#ref-for-referrer-policy-strict-origin-6">8.5. 
-    Determine the Ancestor Origin availble to a Location </a>
+    Determine the origin serialization available to a Location </a>
     <li><a href="#ref-for-referrer-policy-strict-origin-7">10.1. Information Leakage</a>
    </ul>
   </aside>
@@ -2428,7 +2428,7 @@ Possible extra rowspan handling
     <li><a href="#ref-for-referrer-policy-origin-when-cross-origin-5">8.3. 
     Determine request’s Referrer </a>
     <li><a href="#ref-for-referrer-policy-origin-when-cross-origin-6">8.5. 
-    Determine the Ancestor Origin availble to a Location </a>
+    Determine the origin serialization available to a Location </a>
     <li><a href="#ref-for-referrer-policy-origin-when-cross-origin-7">10.1. Information Leakage</a>
    </ul>
   </aside>
@@ -2440,7 +2440,7 @@ Possible extra rowspan handling
     <li><a href="#ref-for-referrer-policy-strict-origin-when-cross-origin-4">8.3. 
     Determine request’s Referrer </a>
     <li><a href="#ref-for-referrer-policy-strict-origin-when-cross-origin-5">8.5. 
-    Determine the Ancestor Origin availble to a Location </a>
+    Determine the origin serialization available to a Location </a>
     <li><a href="#ref-for-referrer-policy-strict-origin-when-cross-origin-6">10.1. Information Leakage</a>
    </ul>
   </aside>
@@ -2451,7 +2451,7 @@ Possible extra rowspan handling
     <li><a href="#ref-for-referrer-policy-unsafe-url-3">8.3. 
     Determine request’s Referrer </a>
     <li><a href="#ref-for-referrer-policy-unsafe-url-4">8.5. 
-    Determine the Ancestor Origin availble to a Location </a>
+    Determine the origin serialization available to a Location </a>
     <li><a href="#ref-for-referrer-policy-unsafe-url-5">10.1. Information Leakage</a>
     <li><a href="#ref-for-referrer-policy-unsafe-url-6">10.2. Downgrade to less strict policies</a>
     <li><a href="#ref-for-referrer-policy-unsafe-url-7">11.1. Unknown Policy Values</a> <a href="#ref-for-referrer-policy-unsafe-url-8">(2)</a> <a href="#ref-for-referrer-policy-unsafe-url-9">(3)</a> <a href="#ref-for-referrer-policy-unsafe-url-10">(4)</a>

--- a/index.html
+++ b/index.html
@@ -1,55 +1,319 @@
 <!doctype html><html lang="en">
  <head>
   <meta content="text/html; charset=utf-8" http-equiv="Content-Type">
+  <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport">
   <title>Referrer Policy</title>
-<style data-fill-with="stylesheet">/* This section copied from the W3C's ED styles. */
+<style data-fill-with="stylesheet">/******************************************************************************
+ *                   Style sheet for the W3C specifications                   *
+ *
+ * Special classes handled by this style sheet include:
+ *
+ * Indices
+ *   - .toc for the Table of Contents (<ol class="toc">)
+ *     + <span class="secno"> for the section numbers
+ *   - #toc for the Table of Contents (<nav id="toc">)
+ *   - ul.index for Indices (<a href="#ref">term</a><span>, in §N.M</span>)
+ *   - table.index for Index Tables (e.g. for properties or elements)
+ *
+ * Structural Markup
+ *   - table.data for general data tables
+ *     -> use 'scope' attribute, <colgroup>, <thead>, and <tbody> for best results !
+ *     -> use <table class='complex data'> for extra-complex tables
+ *     -> use <td class='long'> for paragraph-length cell content
+ *     -> use <td class='pre'> when manual line breaks/indentation would help readability
+ *   - dl.switch for switch statements
+ *   - ol.algorithm for algorithms (helps to visualize nesting)
+ *   - .figure and .caption (HTML4) and figure and figcaption (HTML5)
+ *     -> .sidefigure for right-floated figures
+ *   - ins/del
+ *
+ * Code
+ *   - pre and code
+ *
+ * Special Sections
+ *   - .note       for informative notes             (div, p, span, aside, details)
+ *   - .example    for informative examples          (div, p, pre, span)
+ *   - .issue      for issues                        (div, p, span)
+ *   - .advisement for loud normative statements     (div, p, strong)
+ *   - .annoying-warning for spec obsoletion notices (div, aside, details)
+ *
+ * Definition Boxes
+ *   - pre.def   for WebIDL definitions
+ *   - table.def for tables that define other entities (e.g. CSS properties)
+ *   - dl.def    for definition lists that define other entitles (e.g. HTML elements)
+ *
+ * Numbering
+ *   - .secno for section numbers in .toc and headings (<span class='secno'>3.2</span>)
+ *   - .marker for source-inserted example/figure/issue numbers (<span class='marker'>Issue 4</span>)
+ *   - ::before styled for CSS-generated issue/example/figure numbers:
+ *     -> Documents wishing to use this only need to add
+ *        figcaption::before,
+ *        .caption::before { content: "Figure "  counter(figure);  }
+ *        .example::before { content: "Example " counter(example); }
+ *        .issue::before   { content: "Issue "   counter(issue);   }
+ *
+ * Header Stuff (ignore, just don't conflict with these classes)
+ *   - .head for the header
+ *   - .copyright for the copyright
+ *
+ * Miscellaneous
+ *   - .overlarge for things that should be as wide as possible, even if
+ *     that overflows the body text area. This can be used on an item or
+ *     on its container, depending on the effect desired.
+ *     Note that this styling basically doesn't help at all when printing,
+ *     since A4 paper isn't much wider than the max-width here.
+ *     It's better to design things to fit into a narrower measure if possible.
+ *   - js-added ToC jump links (see fixup.js)
+ *
+ ******************************************************************************/
+
+/******************************************************************************/
+/*                                   Body                                     */
+/******************************************************************************/
 
 	body {
-		color: black;
+		counter-reset: example figure issue;
+
+		/* Layout */
+		max-width: 50em;               /* limit line length to 50em for readability   */
+		margin: 0 auto;                /* center text within page                     */
+		padding: 1.6em 1.5em 2em 50px; /* assume 16px font size for downlevel clients */
+		padding: 1.6em 1.5em 2em calc(26px + 1.5em); /* leave space for status flag     */
+
+		/* Typography */
+		line-height: 1.5;
 		font-family: sans-serif;
-		margin: 0 auto;
-		max-width: 50em;
-		padding: 2em 1em 2em 70px;
+		widows: 2;
+		orphans: 2;
+		word-wrap: break-word;
+		overflow-wrap: break-word;
+		hyphens: auto;
+
+		/* Colors */
+		color: black;
+		background: white top left fixed no-repeat;
+		background-size: 25px auto;
 	}
-	:link { color: #00C; background: transparent }
-	:visited { color: #609; background: transparent }
-	a[href]:active { color: #C00; background: transparent }
-	a[href]:hover { background: #ffa }
 
-	a[href] img { border-style: none }
 
-	h1, h2, h3, h4, h5, h6 { text-align: left }
-	h1, h2, h3 { color: #005A9C; }
-	h1 { font: 170% sans-serif }
-	h2 { font: 140% sans-serif }
-	h3 { font: 120% sans-serif }
-	h4 { font: bold 100% sans-serif }
-	h5 { font: italic 100% sans-serif }
-	h6 { font: small-caps 100% sans-serif }
+/******************************************************************************/
+/*                         Front Matter & Navigation                          */
+/******************************************************************************/
 
-	.hide { display: none }
+/** Header ********************************************************************/
 
 	div.head { margin-bottom: 1em }
-	div.head h1 { margin-top: 2em; clear: both }
-	div.head table { margin-left: 2em; margin-top: 2em }
+	div.head hr { border-style: solid; }
 
-	p.copyright { font-size: small }
-	p.copyright small { font-size: small }
-
-	pre { margin-left: 2em }
-	dt { font-weight: bold }
-
-	ul.toc, ol.toc {
-		list-style: none;
+	div.head h1 {
+		font-weight: bold;
+		margin: 0 0 .1em;
+		font-size: 220%;
 	}
 
-/* The rest copied from the CSSWG's default.css */
+	div.head h2 { margin-bottom: 1.5em;}
 
-	body {
-		counter-reset: exampleno figure issue;
-		max-width: 50em;
-		margin: 0 auto !important;
-		line-height: 1.5;
+/** W3C Logo ******************************************************************/
+
+	.head .logo {
+		float: right;
+		margin: 0.4rem 0 0.2rem .4rem;
+	}
+
+	.head img[src*="logos/W3C"] {
+		display: block;
+		border: solid #1a5e9a;
+		border-width: .65rem .7rem .6rem;
+		border-radius: .4rem;
+		background: #1a5e9a;
+		color: white;
+		font-weight: bold;
+	}
+
+	.head a:hover > img[src*="logos/W3C"],
+	.head a:focus > img[src*="logos/W3C"] {
+		opacity: .8;
+	}
+
+	.head a:active > img[src*="logos/W3C"] {
+		background: #c00;
+		border-color: #c00;
+	}
+
+	/* see also additional rules in Link Styling section */
+
+/** Copyright *****************************************************************/
+
+	p.copyright,
+	p.copyright small { font-size: small }
+
+/** Back to Top / ToC Toggle **************************************************/
+
+	@media print {
+		#toc-nav {
+			display: none;
+		}
+	}
+	@media not print {
+		#toc-nav {
+			position: fixed;
+			z-index: 2;
+			bottom: 0; left: 0;
+			margin: 0;
+			min-width: 1.33em;
+			border-top-right-radius: 2rem;
+			box-shadow: 0 0 2px;
+			font-size: 1.5em;
+			color: black;
+		}
+		#toc-nav > a {
+			display: block;
+			white-space: nowrap;
+
+			height: 1.33em;
+			padding: .1em 0.3em;
+			margin: 0;
+
+			background: white;
+			box-shadow: 0 0 2px;
+			border: none;
+			border-top-right-radius: 1.33em;
+			background: white;
+		}
+		#toc-nav > #toc-jump {
+			padding-bottom: 2em;
+			margin-bottom: -1.9em;
+		}
+
+		#toc-nav > a:hover,
+		#toc-nav > a:focus {
+			background: #f8f8f8;
+		}
+		#toc-nav > a:not(:hover):not(:focus) {
+			color: #707070;
+		}
+
+		/* statusbar gets in the way on keyboard focus; remove once browsers fix */
+		#toc-nav > a[href="#toc"]:not(:hover):focus:last-child {
+			padding-bottom: 1.5rem;
+		}
+
+		#toc-nav:not(:hover) > a:not(:focus) > span + span {
+			/* Ideally this uses :focus-within on #toc-nav */
+			display: none;
+		}
+		#toc-nav > a > span + span {
+			padding-right: 0.2em;
+		}
+
+		#toc-toggle-inline {
+			vertical-align: 0.05em;
+			font-size: 80%;
+			color: gray;
+			color: hsla(203,20%,40%,.7);
+			border-style: none;
+			background: transparent;
+			position: relative;
+		}
+		#toc-toggle-inline:hover:not(:active),
+		#toc-toggle-inline:focus:not(:active) {
+			text-shadow: 1px 1px silver;
+			top: -1px;
+			left: -1px;
+		}
+
+		#toc-nav :active {
+			color: #C00;
+		}
+	}
+
+/** ToC Sidebar ***************************************************************/
+
+	/* Floating sidebar */
+	@media screen {
+		body.toc-sidebar #toc {
+			position: fixed;
+			top: 0; bottom: 0;
+			left: 0;
+			width: 23.5em;
+			max-width: 80%;
+			max-width: calc(100% - 2em - 26px);
+			overflow: auto;
+			padding: 0 1em;
+			padding-left: 42px;
+			padding-left: calc(1em + 26px);
+			background: inherit;
+			background-color: #f7f8f9;
+			z-index: 1;
+			box-shadow: -.1em 0 .25em rgba(0,0,0,.1) inset;
+		}
+		body.toc-sidebar #toc h2 {
+			margin-top: .8rem;
+			font-variant: small-caps;
+			font-variant: all-small-caps;
+			text-transform: lowercase;
+			font-weight: bold;
+			color: gray;
+			color: hsla(203,20%,40%,.7);
+		}
+		body.toc-sidebar #toc-jump:not(:focus) {
+			width: 0;
+			height: 0;
+			padding: 0;
+			position: absolute;
+			overflow: hidden;
+		}
+	}
+	/* Hide main scroller when only the ToC is visible anyway */
+	@media screen and (max-width: 28em) {
+		body.toc-sidebar {
+			overflow: hidden;
+		}
+	}
+
+	/* Sidebar with its own space */
+	@media screen and (min-width: 78em) {
+		body:not(.toc-inline) #toc {
+			position: fixed;
+			top: 0; bottom: 0;
+			left: 0;
+			width: 23.5em;
+			overflow: auto;
+			padding: 0 1em;
+			padding-left: 42px;
+			padding-left: calc(1em + 26px);
+			background: inherit;
+			background-color: #f7f8f9;
+			z-index: 1;
+			box-shadow: -.1em 0 .25em rgba(0,0,0,.1) inset;
+		}
+		body:not(.toc-inline) #toc h2 {
+			margin-top: .8rem;
+			font-variant: small-caps;
+			font-variant: all-small-caps;
+			text-transform: lowercase;
+			font-weight: bold;
+			color: gray;
+			color: hsla(203,20%,40%,.7);
+		}
+
+		body:not(.toc-inline) {
+			padding-left: 29em;
+		}
+		/* See also Overflow section at the bottom */
+
+		body:not(.toc-inline) #toc-jump:not(:focus) {
+			width: 0;
+			height: 0;
+			padding: 0;
+			position: absolute;
+			overflow: hidden;
+		}
+	}
+	@media screen and (min-width: 90em) {
+		body:not(.toc-inline) {
+			margin: 0 4em;
+		}
 	}
 
 /******************************************************************************/
@@ -60,19 +324,34 @@
 
 	h1, h2, h3, h4, h5, h6, dt {
 		page-break-after: avoid;
+		page-break-inside: avoid;
+		font: 100% sans-serif;   /* Reset all font styling to clear out UA styles */
+		font-family: inherit;    /* Inherit the font family. */
+		line-height: 1.2;        /* Keep wrapped headings compact */
+		hyphens: manual;         /* Hyphenated headings look weird */
 	}
 
-	h2, h3, h5, h6 {
-		margin-top: 3em;
+	h2, h3, h4, h5, h6 {
+		margin-top: 3rem;
 	}
-	h4 {
-		 margin-top: 4em;
+
+	h1, h2, h3 {
+		color: #005A9C;
+		background: transparent;
 	}
+
+	h1 { font-size: 170%; }
+	h2 { font-size: 140%; }
+	h3 { font-size: 120%; }
+	h4 { font-weight: bold; }
+	h5 { font-style: italic; }
+	h6 { font-variant: small-caps; }
+	dt { font-weight: bold; }
 
 /** Subheadings ***************************************************************/
 
 	h1 + h2,
-	#subtitle + h2 {
+	#subtitle {
 		/* #subtitle is a subtitle in an H2 under the H1 */
 		margin-top: 0;
 	}
@@ -84,8 +363,8 @@
 	}
 
 /** Section divider ***********************************************************/
-	/* <hr> used to separate TMI into the second half of a section              */
-	hr:not([title]) {
+
+	:not(.head) > hr {
 		font-size: 1.5em;
 		text-align: center;
 		margin: 1em auto;
@@ -93,10 +372,9 @@
 		border: transparent solid 0;
 		background: transparent;
 	}
-	hr:not([title])::before {
-		content: "\1F411\2003\2003\1F411\2003\2003\1F411";
+	:not(.head) > hr::before {
+		content: "\2727\2003\2003\2727\2003\2003\2727";
 	}
-	/* note: <hr> with title separates document header from contents */
 
 /******************************************************************************/
 /*                            Paragraphs and Lists                            */
@@ -105,8 +383,9 @@
 	p {
 		margin: 1em 0;
 	}
-	dd     > p:first-child,
-	li     > p:first-child {
+
+	dd > p:first-child,
+	li > p:first-child {
 		margin-top: 0;
 	}
 
@@ -114,33 +393,33 @@
 		margin-left: 0;
 		padding-left: 2em;
 	}
+
 	li {
-		margin: 0.25em 2em 0.5em 0;
-		padding-left: 0;
+		margin: 0.25em 0 0.5em;
+		padding: 0;
 	}
 
 	dl dd {
-		margin: 0 0 1em 2em;
+		margin: 0 0 .5em 2em;
 	}
-	.head dd {
-		margin-bottom: 0;
+
+	.head dd + dd { /* compact for header */
+		margin-top: -.5em;
 	}
 
 	/* Style for algorithms */
-	ol.algorithm ol {
-	 border-left: 1px solid #90b8de;
-	 margin-left: 1em;
-	}
-	ol.algorithm ol.algorithm {
-	 border-left: none;
-	 margin-left: 0;
+	ol.algorithm ol:not(.algorithm),
+	.algorithm > ol ol:not(.algorithm) {
+	 border-left: 0.5em solid #DEF;
 	}
 
 	/* Style for switch/case <dl>s */
-	dl.switch > dd > ol.only {
+	dl.switch > dd > ol.only,
+	dl.switch > dd > .only > ol {
 	 margin-left: 0;
 	}
-	dl.switch > dd > ol.algorithm {
+	dl.switch > dd > ol.algorithm,
+	dl.switch > dd > .algorithm > ol {
 	 margin-left: -2em;
 	}
 	dl.switch {
@@ -160,32 +439,6 @@
 	 width: 1em;
 	 text-align: right;
 	 line-height: 0.5em;
-	}
-
-	/* Style for paragraphs I know are in MD-genned lists */
-	[data-md] > :first-child {
-		margin-top: 0;
-	}
-	[data-md] > :last-child {
-		margin-bottom: 0;
-	}
-
-/** Inline Lists **************************************************************/
-	/* This is mostly to make the list inside the CR exit criteria more compact. */
-
-	ol.inline, ol.inline li {
-		display: inline;
-		padding: 0; margin: 0;
-	}
-	ol.inline {
-		counter-reset: list-item;
-	}
-	ol.inline li {
-		counter-increment: list-item;
-	}
-	ol.inline li::before {
-		content: "(" counter(list-item) ") ";
-		font-weight: bold;
 	}
 
 /** Terminology Markup ********************************************************/
@@ -227,129 +480,27 @@
 
 /** General monospace/pre rules ***********************************************/
 
-	pre, code {
-		font-family: Menlo, Consolas, "DejaVu Sans Mono", monospace;
+	pre, code, samp {
+		font-family: Menlo, Consolas, "DejaVu Sans Mono", Monaco, monospace;
 		font-size: .9em;
 		page-break-inside: avoid;
+		hyphens: none;
+		text-transform: none;
 	}
+	pre code,
+	code code {
+		font-size: 100%;
+	}
+
 	pre {
 		margin-top: 1em;
 		margin-bottom: 1em;
 		overflow: auto;
 	}
 
-/** Syntax-Highlighted Code ***************************************************/
+/** Inline Code fragments *****************************************************/
 
-	.example pre[class*="language-"],
-	.example [class*="language-"] pre,
-	.example pre[class*="lang-"],
-	.example [class*="lang-"] pre {
-		background: transparent; /* Prism applies a gray background that doesn't work well in the template. */
-	}
-
-/** Example Code **************************************************************/
-
-	div.html, div.xml,
-	pre.html, pre.xml {
-		padding: 0.5em;
-		margin: 1em 0;
-		position: relative;
-		clear: both;
-		color: #600;
-	}
-	pre.example,
-	pre.html,
-	pre.xml {
-		padding-top: 1.5em;
-	}
-
-	pre.illegal, .illegal pre
-	pre.deprecated, .deprecated pre {
-		color: red;
-	}
-
-/** IDL fragments *************************************************************/
-
-	pre.idl {
-		/* Match blue propdef boxes */
-		padding: .5em 1em;
-		background: #DEF;
-		margin: 1.2em 0;
-		border-left: 0.5em solid #8CCBF2;
-	}
-	pre.idl :link, pre.idl :visited {
-		color:inherit;
-		background:transparent;
-	}
-
-/** Inline CSS fragments ******************************************************/
-
-	.css.css, .property.property, .descriptor.descriptor {
-		color: #005a9c;
-		font-size: inherit;
-		font-family: inherit;
-	}
-	.css::before, .property::before, .descriptor::before {
-		content: "‘";
-	}
-	.css::after, .property::after, .descriptor::after {
-		content: "’";
-	}
-	.property, .descriptor {
-		/* Don't wrap property and descriptor names */
-		white-space: nowrap;
-	}
-	.type { /* CSS value <type> */
-	font-style: italic;
-	}
-	pre .property::before, pre .property::after {
-		content: "";
-	}
-
-/** Inline markup fragments ***************************************************/
-
-	code.html, code.xml {
-		color: #660000;
-	}
-
-/** Autolinks produced using Bikeshed *****************************************/
-
-	[data-link-type="property"]::before,
-	[data-link-type="propdesc"]::before,
-	[data-link-type="descriptor"]::before,
-	[data-link-type="value"]::before,
-	[data-link-type="function"]::before,
-	[data-link-type="at-rule"]::before,
-	[data-link-type="selector"]::before,
-	[data-link-type="maybe"]::before {
-		content: "‘";
-	}
-	[data-link-type="property"]::after,
-	[data-link-type="propdesc"]::after,
-	[data-link-type="descriptor"]::after,
-	[data-link-type="value"]::after,
-	[data-link-type="function"]::after,
-	[data-link-type="at-rule"]::after,
-	[data-link-type="selector"]::after,
-	[data-link-type="maybe"]::after {
-		content: "’";
-	}
-
-	[data-link-type].production::before,
-	[data-link-type].production::after,
-	.prod [data-link-type]::before,
-	.prod [data-link-type]::after {
-		content: "";
-	}
-
-	[data-link-type=element]         { font-family: monospace; }
-	[data-link-type=element]::before { content: "<" }
-	[data-link-type=element]::after  { content: ">" }
-
-	[data-link-type=biblio] {
-		white-space: pre;
-	}
-
+  /* Do something nice. */
 
 /******************************************************************************/
 /*                                    Links                                   */
@@ -358,75 +509,38 @@
 /** General Hyperlinks ********************************************************/
 
 	/* We hyperlink a lot, so make it less intrusive */
-	a:link, a:visited {
-		color: inherit;
+	a[href] {
+		color: #034575;
 		text-decoration: none;
-		border-bottom: 1px solid silver;
+		border-bottom: 1px solid #707070;
+		/* Need a bit of extending for it to look okay */
+		padding: 0 1px 0;
+		margin: 0 -1px 0;
 	}
-	@supports (text-decoration-color: silver) {
-		a:link, a:visited {
-			border-bottom: none;
-			text-decoration: underline;
-			text-decoration-color: silver;
-		}
-		a:visited {
-			text-decoration-style: dotted;
-		}
+	a:visited {
+		border-bottom-color: #BBB;
 	}
 
-	a.logo:link, a.logo:visited { /* backout above styling for W3C logo */
-		padding: 0;
+	/* Use distinguishing colors when user is interacting with the link */
+	a[href]:focus,
+	a[href]:hover {
+		background: #f8f8f8;
+		background: rgba(75%, 75%, 75%, .25);
+		border-bottom-width: 3px;
+		margin-bottom: -2px;
+	}
+	a[href]:active {
+		color: #C00;
+		border-color: #C00;
+	}
+
+	/* Backout above styling for W3C logo */
+	.head .logo,
+	.head .logo a {
 		border: none;
 		text-decoration: none;
+		background: transparent;
 	}
-
-/** Self-Links ****************************************************************/
-	/* Auto-generated links from an element to its own anchor, for usability */
-
-	.heading, .issue, .note, .example, li, dt {
-		position: relative;
-	}
-	a.self-link {
-		position: absolute;
-		top: 0;
-		left: -2.5em;
-		width: 2em;
-		height: 2em;
-		text-align: center;
-		border: none;
-		transition: opacity .2s;
-		opacity: .5;
-	}
-	a.self-link:hover {
-		opacity: 1;
-	}
-	.heading > a.self-link {
-		font-size: 83%;
-	}
-	li > a.self-link {
-		left: -3.5em;
-	}
-	dfn > a.self-link {
-		top: auto;
-		left: auto;
-		opacity: 0;
-		width: 1.5em;
-		height: 1.5em;
-		background: gray;
-		color: white;
-		font-style: normal;
-		transition: opacity .2s, background-color .2s, color .2s;
-	}
-	dfn:hover > a.self-link {
-		opacity: 1;
-	}
-	dfn > a.self-link:hover {
-		color: black;
-	}
-
-	a.self-link::before            { content: "¶"; }
-	.heading > a.self-link::before { content: "§"; }
-	dfn > a.self-link::before      { content: "#"; }
 
 /******************************************************************************/
 /*                                    Images                                  */
@@ -436,15 +550,21 @@
 		border-style: none;
 	}
 
-	figure, div.figure, div.sidefigure {
-		page-break-inside: avoid;
-	}
+	/* For autogen numbers, add
+	   .caption::before, figcaption::before { content: "Figure " counter(figure) ". "; }
+	*/
 
-	div.figure, p.figure, div.sidefigure, figure {
+	figure, .figure, .sidefigure {
+		page-break-inside: avoid;
 		text-align: center;
 		margin: 2.5em 0;
 	}
-	div.figure pre, div.sidefigure pre, figure pre {
+	.figure img,    .sidefigure img,    figure img,
+	.figure object, .sidefigure object, figure object {
+		max-width: 100%;
+		margin: auto;
+	}
+	.figure pre, .sidefigure pre, figure pre {
 		text-align: left;
 		display: table;
 		margin: 1em auto;
@@ -452,55 +572,32 @@
 	.figure table, figure table {
 		margin: auto;
 	}
-	div.sidefigure, figure.sidefigure {
-		float: right;
-		width: 50%;
-		margin: 0 0 0.5em 0.5em
+	@media screen and (min-width: 20em) {
+		.sidefigure {
+			float: right;
+			width: 50%;
+			margin: 0 0 0.5em 0.5em
+		}
 	}
-	div.figure img, div.sidefigure img, figure img,
-	div.figure object, div.sidefigure object, figure object {
-		display: block;
-		margin: auto;
-		max-width: 100%
-	}
-	p.caption, figcaption, caption {
-		text-align: center;
+	.caption, figcaption, caption {
 		font-style: italic;
 		font-size: 90%;
 	}
-	p.caption:not(.no-marker)::before, figcaption:not(.no-marker)::before {
-		content: "Figure " counter(figure) ". ";
-	}
-	p.caption::before, figcaption::before, figcaption > .marker {
+	.caption::before, figcaption::before, figcaption > .marker {
 		font-weight: bold;
 	}
-	p.caption, figcaption {
+	.caption, figcaption {
 		counter-increment: figure;
 	}
 
 	/* DL list is indented 2em, but figure inside it is not */
-	dd > div.figure, dd > figure { margin-left: -2em }
-
-	pre.ascii-art {
-		display: table; /* shrinkwrap */
-		margin: 1em auto;
-	}
-
-	/* Displaying the output of text layout, particularly when
-		 line-breaking is being invoked, and thus having a
-		 visible width is good. */
-	pre.output {
-		margin: 1em;
-		border: solid thin silver;
-		padding: 0.25em;
-		display: table;
-	}
+	dd > .figure, dd > figure { margin-left: -2em }
 
 /******************************************************************************/
 /*                             Colored Boxes                                  */
 /******************************************************************************/
 
-	.issue, .note, .example, .why, .advisement, blockquote {
+	.issue, .note, .example, .advisement, blockquote {
 		padding: .5em;
 		border: .5em;
 		border-left-style: solid;
@@ -511,10 +608,10 @@
 		border-right-style: solid;
 	}
 
-	div.issue,
-	div.note,
-	div.example,
-	details.why,
+	.issue,
+	.note,
+	.example,
+	.advisement,
 	blockquote {
 		margin: 1em auto;
 	}
@@ -534,7 +631,6 @@
 	}
 
 /** Open issue ****************************************************************/
-	/* not intended for CR+ publication */
 
 	.issue {
 		border-color: #E05252;
@@ -542,53 +638,57 @@
 		counter-increment: issue;
 		overflow: auto;
 	}
-	.issue:not(.no-marker)::before {
-		content: "ISSUE " counter(issue);
-		padding-right: 1em;
-	}
 	.issue::before, .issue > .marker {
+		text-transform: uppercase;
 		color: #AE1E1E;
+		padding-right: 1em;
+		text-transform: uppercase;
 	}
+	/* Add .issue::before { content: "Issue " counter(issue); } for autogen numbers,
+	   or use class="marker" to mark up the issue number in source. */
 
 /** Example *******************************************************************/
 
 	.example {
 		border-color: #E0CB52;
 		background: #FCFAEE;
-		counter-increment: exampleno;
+		counter-increment: example;
 		overflow: auto;
 		clear: both;
 	}
 	.example::before, .example > .marker {
+		text-transform: uppercase;
 		color: #827017;
-		font-family: sans-serif;
 		min-width: 7.5em;
 		display: block;
 	}
-	.example:not(.no-marker)::before {
-		content: "EXAMPLE";
-		content: "EXAMPLE " counter(exampleno);
-	}
-	.invalid.example::before, .invalid.example > .marker,
-	.illegal.example::before, .illegal.example > .marker {
-		color: red;
-	}
-	.invalid.example:not(.no-marker)::before,
-	.illegal.example:not(.no-marker)::before {
-		content: "INVALID EXAMPLE";
-		content: "INVALID EXAMPLE" counter(exampleno);
-	}
+	/* Add .example::before { content: "Example " counter(example); } for autogen numbers,
+	   or use class="marker" to mark up the example number in source. */
 
 /** Non-normative Note ********************************************************/
 
-	.note, .why {
+	.note {
 		border-color: #52E052;
 		background: #E9FBE9;
 		overflow: auto;
 	}
-	.note::before, .note > .marker {
+
+	.note::before, .note > .marker,
+	details.note > summary::before,
+	details.note > summary > .marker {
+		text-transform: uppercase;
 		display: block;
 		color: hsl(120, 70%, 30%);
+	}
+	/* Add .note::before { content: "Note"; } for autogen label,
+	   or use class="marker" to mark up the label in source. */
+
+	details.note > summary {
+		display: block;
+		color: hsl(120, 70%, 30%);
+	}
+	details.note[open] > summary {
+		border-bottom: 1px silver solid;
 	}
 
 /** Advisement Box ************************************************************/
@@ -598,46 +698,40 @@
 		border-color: orange;
 		border-style: none solid;
 		background: #FFEECC;
-		text-align: center;
 	}
 	strong.advisement {
 		display: block;
+		text-align: center;
 	}
-	/*.advisement::before { color: #FF8800; } */
-
-/** ??? ***********************************************************************/
-
-	details.why {
-		border-color: #52E052;
-		background: #E9FBE9;
-		display: block;
-	}
-
-	details.why > summary {
-		font-style: italic;
-		display: block;
-	}
-
-	details.why[open] > summary {
-		border-bottom: 1px silver solid;
+	.advisement > .marker {
+		color: #B35F00;
 	}
 
 /** Spec Obsoletion Notice ****************************************************/
 	/* obnoxious obsoletion notice for older/abandoned specs. */
 
-	details.annoying-warning {
+	details {
 		display: block;
 	}
+	summary {
+		font-weight: bolder;
+	}
 
+	.annoying-warning:not(details),
+	details.annoying-warning:not([open]) > summary,
 	details.annoying-warning[open] {
 		background: #fdd;
 		color: red;
 		font-weight: bold;
-		text-align: center;
-		padding: .5em;
-		border: thick solid red;
+		padding: .75em 1em;
+		border: thick red;
+		border-style: solid;
 		border-radius: 1em;
 	}
+	.annoying-warning :last-child {
+		margin-bottom: 0;
+	}
+
 @media not print {
 	details.annoying-warning[open] {
 		position: fixed;
@@ -649,57 +743,52 @@
 }
 
 	details.annoying-warning:not([open]) > summary {
-		background: #fdd;
-		color: red;
-		font-weight: bold;
 		text-align: center;
-		padding: .5em;
+	}
+
+/** Entity Definition Boxes ***************************************************/
+
+	.def {
+		padding: .5em 1em;
+		background: #DEF;
+		margin: 1.2em 0;
+		border-left: 0.5em solid #8CCBF2;
 	}
 
 /******************************************************************************/
 /*                                    Tables                                  */
 /******************************************************************************/
 
+	th, td {
+		text-align: left;
+		text-align: start;
+	}
+
 /** Property/Descriptor Definition Tables *************************************/
 
-	table.propdef, table.propdef-extra,
-	table.descdef, table.definition-table {
-		page-break-inside: avoid;
+	table.def {
+		/* inherits .def box styling, see above */
 		width: 100%;
-		margin: 1.2em 0;
-		border-left: 0.5em solid #8CCBF2;
-		padding: 0.5em 1em;
-		background: #DEF;
 		border-spacing: 0;
 	}
 
-	table.propdef td, table.propdef-extra td,
-	table.descdef td, table.definition-table td,
-	table.propdef th, table.propdef-extra th,
-	table.descdef th, table.definition-table th {
+	table.def td,
+	table.def th {
 		padding: 0.5em;
 		vertical-align: baseline;
 		border-bottom: 1px solid #bbd7e9;
 	}
-	table.propdef > tbody > tr:last-child th,
-	table.propdef-extra > tbody > tr:last-child th,
-	table.descdef > tbody > tr:last-child th,
-	table.definition-table > tbody > tr:last-child th,
-	table.propdef > tbody > tr:last-child td,
-	table.propdef-extra > tbody > tr:last-child td,
-	table.descdef > tbody > tr:last-child td,
-	table.definition-table > tbody > tr:last-child td {
+
+	table.def > tbody > tr:last-child th,
+	table.def > tbody > tr:last-child td {
 		border-bottom: 0;
 	}
 
-	table.propdef th,
-	table.propdef-extra th,
-	table.descdef th,
-	table.definition-table th {
+	table.def th {
 		font-style: italic;
 		font-weight: normal;
-		width: 8.3em;
 		padding-left: 1em;
+		width: 3em;
 	}
 
 	/* For when values are extra-complex and need formatting for readability */
@@ -707,17 +796,11 @@
 		white-space: pre-wrap;
 	}
 
-	/* A footnote at the bottom of a propdef */
-	table.propdef td.footnote,
-	table.propdef-extra td.footnote,
-	table.descdef td.footnote,
-	table.definition-table td.footnote {
+	/* A footnote at the bottom of a def table */
+	table.def           td.footnote {
 		padding-top: 0.6em;
 	}
-	table.propdef td.footnote::before,
-	table.propdef-extra td.footnote::before,
-	table.descdef td.footnote::before,
-	table.definition-table td.footnote::before {
+	table.def           td.footnote::before {
 		content: " ";
 		display: block;
 		height: 0.6em;
@@ -725,22 +808,7 @@
 		border-top: thin solid;
 	}
 
-/** Profile Tables ************************************************************/
-	/* table of required features in a CSS profile */
-
-	table.features th {
-		background: #00589f;
-		color: #fff;
-		text-align: left;
-		padding: 0.2em 0.2em 0.2em 0.5em;
-	}
-	table.features td {
-		vertical-align: top;
-		border-bottom: 1px solid #ccc;
-		padding: 0.3em 0.3em 0.3em 0.7em;
-	}
-
-/** Data tables (and properly marked-up proptables) ***************************/
+/** Data tables (and properly marked-up index tables) *************************/
 	/*
 		 <table class="data"> highlights structural relationships in a table
 		 when correct markup is used (e.g. thead/tbody, th vs. td, scope attribute)
@@ -750,89 +818,117 @@
 
 		 Use class="long" on table cells with paragraph-like contents
 		 (This will adjust text alignment accordingly.)
+		 Alternately use class="longlastcol" on tables, to have the last column assume "long".
 	*/
 
-	.data, .proptable {
-		margin: 1em auto;
-		border-collapse: collapse;
-		width: 100%;
-		border: hidden;
-	}
-	.data {
-		text-align: center;
-		width: auto;
-	}
-	.data caption {
-		width: 100%;
+	table {
+		word-wrap: normal;
+		overflow-wrap: normal;
+		hyphens: manual;
 	}
 
-	.data td, .data th,
-	.proptable td, .proptable th {
-		padding: 0.5em;
+	table.data,
+	table.index {
+		margin: 1em auto;
+		border-collapse: collapse;
+		border: hidden;
+		width: 100%;
+	}
+	table.data caption,
+	table.index caption {
+		max-width: 50em;
+		margin: 0 auto 1em;
+	}
+
+	table.data td,  table.data th,
+	table.index td, table.index th {
+		padding: 0.5em 1em;
 		border-width: 1px;
 		border-color: silver;
 		border-top-style: solid;
 	}
 
-	.data thead td:empty {
+	table.data thead td:empty {
 		padding: 0;
 		border: 0;
 	}
 
-	.data thead th[scope="row"],
-	.proptable thead th[scope="row"] {
-		text-align: right;
-		color: inherit;
-	}
-
-	.data thead,
-	.proptable thead,
-	.data tbody,
-	.proptable tbody {
-		color: inherit;
+	table.data  thead,
+	table.index thead,
+	table.data  tbody,
+	table.index tbody {
 		border-bottom: 2px solid;
 	}
 
-	.data colgroup {
+	table.data colgroup,
+	table.index colgroup {
 		border-left: 2px solid;
 	}
 
-	.data tbody th:first-child,
-	.proptable tbody th:first-child ,
-	.data tbody td[scope="row"]:first-child,
-	.proptable tbody td[scope="row"]:first-child {
-		text-align: right;
-		color: inherit;
+	table.data  tbody th:first-child,
+	table.index tbody th:first-child  {
 		border-right: 2px solid;
 		border-top: 1px solid silver;
 		padding-right: 1em;
 	}
-	.data.define td:last-child {
-		text-align: left;
+
+	table.data th[colspan],
+	table.data td[colspan] {
+		text-align: center;
 	}
 
-	.data tbody th[rowspan],
-	.proptable tbody th[rowspan],
-	.data tbody td[rowspan],
-	.proptable tbody td[rowspan]{
-		border-left:  1px solid silver;
-		border-right: 1px solid silver;
-	}
-
-	.complex.data th,
-	.complex.data td {
+	table.complex.data th,
+	table.complex.data td {
 		border: 1px solid silver;
+		text-align: center;
 	}
 
-	.data td.long {
+	table.data.longlastcol td:last-child,
+	table.data td.long {
 	 vertical-align: baseline;
 	 text-align: left;
 	}
 
-	.data img {
+	table.data img {
 		vertical-align: middle;
 	}
 
+
+/*
+Alternate table alignment rules
+
+	table.data,
+	table.index {
+		text-align: center;
+	}
+
+	table.data  thead th[scope="row"],
+	table.index thead th[scope="row"] {
+		text-align: right;
+	}
+
+	table.data  tbody th:first-child,
+	table.index tbody th:first-child  {
+		text-align: right;
+	}
+
+Possible extra rowspan handling
+
+	table.data  tbody th[rowspan]:not([rowspan='1']),
+	table.index tbody th[rowspan]:not([rowspan='1']),
+	table.data  tbody td[rowspan]:not([rowspan='1']),
+	table.index tbody td[rowspan]:not([rowspan='1']) {
+		border-left: 1px solid silver;
+	}
+
+	table.data  tbody th[rowspan]:first-child,
+	table.index tbody th[rowspan]:first-child,
+	table.data  tbody td[rowspan]:first-child,
+	table.index tbody td[rowspan]:first-child{
+		border-left: 0;
+		border-right: 1px solid silver;
+	}
+*/
 
 /******************************************************************************/
 /*                                  Indices                                   */
@@ -841,97 +937,116 @@
 
 /** Table of Contents *********************************************************/
 
-	/* ToC not indented, but font style shows hierarchy */
-	ul.toc           { margin: 1em 0;     font-weight: bold; /*text-transform: uppercase;*/ }
-	ul.toc ul        { margin: 0;        font-weight: normal; text-transform: none; }
-	ul.toc ul ul     { margin: 0 0 0 2em; font-style: italic; }
-	ul.toc ul ul ul  { margin: 0; }
-	ul.toc > li      { margin: 1.5em 0; }
-	ul.toc ul.toc li { margin: 0.3em 0 0 0; }
-
-	ul.toc, ul.toc ul, ul.toc li { padding: 0; line-height: 1.3; }
-	ul.toc a { text-decoration: none; border-bottom-style: none; }
-	ul.toc a:hover, ul.toc a:focus  { border-bottom-style: solid; }
-	@supports (text-decoration-style: solid) {
-		ul.toc a:hover, ul.toc a:focus  {
-			border-bottom-style: none;
-			text-decoration-style: solid;
-		}
+	.toc a {
+		/* More spacing; use padding to make it part of the click target. */
+		padding-top: 0.1rem;
+		/* Larger, more consistently-sized click target */
+		display: block;
+		/* Reverse color scheme */
+		color: black;
+		border-color: #3980B5;
 	}
-	/*
-	ul.toc li li li, ul.toc li li li ul {margin-left: 0; display: inline}
-	ul.toc li li li ul, ul.toc li li li ul li {margin-left: 0; display: inline}
-	*/
+	.toc a:visited {
+		border-color: #054572;
+	}
+	.toc a:not(:focus):not(:hover) {
+		/* Allow colors to cascade through from link styling */
+		border-bottom-color: transparent;
+	}
+
+	.toc, .toc ol, .toc ul, .toc li {
+		list-style: none; /* Numbers must be inlined into source */
+		/* because generated content isn't search/selectable and markers can't do multilevel yet */
+		margin:  0;
+		padding: 0;
+		line-height: 1.1rem; /* consistent spacing */
+	}
+
+	/* ToC not indented until third level, but font style & margins show hierarchy */
+	.toc > li             { font-weight: bold;   }
+	.toc > li li          { font-weight: normal; }
+	.toc > li li li       { font-size:   95%;    }
+	.toc > li li li li    { font-size:   90%;    }
+	.toc > li li li li li { font-size:   85%;    }
+
+	.toc > li             { margin: 1.5rem 0;    }
+	.toc > li li          { margin: 0.3rem 0;    }
+	.toc > li li li       { margin-left: 2rem;   }
 
 	/* Section numbers in a column of their own */
-	ul.toc {
-		margin-left: 5em
-	}
-	ul.toc span.secno {
+	.toc .secno {
 		float: left;
-		width: 4em;
-		margin-left: -5em;
+		width: 4rem;
+		white-space: nowrap;
 	}
-	ul.toc ul ul span.secno {
-		margin-left: -7em;
+	.toc > li li li li .secno {
+		font-size: 85%;
 	}
-	/*ul.toc span.secno {text-align: right}*/
-	ul.toc li {
+	.toc > li li li li li .secno {
+		font-size: 100%;
+	}
+
+	:not(li) > .toc              { margin-left:  5rem; }
+	.toc .secno                  { margin-left: -5rem; }
+	.toc > li li li .secno       { margin-left: -7rem; }
+	.toc > li li li li .secno    { margin-left: -9rem; }
+	.toc > li li li li li .secno { margin-left: -11rem; }
+
+	/* Tighten up indentation in narrow ToCs */
+	@media (max-width: 30em) {
+		:not(li) > .toc              { margin-left:  4rem; }
+		.toc .secno                  { margin-left: -4rem; }
+		.toc > li li li              { margin-left:  1rem; }
+		.toc > li li li .secno       { margin-left: -5rem; }
+		.toc > li li li li .secno    { margin-left: -6rem; }
+		.toc > li li li li li .secno { margin-left: -7rem; }
+	}
+	@media screen and (min-width: 78em) {
+		body:not(.toc-inline) :not(li) > .toc              { margin-left:  4rem; }
+		body:not(.toc-inline) .toc .secno                  { margin-left: -4rem; }
+		body:not(.toc-inline) .toc > li li li              { margin-left:  1rem; }
+		body:not(.toc-inline) .toc > li li li .secno       { margin-left: -5rem; }
+		body:not(.toc-inline) .toc > li li li li .secno    { margin-left: -6rem; }
+		body:not(.toc-inline) .toc > li li li li li .secno { margin-left: -7rem; }
+	}
+	body.toc-sidebar #toc :not(li) > .toc              { margin-left:  4rem; }
+	body.toc-sidebar #toc .toc .secno                  { margin-left: -4rem; }
+	body.toc-sidebar #toc .toc > li li li              { margin-left:  1rem; }
+	body.toc-sidebar #toc .toc > li li li .secno       { margin-left: -5rem; }
+	body.toc-sidebar #toc .toc > li li li li .secno    { margin-left: -6rem; }
+	body.toc-sidebar #toc .toc > li li li li li .secno { margin-left: -7rem; }
+
+	.toc li {
 		clear: both;
 	}
-	/* If we had 'tab', floats would not be needed here:
-		 ul.toc span.secno {tab: 5em right; margin-right: 1em}
-		 ul.toc li {text-indent: 5em hanging}
-	 The second line in case items wrap
-	*/
 
-/** At-risk List **************************************************************/
-	/* Style for At Risk features (intended as editorial aid, not intended for publishing) */
-
-	.atrisk::before {
-	 float: right;
-	 margin-top: -0.25em;
-	 padding: 0.5em 1em 0.5em 0;
-	 text-indent: -0.9em;
-	 border: 1px solid;
-	 content: '\25C0    Not yet widely implemented';
-	 white-space: pre;
-	 font-size: small;
-	 background-color: white;
-	 color: gray;
-	 text-align: center;
-	}
-
-	.toc .atrisk::before { content:none }
 
 /** Index *********************************************************************/
 
 	/* Index Lists: Layout */
-	ul.indexlist       { margin-left: 0; columns: 15em; -webkit-columns: 15em; text-indent: 1em hanging; }
-	ul.indexlist li    { margin-left: 0; list-style: none; break-inside: avoid; word-break: break-word; }
-	ul.indexlist li li { margin-left: 1em }
-	ul.indexlist dl    { margin-top: 0; }
-	ul.indexlist dt    { margin: .2em 0 .2em 20px;}
-	ul.indexlist dd    { margin: .2em 0 .2em 40px;}
+	ul.index       { margin-left: 0; columns: 15em; text-indent: 1em hanging; }
+	ul.index li    { margin-left: 0; list-style: none; break-inside: avoid; }
+	ul.index li li { margin-left: 1em }
+	ul.index dl    { margin-top: 0; }
+	ul.index dt    { margin: .2em 0 .2em 20px;}
+	ul.index dd    { margin: .2em 0 .2em 40px;}
 	/* Index Lists: Typography */
-	ul.indexlist ul,
-	ul.indexlist dl { font-size: smaller; }
-	ul.indexlist li span {
-		white-space: nowrap;
-		position: absolute;
-		color: transparent; }
-	ul.indexlist li a:hover + span,
-	ul.indexlist li a:focus + span {
-		color: gray;
-	}
-	@media print {
-		ul.indexlist li span { color: gray; }
+	ul.index ul,
+	ul.index dl { font-size: smaller; }
+	@media not print {
+		ul.index li span {
+			white-space: nowrap;
+			color: transparent; }
+		ul.index li a:hover + span,
+		ul.index li a:focus + span {
+			color: #707070;
+		}
 	}
 
-/** Property Index Tables *****************************************************/
+/** Index Tables *****************************************************/
 	/* See also the data table styling section, which this effectively subclasses */
 
-	table.proptable {
+	table.index {
 		font-size: small;
 		border-collapse: collapse;
 		border-spacing: 0;
@@ -939,34 +1054,19 @@
 		margin: 1em 0;
 	}
 
-	table.proptable td,
-	table.proptable th {
+	table.index td,
+	table.index th {
 		padding: 0.4em;
-		text-align: center;
 	}
 
-	table.proptable tr:hover td {
-		background: #DEF;
+	table.index tr:hover td:not([rowspan]),
+	table.index tr:hover th:not([rowspan]) {
+		background: #f7f8f9;
 	}
-	.propdef th {
-		font-style: italic;
-		font-weight: normal;
-		text-align: left;
-		width: 3em;
-	}
+
 	/* The link in the first column in the property table (formerly a TD) */
-	table.proptable td .property,
-	table.proptable th .property {
-		display: block;
-		text-align: left;
+	table.index th:first-child a {
 		font-weight: bold;
-	}
-
-/** Extra-large Elements ******************************************************/
-
-	.big-element-wrapper {
-		max-width: 50em;
-		overflow-x: auto;
 	}
 
 /******************************************************************************/
@@ -974,32 +1074,274 @@
 /******************************************************************************/
 
 	@media print {
+		/* Pages have their own margins. */
 		html {
-			margin: 0 !important; }
+			margin: 0;
+		}
+		/* Serif for print. */
 		body {
-			font-family: serif; }
-		th, td {
-			font-family: inherit; }
-		a {
-			color: inherit !important; }
-
-		a:link, a:visited {
-			text-decoration: none !important }
-		a:link::after, a:visited::after { /* create a cross-ref "see..." */ }
-		.example::before {
-			font-family: serif !important; }
+			font-family: serif;
+		}
 	}
 	@page {
 		margin: 1.5cm 1.1cm;
 	}
 
+/******************************************************************************/
+/*                                    Legacy                                  */
+/******************************************************************************/
+
+	/* This rule is inherited from past style sheets. No idea what it's for. */
+	.hide { display: none }
+
+
+
+/******************************************************************************/
+/*                             Overflow Control                               */
+/******************************************************************************/
+
+	.figure .caption, .sidefigure .caption, figcaption {
+		/* in case figure is overlarge, limit caption to 50em */
+		max-width: 50rem;
+		margin-left: auto;
+		margin-right: auto;
+	}
+	.overlarge > table {
+		/* limit preferred width of table */
+		max-width: 50em;
+		margin-left: auto;
+		margin-right: auto;
+	}
+
+	@media (min-width: 55em) {
+		.overlarge {
+			margin-left: calc(13px + 26.5rem - 50vw);
+			margin-right: calc(13px + 26.5rem - 50vw);
+			max-width: none;
+		}
+	}
+	@media screen and (min-width: 78em) {
+		body:not(.toc-inline) .overlarge {
+			/* 30.5em body padding 50em content area */
+			margin-left: calc(40em - 50vw) !important;
+			margin-right: calc(40em - 50vw) !important;
+		}
+	}
+	@media screen and (min-width: 90em) {
+		body:not(.toc-inline) .overlarge {
+			/* 4em html margin 30.5em body padding 50em content area */
+			margin-left: 0 !important;
+			margin-right: calc(84.5em - 100vw) !important;
+		}
+	}
+
+	@media not print {
+		.overlarge {
+			overflow-x: auto;
+			/* See Lea Verou's explanation background-attachment:
+			 * http://lea.verou.me/2012/04/background-attachment-local/
+			 *
+			background: top left  / 4em 100% linear-gradient(to right,  #ffffff, rgba(255, 255, 255, 0)) local,
+			            top right / 4em 100% linear-gradient(to left, #ffffff, rgba(255, 255, 255, 0)) local,
+			            top left  / 1em 100% linear-gradient(to right,  #c3c3c5, rgba(195, 195, 197, 0)) scroll,
+			            top right / 1em 100% linear-gradient(to left, #c3c3c5, rgba(195, 195, 197, 0)) scroll,
+			            white;
+			background-repeat: no-repeat;
+			*/
+		}
+	}
 </style>
   <meta content="Bikeshed 1.0.0" name="generator">
-<style>.highlight .hll { background-color: #ffffcc }
+<style>/* style-md-lists */
+
+            /* This is a weird hack for me not yet following the commonmark spec
+               regarding paragraph and lists. */
+            [data-md] > :first-child {
+                margin-top: 0;
+            }
+            [data-md] > :last-child {
+                margin-bottom: 0;
+            }</style>
+<style>/* style-selflinks */
+
+            .heading, .issue, .note, .example, li, dt {
+                position: relative;
+            }
+            a.self-link {
+                position: absolute;
+                top: 0;
+                left: calc(-1 * (3.5rem - 26px));
+                width: calc(3.5rem - 26px);
+                height: 2em;
+                text-align: center;
+                border: none;
+                transition: opacity .2s;
+                opacity: .5;
+            }
+            a.self-link:hover {
+                opacity: 1;
+            }
+            .heading > a.self-link {
+                font-size: 83%;
+            }
+            li > a.self-link {
+                left: calc(-1 * (3.5rem - 26px) - 2em);
+            }
+            dfn > a.self-link {
+                top: auto;
+                left: auto;
+                opacity: 0;
+                width: 1.5em;
+                height: 1.5em;
+                background: gray;
+                color: white;
+                font-style: normal;
+                transition: opacity .2s, background-color .2s, color .2s;
+            }
+            dfn:hover > a.self-link {
+                opacity: 1;
+            }
+            dfn > a.self-link:hover {
+                color: black;
+            }
+
+            a.self-link::before            { content: "¶"; }
+            .heading > a.self-link::before { content: "§"; }
+            dfn > a.self-link::before      { content: "#"; }</style>
+<style>/* style-counters */
+
+            body {
+                counter-reset: example figure issue;
+            }
+            .issue {
+                counter-increment: issue;
+            }
+            .issue:not(.no-marker)::before {
+                content: "Issue " counter(issue);
+            }
+
+            .example {
+                counter-increment: example;
+            }
+            .example:not(.no-marker)::before {
+                content: "Example " counter(example);
+            }
+            .invalid.example:not(.no-marker)::before,
+            .illegal.example:not(.no-marker)::before {
+                content: "Invalid Example" counter(example);
+            }
+
+            figure {
+                counter-increment: figure;
+            }
+            figcaption:not(.no-marker)::before {
+                content: "Figure " counter(figure);
+            }</style>
+<style>/* style-autolinks */
+
+            .css.css, .property.property, .descriptor.descriptor {
+                color: #005a9c;
+                font-size: inherit;
+                font-family: inherit;
+            }
+            .css::before, .property::before, .descriptor::before {
+                content: "‘";
+            }
+            .css::after, .property::after, .descriptor::after {
+                content: "’";
+            }
+            .property, .descriptor {
+                /* Don't wrap property and descriptor names */
+                white-space: nowrap;
+            }
+            .type { /* CSS value <type> */
+                font-style: italic;
+            }
+            pre .property::before, pre .property::after {
+                content: "";
+            }
+            [data-link-type="property"]::before,
+            [data-link-type="propdesc"]::before,
+            [data-link-type="descriptor"]::before,
+            [data-link-type="value"]::before,
+            [data-link-type="function"]::before,
+            [data-link-type="at-rule"]::before,
+            [data-link-type="selector"]::before,
+            [data-link-type="maybe"]::before {
+                content: "‘";
+            }
+            [data-link-type="property"]::after,
+            [data-link-type="propdesc"]::after,
+            [data-link-type="descriptor"]::after,
+            [data-link-type="value"]::after,
+            [data-link-type="function"]::after,
+            [data-link-type="at-rule"]::after,
+            [data-link-type="selector"]::after,
+            [data-link-type="maybe"]::after {
+                content: "’";
+            }
+
+            [data-link-type].production::before,
+            [data-link-type].production::after,
+            .prod [data-link-type]::before,
+            .prod [data-link-type]::after {
+                content: "";
+            }
+
+            [data-link-type=element],
+            [data-link-type=element-attr] {
+                font-family: Menlo, Consolas, "DejaVu Sans Mono", monospace;
+                font-size: .9em;
+            }
+            [data-link-type=element]::before { content: "<" }
+            [data-link-type=element]::after  { content: ">" }
+
+            [data-link-type=biblio] {
+                white-space: pre;
+            }</style>
+<style>/* style-dfn-panel */
+
+        .dfn-panel {
+            position: absolute;
+            z-index: 35;
+            height: auto;
+            width: -webkit-fit-content;
+            width: fit-content;
+            max-width: 300px;
+            max-height: 500px;
+            overflow: auto;
+            padding: 0.5em 0.75em;
+            font: small Helvetica Neue, sans-serif, Droid Sans Fallback;
+            background: #DDDDDD;
+            color: black;
+            border: outset 0.2em;
+        }
+        .dfn-panel:not(.on) { display: none; }
+        .dfn-panel * { margin: 0; padding: 0; text-indent: 0; }
+        .dfn-panel > b { display: block; }
+        .dfn-panel a { color: black; }
+        .dfn-panel a:not(:hover) { text-decoration: none !important; border-bottom: none !important; }
+        .dfn-panel > b + b { margin-top: 0.25em; }
+        .dfn-panel ul { padding: 0; }
+        .dfn-panel li { list-style: inside; }
+        .dfn-panel.activated {
+            display: inline-block;
+            position: fixed;
+            left: .5em;
+            bottom: 2em;
+            margin: 0 auto;
+            max-width: calc(100vw - 1.5em - .4em - .5em);
+            max-height: 30vh;
+        }
+
+        .dfn-paneled { cursor: pointer; }
+        </style>
+<style>/* style-syntax-highlighting */
+.highlight .hll { background-color: #ffffcc }
 .highlight  { background: #ffffff; }
 .highlight .c { color: #708090 } /* Comment */
 .highlight .k { color: #990055 } /* Keyword */
-.highlight .l { color: #669900 } /* Literal */
+.highlight .l { color: #000000 } /* Literal */
 .highlight .n { color: #0077aa } /* Name */
 .highlight .o { color: #999999 } /* Operator */
 .highlight .p { color: #999999 } /* Punctuation */
@@ -1013,9 +1355,9 @@
 .highlight .kp { color: #990055 } /* Keyword.Pseudo */
 .highlight .kr { color: #990055 } /* Keyword.Reserved */
 .highlight .kt { color: #990055 } /* Keyword.Type */
-.highlight .ld { color: #669900 } /* Literal.Date */
-.highlight .m { color: #990055 } /* Literal.Number */
-.highlight .s { color: #669900 } /* Literal.String */
+.highlight .ld { color: #000000 } /* Literal.Date */
+.highlight .m { color: #000000 } /* Literal.Number */
+.highlight .s { color: #a67f59 } /* Literal.String */
 .highlight .na { color: #0077aa } /* Name.Attribute */
 .highlight .nc { color: #0077aa } /* Name.Class */
 .highlight .no { color: #0077aa } /* Name.Constant */
@@ -1026,44 +1368,43 @@
 .highlight .nl { color: #0077aa } /* Name.Label */
 .highlight .nn { color: #0077aa } /* Name.Namespace */
 .highlight .py { color: #0077aa } /* Name.Property */
-.highlight .nt { color: #0077aa } /* Name.Tag */
+.highlight .nt { color: #669900 } /* Name.Tag */
 .highlight .nv { color: #0077aa } /* Name.Variable */
 .highlight .ow { color: #999999 } /* Operator.Word */
-.highlight .mb { color: #990055 } /* Literal.Number.Bin */
-.highlight .mf { color: #990055 } /* Literal.Number.Float */
-.highlight .mh { color: #990055 } /* Literal.Number.Hex */
-.highlight .mi { color: #990055 } /* Literal.Number.Integer */
-.highlight .mo { color: #990055 } /* Literal.Number.Oct */
-.highlight .sb { color: #669900 } /* Literal.String.Backtick */
-.highlight .sc { color: #669900 } /* Literal.String.Char */
-.highlight .sd { color: #669900 } /* Literal.String.Doc */
-.highlight .s2 { color: #669900 } /* Literal.String.Double */
-.highlight .se { color: #669900 } /* Literal.String.Escape */
-.highlight .sh { color: #669900 } /* Literal.String.Heredoc */
-.highlight .si { color: #669900 } /* Literal.String.Interpol */
-.highlight .sx { color: #669900 } /* Literal.String.Other */
-.highlight .sr { color: #669900 } /* Literal.String.Regex */
-.highlight .s1 { color: #669900 } /* Literal.String.Single */
-.highlight .ss { color: #669900 } /* Literal.String.Symbol */
+.highlight .mb { color: #000000 } /* Literal.Number.Bin */
+.highlight .mf { color: #000000 } /* Literal.Number.Float */
+.highlight .mh { color: #000000 } /* Literal.Number.Hex */
+.highlight .mi { color: #000000 } /* Literal.Number.Integer */
+.highlight .mo { color: #000000 } /* Literal.Number.Oct */
+.highlight .sb { color: #a67f59 } /* Literal.String.Backtick */
+.highlight .sc { color: #a67f59 } /* Literal.String.Char */
+.highlight .sd { color: #a67f59 } /* Literal.String.Doc */
+.highlight .s2 { color: #a67f59 } /* Literal.String.Double */
+.highlight .se { color: #a67f59 } /* Literal.String.Escape */
+.highlight .sh { color: #a67f59 } /* Literal.String.Heredoc */
+.highlight .si { color: #a67f59 } /* Literal.String.Interpol */
+.highlight .sx { color: #a67f59 } /* Literal.String.Other */
+.highlight .sr { color: #a67f59 } /* Literal.String.Regex */
+.highlight .s1 { color: #a67f59 } /* Literal.String.Single */
+.highlight .ss { color: #a67f59 } /* Literal.String.Symbol */
 .highlight .vc { color: #0077aa } /* Name.Variable.Class */
 .highlight .vg { color: #0077aa } /* Name.Variable.Global */
 .highlight .vi { color: #0077aa } /* Name.Variable.Instance */
-.highlight .il { color: #990055 } /* Literal.Number.Integer.Long */
+.highlight .il { color: #000000 } /* Literal.Number.Integer.Long */
         .highlight { background: hsl(24, 20%, 95%); }
         code.highlight { padding: .1em; border-radius: .3em; }
-        pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em 0; overflow: auto; border-radius: 0; }
+        xmp.highlight, pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em 0; overflow: auto; border-radius: 0; }
         </style>
- </head>
  <body class="h-entry">
   <div class="head">
-   <p data-fill-with="logo"><a class="logo" href="http://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/Icons/w3c_home" width="72"> </a> </p>
+   <p data-fill-with="logo"><a class="logo" href="http://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Referrer Policy</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2016-10-15">15 October 2016</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2016-10-18">18 October 2016</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
      <dd><a class="u-url" href="https://w3c.github.io/webappsec-referrer-policy/">https://w3c.github.io/webappsec-referrer-policy/</a>
-     <dt>Latest version:
+     <dt>Latest published version:
      <dd><a href="http://www.w3.org/TR/referrer-policy/">http://www.w3.org/TR/referrer-policy/</a>
      <dt>Version History:
      <dd><a href="https://github.com/w3c/webappsec-referrer-policy/commits/master/index.src.html">https://github.com/w3c/webappsec-referrer-policy/commits/master/index.src.html</a>
@@ -1107,20 +1448,20 @@
    <p></p>
   </div>
   <div data-fill-with="at-risk"></div>
-  <h2 class="no-num no-toc no-ref heading settled" id="contents"><span class="content">Table of Contents</span></h2>
-  <div data-fill-with="table-of-contents" role="navigation">
-   <ul class="toc" role="directory">
+  <nav data-fill-with="table-of-contents" id="toc">
+   <h2 class="no-num no-toc no-ref" id="contents">Table of Contents</h2>
+   <ol class="toc" role="directory">
     <li>
      <a href="#intro"><span class="secno">1</span> <span class="content">Introduction</span></a>
-     <ul class="toc">
+     <ol class="toc">
       <li><a href="#intro-privacy"><span class="secno">1.1</span> <span class="content">Privacy</span></a>
       <li><a href="#intro-security"><span class="secno">1.2</span> <span class="content">Security</span></a>
       <li><a href="#intro-trackback"><span class="secno">1.3</span> <span class="content">Trackback</span></a>
-     </ul>
+     </ol>
     <li><a href="#terms"><span class="secno">2</span> <span class="content">Key Concepts and Terminology</span></a>
     <li>
      <a href="#referrer-policies"><span class="secno">3</span> <span class="content">Referrer Policies</span></a>
-     <ul class="toc">
+     <ol class="toc">
       <li><a href="#referrer-policy-no-referrer"><span class="secno">3.1</span> <span class="content">"<code>no-referrer</code>"</span></a>
       <li><a href="#referrer-policy-no-referrer-when-downgrade"><span class="secno">3.2</span> <span class="content">"<code>no-referrer-when-downgrade</code>"</span></a>
       <li><a href="#referrer-policy-same-origin"><span class="secno">3.3</span> <span class="content">"<code>same-origin</code>"</span></a>
@@ -1130,69 +1471,70 @@
       <li><a href="#referrer-policy-strict-origin-when-cross-origin"><span class="secno">3.7</span> <span class="content">"<code>strict-origin-when-cross-origin</code>"</span></a>
       <li><a href="#referrer-policy-unsafe-url"><span class="secno">3.8</span> <span class="content">"<code>unsafe-url</code>"</span></a>
       <li><a href="#referrer-policy-empty-string"><span class="secno">3.9</span> <span class="content">The empty string</span></a>
-     </ul>
+     </ol>
     <li>
      <a href="#referrer-policy-delivery"><span class="secno">4</span> <span class="content">Referrer Policy Delivery</span></a>
-     <ul class="toc">
+     <ol class="toc">
       <li>
        <a href="#referrer-policy-header"><span class="secno">4.1</span> <span class="content">Delivery via Referrer-Policy header</span></a>
-       <ul class="toc">
+       <ol class="toc">
         <li><a href="#referrer-usage"><span class="secno">4.1.1</span> <span class="content">Usage</span></a>
-       </ul>
+       </ol>
       <li><a href="#referrer-policy-delivery-meta"><span class="secno">4.2</span> <span class="content">Delivery via <code><span>meta</span></code></span></a>
       <li><a href="#referrer-policy-delivery-referrer-attribute"><span class="secno">4.3</span> <span class="content">Delivery
     via a <code>referrerpolicy</code> content attribute</span></a>
       <li><a href="#referrer-policy-delivery-nested"><span class="secno">4.4</span> <span class="content">Nested browsing contexts</span></a>
-     </ul>
+     </ol>
     <li><a href="#integration-with-fetch"><span class="secno">5</span> <span class="content">Integration with Fetch</span></a>
     <li><a href="#integration-with-html"><span class="secno">6</span> <span class="content">Integration with HTML</span></a>
     <li><a href="#integration-with-css"><span class="secno">7</span> <span class="content">Integration with CSS</span></a>
     <li>
      <a href="#algorithms"><span class="secno">8</span> <span class="content">Algorithms</span></a>
-     <ul class="toc">
+     <ol class="toc">
       <li><a href="#parse-referrer-policy-from-header"><span class="secno">8.1</span> <span class="content"> Parse a referrer policy from a <span><code>Referrer-Policy</code></span> header </span></a>
       <li><a href="#set-requests-referrer-policy-on-redirect"><span class="secno">8.2</span> <span class="content"> Set <var>request</var>’s referrer policy on redirect </span></a>
       <li><a href="#determine-requests-referrer"><span class="secno">8.3</span> <span class="content"> Determine <var>request</var>’s Referrer </span></a>
       <li><a href="#strip-url"><span class="secno">8.4</span> <span class="content"> Strip <var>url</var> for use as a referrer </span></a>
-     </ul>
+      <li><a href="#ancestor-origin"><span class="secno">8.5</span> <span class="content"> Determine the Ancestor Origin availble to a Location </span></a>
+     </ol>
     <li>
      <a href="#privacy"><span class="secno">9</span> <span class="content">Privacy Considerations</span></a>
-     <ul class="toc">
+     <ol class="toc">
       <li><a href="#user-controls"><span class="secno">9.1</span> <span class="content">User Controls</span></a>
-     </ul>
+     </ol>
     <li>
      <a href="#security"><span class="secno">10</span> <span class="content">Security Considerations</span></a>
-     <ul class="toc">
+     <ol class="toc">
       <li><a href="#information-leakage"><span class="secno">10.1</span> <span class="content">Information Leakage</span></a>
       <li><a href="#downgrade"><span class="secno">10.2</span> <span class="content">Downgrade to less strict policies</span></a>
-     </ul>
+     </ol>
     <li>
      <a href="#authoring"><span class="secno">11</span> <span class="content">Authoring Considerations</span></a>
-     <ul class="toc">
+     <ol class="toc">
       <li><a href="#unknown-policy-values"><span class="secno">11.1</span> <span class="content">Unknown Policy Values</span></a>
-     </ul>
+     </ol>
     <li><a href="#acknowledgements"><span class="secno">12</span> <span class="content">Acknowledgements</span></a>
     <li>
      <a href="#conformance"><span class="secno"></span> <span class="content">Conformance</span></a>
-     <ul class="toc">
+     <ol class="toc">
       <li><a href="#conventions"><span class="secno"></span> <span class="content">Document conventions</span></a>
       <li><a href="#conformant-algorithms"><span class="secno"></span> <span class="content">Conformant Algorithms</span></a>
-     </ul>
+     </ol>
     <li>
      <a href="#index"><span class="secno"></span> <span class="content">Index</span></a>
-     <ul class="toc">
+     <ol class="toc">
       <li><a href="#index-defined-here"><span class="secno"></span> <span class="content">Terms defined by this specification</span></a>
       <li><a href="#index-defined-elsewhere"><span class="secno"></span> <span class="content">Terms defined by reference</span></a>
-     </ul>
+     </ol>
     <li>
      <a href="#references"><span class="secno"></span> <span class="content">References</span></a>
-     <ul class="toc">
+     <ol class="toc">
       <li><a href="#normative"><span class="secno"></span> <span class="content">Normative References</span></a>
       <li><a href="#informative"><span class="secno"></span> <span class="content">Informative References</span></a>
-     </ul>
+     </ol>
     <li><a href="#idl-index"><span class="secno"></span> <span class="content">IDL Index</span></a>
-   </ul>
-  </div>
+   </ol>
+  </nav>
   <main>
    <section>
     <h2 class="heading settled" data-level="1" id="intro"><span class="secno">1. </span><span class="content">Introduction</span><a class="self-link" href="#intro"></a></h2>
@@ -1227,53 +1569,53 @@
    <section>
     <h2 class="heading settled" data-level="2" id="terms"><span class="secno">2. </span><span class="content">Key Concepts and Terminology</span><a class="self-link" href="#terms"></a></h2>
     <dl>
-     <dt> <a data-link-type="dfn" href="#referrer-policy">referrer policy</a> 
+     <dt> <a data-link-type="dfn" href="#referrer-policy" id="ref-for-referrer-policy-1">referrer policy</a> 
      <dd>
-       A <a data-link-type="dfn" href="#referrer-policy">referrer policy</a> modifies the algorithm used to populate the <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc7231#section-5.5.2"><code>Referer</code></a> header when <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#fetching">fetching</a> subresources,
+       A <a data-link-type="dfn" href="#referrer-policy" id="ref-for-referrer-policy-2">referrer policy</a> modifies the algorithm used to populate the <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc7231#section-5.5.2"><code>Referer</code></a> header when <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#fetching">fetching</a> subresources,
       prefetching, or performing navigations. This document defines the various
-      behaviors for each <a data-link-type="dfn" href="#referrer-policy">referrer policy</a>. 
-      <p>Every <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">environment settings object</a> has an algorithm for obtaining a <a data-link-type="dfn" href="#referrer-policy">referrer policy</a>, which is used by default for all <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">requests</a> with that <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">environment settings object</a> as their <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client">request
+      behaviors for each <a data-link-type="dfn" href="#referrer-policy" id="ref-for-referrer-policy-3">referrer policy</a>. 
+      <p>Every <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">environment settings object</a> has an algorithm for obtaining a <a data-link-type="dfn" href="#referrer-policy" id="ref-for-referrer-policy-4">referrer policy</a>, which is used by default for all <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">requests</a> with that <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">environment settings object</a> as their <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client">request
       client</a>.</p>
-     <dt><dfn data-dfn-type="dfn" data-noexport="" id="same-origin-request">same-origin request<a class="self-link" href="#same-origin-request"></a></dfn>
+     <dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="same-origin-request">same-origin request</dfn>
      <dd> A <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#request">Request</a></code> <var>request</var> is a <strong>same-origin request</strong> if <var>request</var>’s <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#concept-request-origin">origin</a></code> and the <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc6454#section-3.2">origin</a> of <var>request</var>’s <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#concept-request-url">url</a></code> are <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc6454#section-5"><code>the same</code></a>. 
-     <dt><dfn data-dfn-type="dfn" data-noexport="" id="cross-origin-request">cross-origin request<a class="self-link" href="#cross-origin-request"></a></dfn>
-     <dd> A <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#request">Request</a></code> is a <strong>cross-origin request</strong> if it is <em>not</em> <a data-link-type="dfn" href="#same-origin-request">same-origin</a>. 
+     <dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="cross-origin-request">cross-origin request</dfn>
+     <dd> A <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#request">Request</a></code> is a <strong>cross-origin request</strong> if it is <em>not</em> <a data-link-type="dfn" href="#same-origin-request" id="ref-for-same-origin-request-1">same-origin</a>. 
     </dl>
    </section>
    <section>
     <h2 class="heading settled" data-level="3" id="referrer-policies"><span class="secno">3. </span><span class="content">Referrer Policies</span><span id="referrer-policy-states"></span><a class="self-link" href="#referrer-policies"></a></h2>
-    <p>A <dfn data-dfn-type="dfn" data-export="" id="referrer-policy" title="concept-referrer-policy">referrer policy<a class="self-link" href="#referrer-policy"></a></dfn> is the empty string, "<code>no-referrer</code>",
+    <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="referrer-policy" title="concept-referrer-policy">referrer policy</dfn> is the empty string, "<code>no-referrer</code>",
   "<code>no-referrer-when-downgrade</code>", "<code>same-origin</code>",
   "<code>origin</code>", "<code>strict-origin</code>",
   "<code>origin-when-cross-origin</code>",
   "<code>strict-origin-when-cross-origin</code>", or
   "<code>unsafe-url</code>".</p>
-<pre class="idl">enum <dfn class="idl-code" data-dfn-type="enum" data-export="" id="enumdef-referrerpolicy">ReferrerPolicy<a class="self-link" href="#enumdef-referrerpolicy"></a></dfn> {
-  "",
-  "no-referrer",
-  "no-referrer-when-downgrade",
-  "same-origin",
-  "origin",
-  "strict-origin",
-  "origin-when-cross-origin",
-  "strict-origin-when-cross-origin",
-  "unsafe-url"
+<pre class="idl def">enum <dfn class="idl-code" data-dfn-type="enum" data-export="" id="enumdef-referrerpolicy">ReferrerPolicy<a class="self-link" href="#enumdef-referrerpolicy"></a></dfn> {
+  <dfn class="idl-code" data-dfn-for="ReferrerPolicy" data-dfn-type="enum-value" data-export="" data-lt="&quot;&quot;|" id="dom-referrerpolicy">""<a class="self-link" href="#dom-referrerpolicy"></a></dfn>,
+  <dfn class="idl-code" data-dfn-for="ReferrerPolicy" data-dfn-type="enum-value" data-export="" data-lt="&quot;no-referrer&quot;|no-referrer" id="dom-referrerpolicy-no-referrer">"no-referrer"<a class="self-link" href="#dom-referrerpolicy-no-referrer"></a></dfn>,
+  <dfn class="idl-code" data-dfn-for="ReferrerPolicy" data-dfn-type="enum-value" data-export="" data-lt="&quot;no-referrer-when-downgrade&quot;|no-referrer-when-downgrade" id="dom-referrerpolicy-no-referrer-when-downgrade">"no-referrer-when-downgrade"<a class="self-link" href="#dom-referrerpolicy-no-referrer-when-downgrade"></a></dfn>,
+  <dfn class="idl-code" data-dfn-for="ReferrerPolicy" data-dfn-type="enum-value" data-export="" data-lt="&quot;same-origin&quot;|same-origin" id="dom-referrerpolicy-same-origin">"same-origin"<a class="self-link" href="#dom-referrerpolicy-same-origin"></a></dfn>,
+  <dfn class="idl-code" data-dfn-for="ReferrerPolicy" data-dfn-type="enum-value" data-export="" data-lt="&quot;origin&quot;|origin" id="dom-referrerpolicy-origin">"origin"<a class="self-link" href="#dom-referrerpolicy-origin"></a></dfn>,
+  <dfn class="idl-code" data-dfn-for="ReferrerPolicy" data-dfn-type="enum-value" data-export="" data-lt="&quot;strict-origin&quot;|strict-origin" id="dom-referrerpolicy-strict-origin">"strict-origin"<a class="self-link" href="#dom-referrerpolicy-strict-origin"></a></dfn>,
+  <dfn class="idl-code" data-dfn-for="ReferrerPolicy" data-dfn-type="enum-value" data-export="" data-lt="&quot;origin-when-cross-origin&quot;|origin-when-cross-origin" id="dom-referrerpolicy-origin-when-cross-origin">"origin-when-cross-origin"<a class="self-link" href="#dom-referrerpolicy-origin-when-cross-origin"></a></dfn>,
+  <dfn class="idl-code" data-dfn-for="ReferrerPolicy" data-dfn-type="enum-value" data-export="" data-lt="&quot;strict-origin-when-cross-origin&quot;|strict-origin-when-cross-origin" id="dom-referrerpolicy-strict-origin-when-cross-origin">"strict-origin-when-cross-origin"<a class="self-link" href="#dom-referrerpolicy-strict-origin-when-cross-origin"></a></dfn>,
+  <dfn class="idl-code" data-dfn-for="ReferrerPolicy" data-dfn-type="enum-value" data-export="" data-lt="&quot;unsafe-url&quot;|unsafe-url" id="dom-referrerpolicy-unsafe-url">"unsafe-url"<a class="self-link" href="#dom-referrerpolicy-unsafe-url"></a></dfn>
 };
 </pre>
-    <p>Each possible <a data-link-type="dfn" href="#referrer-policy">referrer policy</a> is explained below. A detailed
+    <p>Each possible <a data-link-type="dfn" href="#referrer-policy" id="ref-for-referrer-policy-5">referrer policy</a> is explained below. A detailed
   algorithm for evaluating their effect is given in the <a href="#integration-with-fetch">§5 Integration with Fetch</a> and <a href="#algorithms">§8 Algorithms</a> sections.</p>
     <p class="note" role="note">Note: The referrer policy for an <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">environment settings object</a> provides a
   default baseline policy for requests when that <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">environment settings
   object</a> is used as a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client">request client</a>. This policy may be tightened
   for specific requests via mechanisms like the <code><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/semantics.html#link-type-noreferrer">noreferrer</a></code> link type.</p>
-    <h3 class="heading settled" data-dfn-type="dfn" data-export="" data-level="3.1" data-lt="&quot;no-referrer&quot;" id="referrer-policy-no-referrer"><span class="secno">3.1. </span><span class="content">"<code>no-referrer</code>"</span><span id="referrer-policy-state-no-referrer"></span><a class="self-link" href="#referrer-policy-no-referrer"></a></h3>
-    <p>The simplest policy is <a data-link-type="dfn" href="#referrer-policy-no-referrer">"<code>no-referrer</code>"</a>, which specifies
+    <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-export="" data-level="3.1" data-lt="&quot;no-referrer&quot;" id="referrer-policy-no-referrer"><span class="secno">3.1. </span><span class="content">"<code>no-referrer</code>"</span><span id="referrer-policy-state-no-referrer"></span></h3>
+    <p>The simplest policy is <a data-link-type="dfn" href="#referrer-policy-no-referrer" id="ref-for-referrer-policy-no-referrer-1">"<code>no-referrer</code>"</a>, which specifies
   that no referrer information is to be sent along with requests made from a
   particular <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client">request client</a> to any <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc6454#section-3.2">origin</a>. The header will be
   omitted entirely.</p>
-    <div class="example" id="example-df4273ed"><a class="self-link" href="#example-df4273ed"></a> If a document at <code>https://example.com/page.html</code> sets a policy of <a data-link-type="dfn" href="#referrer-policy-no-referrer">"<code>no-referrer</code>"</a>, then navigations to <code>https://example.com/</code> (or any other URL) would send no <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc7231#section-5.5.2"><code>Referer</code></a> header. </div>
-    <h3 class="heading settled" data-dfn-type="dfn" data-export="" data-level="3.2" data-lt="&quot;no-referrer-when-downgrade&quot;" id="referrer-policy-no-referrer-when-downgrade"><span class="secno">3.2. </span><span class="content">"<code>no-referrer-when-downgrade</code>"</span><span id="referrer-policy-state-no-referrer-when-downgrade"></span><a class="self-link" href="#referrer-policy-no-referrer-when-downgrade"></a></h3>
-    <p>The <a data-link-type="dfn" href="#referrer-policy-no-referrer-when-downgrade">"<code>no-referrer-when-downgrade</code>"</a> policy sends a full URL
+    <div class="example" id="example-df4273ed"><a class="self-link" href="#example-df4273ed"></a> If a document at <code>https://example.com/page.html</code> sets a policy of <a data-link-type="dfn" href="#referrer-policy-no-referrer" id="ref-for-referrer-policy-no-referrer-2">"<code>no-referrer</code>"</a>, then navigations to <code>https://example.com/</code> (or any other URL) would send no <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc7231#section-5.5.2"><code>Referer</code></a> header. </div>
+    <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-export="" data-level="3.2" data-lt="&quot;no-referrer-when-downgrade&quot;" id="referrer-policy-no-referrer-when-downgrade"><span class="secno">3.2. </span><span class="content">"<code>no-referrer-when-downgrade</code>"</span><span id="referrer-policy-state-no-referrer-when-downgrade"></span></h3>
+    <p>The <a data-link-type="dfn" href="#referrer-policy-no-referrer-when-downgrade" id="ref-for-referrer-policy-no-referrer-when-downgrade-1">"<code>no-referrer-when-downgrade</code>"</a> policy sends a full URL
   along with requests from a <a data-link-type="dfn" href="http://www.w3.org/TR/2010/REC-wsc-ui-20100812/#typesoftls">TLS-protected</a> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">environment settings
   object</a> to a <a data-link-type="dfn" href="https://w3c.github.io/webappsec/specs/mixedcontent/#a-priori-authenticated-url"><em>a priori</em> authenticated URL</a>, and requests from <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client">request clients</a> which are <em>not</em> <a data-link-type="dfn" href="http://www.w3.org/TR/2010/REC-wsc-ui-20100812/#typesoftls">TLS-protected</a> to any <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc6454#section-3.2">origin</a>.</p>
     <p>Requests from <a data-link-type="dfn" href="http://www.w3.org/TR/2010/REC-wsc-ui-20100812/#typesoftls">TLS-protected</a> <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client">request clients</a> to non-<a data-link-type="dfn" href="https://w3c.github.io/webappsec/specs/mixedcontent/#a-priori-authenticated-url"><em>a
@@ -1281,36 +1623,36 @@
   referrer information. A <code><a data-link-type="dfn" href="https://tools.ietf.org/html/rfc7231#section-5.5.2">Referer</a></code> HTTP header will not be
   sent.</p>
     <div class="example" id="example-0323e875">
-     <a class="self-link" href="#example-0323e875"></a> If a document at <code>https://example.com/page.html</code> sets a policy of <a data-link-type="dfn" href="#referrer-policy-no-referrer-when-downgrade">"<code>no-referrer-when-downgrade</code>"</a>, then navigations to <code>https://not.example.com/</code> would send a <code><a data-link-type="dfn" href="https://tools.ietf.org/html/rfc7231#section-5.5.2">Referer</a></code> HTTP header with a value of <code>https://example.com/page.html</code>, as neither resource’s origin is an
+     <a class="self-link" href="#example-0323e875"></a> If a document at <code>https://example.com/page.html</code> sets a policy of <a data-link-type="dfn" href="#referrer-policy-no-referrer-when-downgrade" id="ref-for-referrer-policy-no-referrer-when-downgrade-2">"<code>no-referrer-when-downgrade</code>"</a>, then navigations to <code>https://not.example.com/</code> would send a <code><a data-link-type="dfn" href="https://tools.ietf.org/html/rfc7231#section-5.5.2">Referer</a></code> HTTP header with a value of <code>https://example.com/page.html</code>, as neither resource’s origin is an
     non-<a data-link-type="dfn" href="https://w3c.github.io/webappsec/specs/mixedcontent/#a-priori-authenticated-url"><em>a priori</em> authenticated URL</a>. 
      <p>Navigations from that same page to <code><strong>http</strong>://not.example.com/</code> would send no <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc7231#section-5.5.2"><code>Referer</code></a> header.</p>
     </div>
     <p>This is a user agent’s default behavior, if no policy is otherwise specified.</p>
-    <h3 class="heading settled" data-dfn-type="dfn" data-export="" data-level="3.3" data-lt="&quot;same-origin&quot;" id="referrer-policy-same-origin"><span class="secno">3.3. </span><span class="content">"<code>same-origin</code>"</span><a class="self-link" href="#referrer-policy-same-origin"></a></h3>
-    <p>The <a data-link-type="dfn" href="#referrer-policy-same-origin">"<code>same-origin</code>"</a> policy specifies that a
+    <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-export="" data-level="3.3" data-lt="&quot;same-origin&quot;" id="referrer-policy-same-origin"><span class="secno">3.3. </span><span class="content">"<code>same-origin</code>"</span></h3>
+    <p>The <a data-link-type="dfn" href="#referrer-policy-same-origin" id="ref-for-referrer-policy-same-origin-1">"<code>same-origin</code>"</a> policy specifies that a
   full URL, <a href="#strip-url">stripped for use as a referrer</a>, is sent as
-  referrer information when making <a data-link-type="dfn" href="#same-origin-request">same-origin requests</a> from a particular <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client">request client</a>.</p>
-    <p><a data-link-type="dfn" href="#cross-origin-request">Cross-origin requests</a>, on the other hand, will contain no
+  referrer information when making <a data-link-type="dfn" href="#same-origin-request" id="ref-for-same-origin-request-2">same-origin requests</a> from a particular <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client">request client</a>.</p>
+    <p><a data-link-type="dfn" href="#cross-origin-request" id="ref-for-cross-origin-request-1">Cross-origin requests</a>, on the other hand, will contain no
   referrer information. A <code><a data-link-type="dfn" href="https://tools.ietf.org/html/rfc7231#section-5.5.2">Referer</a></code> HTTP header will not be
   sent.</p>
     <div class="example" id="example-af6c3f8c">
-     <a class="self-link" href="#example-af6c3f8c"></a> If a document at <code>https://example.com/page.html</code> sets a policy of <a data-link-type="dfn" href="#referrer-policy-same-origin">"<code>same-origin</code>"</a>, then navigations to <code>https://example.com/not-page.html</code> would send a <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc7231#section-5.5.2"><code>Referer</code></a> header with a value of <code>https://example.com/page.html</code>. 
+     <a class="self-link" href="#example-af6c3f8c"></a> If a document at <code>https://example.com/page.html</code> sets a policy of <a data-link-type="dfn" href="#referrer-policy-same-origin" id="ref-for-referrer-policy-same-origin-2">"<code>same-origin</code>"</a>, then navigations to <code>https://example.com/not-page.html</code> would send a <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc7231#section-5.5.2"><code>Referer</code></a> header with a value of <code>https://example.com/page.html</code>. 
      <p>Navigations from that same page to <code>https://<strong>not</strong>.example.com/</code> would send no <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc7231#section-5.5.2"><code>Referer</code></a> header.</p>
     </div>
-    <h3 class="heading settled" data-dfn-type="dfn" data-export="" data-level="3.4" data-lt="&quot;origin&quot;" id="referrer-policy-origin"><span class="secno">3.4. </span><span class="content">"<code>origin</code>"</span><span id="referrer-policy-state-origin"></span><a class="self-link" href="#referrer-policy-origin"></a></h3>
-    <p>The <a data-link-type="dfn" href="#referrer-policy-origin">"<code>origin</code>"</a> policy specifies that only the <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc6454#section-6.2">ASCII serialization</a> of the <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc6454#section-3.2">origin</a> of the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client">request client</a> is sent as referrer information
-  when making both <a data-link-type="dfn" href="#same-origin-request">same-origin requests</a> and <a data-link-type="dfn" href="#cross-origin-request">cross-origin requests</a> from a particular <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client">request client</a>.</p>
+    <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-export="" data-level="3.4" data-lt="&quot;origin&quot;" id="referrer-policy-origin"><span class="secno">3.4. </span><span class="content">"<code>origin</code>"</span><span id="referrer-policy-state-origin"></span></h3>
+    <p>The <a data-link-type="dfn" href="#referrer-policy-origin" id="ref-for-referrer-policy-origin-1">"<code>origin</code>"</a> policy specifies that only the <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc6454#section-6.2">ASCII serialization</a> of the <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc6454#section-3.2">origin</a> of the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client">request client</a> is sent as referrer information
+  when making both <a data-link-type="dfn" href="#same-origin-request" id="ref-for-same-origin-request-3">same-origin requests</a> and <a data-link-type="dfn" href="#cross-origin-request" id="ref-for-cross-origin-request-2">cross-origin requests</a> from a particular <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client">request client</a>.</p>
     <p class="note" role="note">Note: The serialization of an origin looks like <code>https://example.com</code>. To ensure that a valid URL is sent in the
   `<code>Referer</code>` header, user agents will append a U+002F SOLIDUS
   ("<code>/</code>") character to the origin (e.g. <code>https://example.com/</code>).</p>
-    <p class="note" role="note">Note: The <a data-link-type="dfn" href="#referrer-policy-origin">"<code>origin</code>"</a> policy causes the origin of HTTPS
+    <p class="note" role="note">Note: The <a data-link-type="dfn" href="#referrer-policy-origin" id="ref-for-referrer-policy-origin-2">"<code>origin</code>"</a> policy causes the origin of HTTPS
   referrers to be sent over the network as part of unencrypted HTTP requests.
-  The <a data-link-type="dfn" href="#referrer-policy-strict-origin">"<code>strict-origin</code>"</a> policy addresses this concern.</p>
-    <div class="example" id="example-b2aaf663"><a class="self-link" href="#example-b2aaf663"></a> If a document at <code>https://example.com/page.html</code> sets a policy of <a data-link-type="dfn" href="#referrer-policy-origin">"<code>origin</code>"</a>, then navigations to any <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc6454#section-3.2">origin</a> would send a <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc7231#section-5.5.2"><code>Referer</code></a> header with a value
+  The <a data-link-type="dfn" href="#referrer-policy-strict-origin" id="ref-for-referrer-policy-strict-origin-1">"<code>strict-origin</code>"</a> policy addresses this concern.</p>
+    <div class="example" id="example-b2aaf663"><a class="self-link" href="#example-b2aaf663"></a> If a document at <code>https://example.com/page.html</code> sets a policy of <a data-link-type="dfn" href="#referrer-policy-origin" id="ref-for-referrer-policy-origin-3">"<code>origin</code>"</a>, then navigations to any <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc6454#section-3.2">origin</a> would send a <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc7231#section-5.5.2"><code>Referer</code></a> header with a value
     of <code>https://example.com/</code>, even to URLs that are not <a data-link-type="dfn" href="https://w3c.github.io/webappsec/specs/mixedcontent/#a-priori-authenticated-url"><em>a
     priori</em> authenticated URLs</a>. </div>
-    <h3 class="heading settled" data-dfn-type="dfn" data-export="" data-level="3.5" data-lt="&quot;strict-origin&quot;" id="referrer-policy-strict-origin"><span class="secno">3.5. </span><span class="content">"<code>strict-origin</code>"</span><a class="self-link" href="#referrer-policy-strict-origin"></a></h3>
-    <p>The <a data-link-type="dfn" href="#referrer-policy-strict-origin">"<code>strict-origin</code>"</a> policy sends the <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc6454#section-6.2">ASCII serialization</a> of the <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc6454#section-3.2">origin</a> of the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client">request client</a> when making requests:</p>
+    <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-export="" data-level="3.5" data-lt="&quot;strict-origin&quot;" id="referrer-policy-strict-origin"><span class="secno">3.5. </span><span class="content">"<code>strict-origin</code>"</span></h3>
+    <p>The <a data-link-type="dfn" href="#referrer-policy-strict-origin" id="ref-for-referrer-policy-strict-origin-2">"<code>strict-origin</code>"</a> policy sends the <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc6454#section-6.2">ASCII serialization</a> of the <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc6454#section-3.2">origin</a> of the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client">request client</a> when making requests:</p>
     <ul>
      <li>from a <a data-link-type="dfn" href="http://www.w3.org/TR/2010/REC-wsc-ui-20100812/#typesoftls">TLS-protected</a> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">environment settings object</a> to a <a data-link-type="dfn" href="https://w3c.github.io/webappsec/specs/mixedcontent/#a-priori-authenticated-url"><em>a priori</em> authenticated URL</a>, and
      <li>from <em>non-</em><a data-link-type="dfn" href="http://www.w3.org/TR/2010/REC-wsc-ui-20100812/#typesoftls">TLS-protected</a> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">environment settings objects</a> to
@@ -1321,31 +1663,31 @@
   referrer information. A <code><a data-link-type="dfn" href="https://tools.ietf.org/html/rfc7231#section-5.5.2">Referer</a></code> HTTP header will not be
   sent.</p>
     <div class="example" id="example-e6df45e4">
-     <a class="self-link" href="#example-e6df45e4"></a> If a document at <code>https://example.com/page.html</code> sets a policy of <a data-link-type="dfn" href="#referrer-policy-strict-origin">"<code>strict-origin</code>"</a>, then navigations to <code>https://<strong>not</strong>.example.com</code> would send a <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc7231#section-5.5.2"><code>Referer</code></a> header with a value of <code>https://example.com/</code>. 
+     <a class="self-link" href="#example-e6df45e4"></a> If a document at <code>https://example.com/page.html</code> sets a policy of <a data-link-type="dfn" href="#referrer-policy-strict-origin" id="ref-for-referrer-policy-strict-origin-3">"<code>strict-origin</code>"</a>, then navigations to <code>https://<strong>not</strong>.example.com</code> would send a <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc7231#section-5.5.2"><code>Referer</code></a> header with a value of <code>https://example.com/</code>. 
      <p>Navigations from that same page to <code><strong>http://</strong>not.example.com</code> would send no <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc7231#section-5.5.2"><code>Referer</code></a> header.</p>
     </div>
-    <div class="example" id="example-e2f29a9f"><a class="self-link" href="#example-e2f29a9f"></a> If a document at <code>http://example.com/page.html</code> sets a policy of <a data-link-type="dfn" href="#referrer-policy-strict-origin">"<code>strict-origin</code>"</a>, then navigations to <code>http://<strong>not</strong>.example.com</code> or <code><strong>https</strong>://example.com</code> would send a <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc7231#section-5.5.2"><code>Referer</code></a> header with a value of <code>http://example.com/</code>. </div>
-    <h3 class="heading settled" data-dfn-type="dfn" data-export="" data-level="3.6" data-lt="&quot;origin-when-cross-origin&quot;" id="referrer-policy-origin-when-cross-origin"><span class="secno">3.6. </span><span class="content">"<code>origin-when-cross-origin</code>"</span><span id="referrer-policy-state-origin-when-cross-origin"></span><a class="self-link" href="#referrer-policy-origin-when-cross-origin"></a></h3>
-    <p>The <a data-link-type="dfn" href="#referrer-policy-origin-when-cross-origin">"<code>origin-when-cross-origin</code>"</a> policy specifies that a
+    <div class="example" id="example-e2f29a9f"><a class="self-link" href="#example-e2f29a9f"></a> If a document at <code>http://example.com/page.html</code> sets a policy of <a data-link-type="dfn" href="#referrer-policy-strict-origin" id="ref-for-referrer-policy-strict-origin-4">"<code>strict-origin</code>"</a>, then navigations to <code>http://<strong>not</strong>.example.com</code> or <code><strong>https</strong>://example.com</code> would send a <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc7231#section-5.5.2"><code>Referer</code></a> header with a value of <code>http://example.com/</code>. </div>
+    <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-export="" data-level="3.6" data-lt="&quot;origin-when-cross-origin&quot;" id="referrer-policy-origin-when-cross-origin"><span class="secno">3.6. </span><span class="content">"<code>origin-when-cross-origin</code>"</span><span id="referrer-policy-state-origin-when-cross-origin"></span></h3>
+    <p>The <a data-link-type="dfn" href="#referrer-policy-origin-when-cross-origin" id="ref-for-referrer-policy-origin-when-cross-origin-1">"<code>origin-when-cross-origin</code>"</a> policy specifies that a
   full URL, <a href="#strip-url">stripped for use as a referrer</a>, is sent as
-  referrer information when making <a data-link-type="dfn" href="#same-origin-request">same-origin requests</a> from a particular <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client">request client</a>, and only the <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc6454#section-6.2">ASCII serialization</a> of the <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc6454#section-3.2">origin</a> of the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client">request client</a> is sent as referrer information
-  when making <a data-link-type="dfn" href="#cross-origin-request">cross-origin requests</a> from a particular <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client">request
+  referrer information when making <a data-link-type="dfn" href="#same-origin-request" id="ref-for-same-origin-request-4">same-origin requests</a> from a particular <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client">request client</a>, and only the <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc6454#section-6.2">ASCII serialization</a> of the <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc6454#section-3.2">origin</a> of the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client">request client</a> is sent as referrer information
+  when making <a data-link-type="dfn" href="#cross-origin-request" id="ref-for-cross-origin-request-3">cross-origin requests</a> from a particular <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client">request
   client</a>.</p>
-    <p class="note" role="note">Note: For the <a data-link-type="dfn" href="#referrer-policy-origin-when-cross-origin">"<code>origin-when-cross-origin</code>"</a> policy, we also
-  consider protocol upgrades, e.g. requests from <code>http://example.com/</code> to <code>https://example.com/</code>, to be <a data-link-type="dfn" href="#cross-origin-request">cross-origin requests</a>.</p>
-    <p class="note" role="note">Note: The <a data-link-type="dfn" href="#referrer-policy-origin-when-cross-origin">"<code>origin-when-cross-origin</code>"</a> policy causes the
+    <p class="note" role="note">Note: For the <a data-link-type="dfn" href="#referrer-policy-origin-when-cross-origin" id="ref-for-referrer-policy-origin-when-cross-origin-2">"<code>origin-when-cross-origin</code>"</a> policy, we also
+  consider protocol upgrades, e.g. requests from <code>http://example.com/</code> to <code>https://example.com/</code>, to be <a data-link-type="dfn" href="#cross-origin-request" id="ref-for-cross-origin-request-4">cross-origin requests</a>.</p>
+    <p class="note" role="note">Note: The <a data-link-type="dfn" href="#referrer-policy-origin-when-cross-origin" id="ref-for-referrer-policy-origin-when-cross-origin-3">"<code>origin-when-cross-origin</code>"</a> policy causes the
   origin of HTTPS referrers to be sent over the network as part of unencrypted
-  HTTP requests. The <a data-link-type="dfn" href="#referrer-policy-strict-origin-when-cross-origin">"<code>strict-origin-when-cross-origin</code>"</a> policy
+  HTTP requests. The <a data-link-type="dfn" href="#referrer-policy-strict-origin-when-cross-origin" id="ref-for-referrer-policy-strict-origin-when-cross-origin-1">"<code>strict-origin-when-cross-origin</code>"</a> policy
   addresses this concern.</p>
     <div class="example" id="example-5fad2266">
-     <a class="self-link" href="#example-5fad2266"></a> If a document at <code>https://example.com/page.html</code> sets a policy of <a data-link-type="dfn" href="#referrer-policy-origin-when-cross-origin">"<code>origin-when-cross-origin</code>"</a>, then navigations to <code>https://example.com/not-page.html</code> would send a <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc7231#section-5.5.2"><code>Referer</code></a> header with a value of <code>https://example.com/page.html</code>. 
+     <a class="self-link" href="#example-5fad2266"></a> If a document at <code>https://example.com/page.html</code> sets a policy of <a data-link-type="dfn" href="#referrer-policy-origin-when-cross-origin" id="ref-for-referrer-policy-origin-when-cross-origin-4">"<code>origin-when-cross-origin</code>"</a>, then navigations to <code>https://example.com/not-page.html</code> would send a <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc7231#section-5.5.2"><code>Referer</code></a> header with a value of <code>https://example.com/page.html</code>. 
      <p>Navigations from that same page to <code>https://not.example.com/</code> would send a <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc7231#section-5.5.2"><code>Referer</code></a> header with a value of <code>https://example.com/</code>, even to URLs that are not <a data-link-type="dfn" href="https://w3c.github.io/webappsec/specs/mixedcontent/#a-priori-authenticated-url"><em>a
     priori</em> authenticated URLs</a>.</p>
     </div>
-    <h3 class="heading settled" data-dfn-type="dfn" data-export="" data-level="3.7" data-lt="&quot;strict-origin-when-cross-origin&quot;" id="referrer-policy-strict-origin-when-cross-origin"><span class="secno">3.7. </span><span class="content">"<code>strict-origin-when-cross-origin</code>"</span><a class="self-link" href="#referrer-policy-strict-origin-when-cross-origin"></a></h3>
-    <p>The <a data-link-type="dfn" href="#referrer-policy-strict-origin-when-cross-origin">"<code>strict-origin-when-cross-origin</code>"</a> policy specifies that a
+    <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-export="" data-level="3.7" data-lt="&quot;strict-origin-when-cross-origin&quot;" id="referrer-policy-strict-origin-when-cross-origin"><span class="secno">3.7. </span><span class="content">"<code>strict-origin-when-cross-origin</code>"</span></h3>
+    <p>The <a data-link-type="dfn" href="#referrer-policy-strict-origin-when-cross-origin" id="ref-for-referrer-policy-strict-origin-when-cross-origin-2">"<code>strict-origin-when-cross-origin</code>"</a> policy specifies that a
   full URL, <a href="#strip-url">stripped for use as a referrer</a>, is sent as
-  referrer information when making <a data-link-type="dfn" href="#same-origin-request">same-origin requests</a> from a particular <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client">request client</a>, and only the <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc6454#section-6.2">ASCII serialization</a> of the <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc6454#section-3.2">origin</a> of the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client">request client</a> when making <a data-link-type="dfn" href="#cross-origin-request">cross-origin requests</a>:</p>
+  referrer information when making <a data-link-type="dfn" href="#same-origin-request" id="ref-for-same-origin-request-5">same-origin requests</a> from a particular <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client">request client</a>, and only the <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc6454#section-6.2">ASCII serialization</a> of the <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc6454#section-3.2">origin</a> of the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client">request client</a> when making <a data-link-type="dfn" href="#cross-origin-request" id="ref-for-cross-origin-request-5">cross-origin requests</a>:</p>
     <ul>
      <li>from a <a data-link-type="dfn" href="http://www.w3.org/TR/2010/REC-wsc-ui-20100812/#typesoftls">TLS-protected</a> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">environment settings object</a> to a <a data-link-type="dfn" href="https://w3c.github.io/webappsec/specs/mixedcontent/#a-priori-authenticated-url"><em>a priori</em> authenticated URL</a>, and
      <li>from <em>non-</em><a data-link-type="dfn" href="http://www.w3.org/TR/2010/REC-wsc-ui-20100812/#typesoftls">TLS-protected</a> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">environment settings objects</a> to
@@ -1356,31 +1698,30 @@
   referrer information. A <code><a data-link-type="dfn" href="https://tools.ietf.org/html/rfc7231#section-5.5.2">Referer</a></code> HTTP header will not be
   sent.</p>
     <div class="example" id="example-2269af87">
-     <a class="self-link" href="#example-2269af87"></a> If a document at <code>https://example.com/page.html</code> sets a policy of <a data-link-type="dfn" href="#referrer-policy-strict-origin-when-cross-origin">"<code>strict-origin-when-cross-origin</code>"</a>, then navigations to <code>https://example.com/not-page.html</code> would send a <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc7231#section-5.5.2"><code>Referer</code></a> header with a value of <code>https://example.com/page.html</code>. 
+     <a class="self-link" href="#example-2269af87"></a> If a document at <code>https://example.com/page.html</code> sets a policy of <a data-link-type="dfn" href="#referrer-policy-strict-origin-when-cross-origin" id="ref-for-referrer-policy-strict-origin-when-cross-origin-3">"<code>strict-origin-when-cross-origin</code>"</a>, then navigations to <code>https://example.com/not-page.html</code> would send a <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc7231#section-5.5.2"><code>Referer</code></a> header with a value of <code>https://example.com/page.html</code>. 
      <p>Navigations from that same page to <code>https://not.example.com/</code> would send a <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc7231#section-5.5.2"><code>Referer</code></a> header with a value of <code>https://example.com/</code>.</p>
      <p>Navigations from that same page to <code><strong>http://</strong>not.example.com/</code> would send no <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc7231#section-5.5.2"><code>Referer</code></a> header.</p>
     </div>
-    <h3 class="heading settled" data-dfn-type="dfn" data-export="" data-level="3.8" data-lt="&quot;unsafe-url&quot;" id="referrer-policy-unsafe-url"><span class="secno">3.8. </span><span class="content">"<code>unsafe-url</code>"</span><span id="referrer-policy-state-unsafe-url"></span><a class="self-link" href="#referrer-policy-unsafe-url"></a></h3>
-    <p>The <a data-link-type="dfn" href="#referrer-policy-unsafe-url">"<code>unsafe-url</code>"</a> policy specifies that a full URL, <a href="#strip-url">stripped for use as a referrer</a>, is sent along with
-  both <a data-link-type="dfn" href="#cross-origin-request">cross-origin requests</a> and <a data-link-type="dfn" href="#same-origin-request">same-origin requests</a> made from
+    <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-export="" data-level="3.8" data-lt="&quot;unsafe-url&quot;" id="referrer-policy-unsafe-url"><span class="secno">3.8. </span><span class="content">"<code>unsafe-url</code>"</span><span id="referrer-policy-state-unsafe-url"></span></h3>
+    <p>The <a data-link-type="dfn" href="#referrer-policy-unsafe-url" id="ref-for-referrer-policy-unsafe-url-1">"<code>unsafe-url</code>"</a> policy specifies that a full URL, <a href="#strip-url">stripped for use as a referrer</a>, is sent along with
+  both <a data-link-type="dfn" href="#cross-origin-request" id="ref-for-cross-origin-request-6">cross-origin requests</a> and <a data-link-type="dfn" href="#same-origin-request" id="ref-for-same-origin-request-6">same-origin requests</a> made from
   a particular <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client">request client</a>.</p>
     <div class="example" id="example-32de6eb8"><a class="self-link" href="#example-32de6eb8"></a> If a document at <code>https://example.com/sekrit.html</code> sets a policy
-    of <a data-link-type="dfn" href="#referrer-policy-unsafe-url">"<code>unsafe-url</code>"</a>, then navigations to <code>http://not.example.com/</code> (and every other origin) would send a <code><a data-link-type="dfn" href="https://tools.ietf.org/html/rfc7231#section-5.5.2">Referer</a></code> HTTP header with a value of <code>https://example.com/sekrit.html</code>. </div>
+    of <a data-link-type="dfn" href="#referrer-policy-unsafe-url" id="ref-for-referrer-policy-unsafe-url-2">"<code>unsafe-url</code>"</a>, then navigations to <code>http://not.example.com/</code> (and every other origin) would send a <code><a data-link-type="dfn" href="https://tools.ietf.org/html/rfc7231#section-5.5.2">Referer</a></code> HTTP header with a value of <code>https://example.com/sekrit.html</code>. </div>
     <p class="note" role="note">Note: The policy’s name doesn’t lie; it is unsafe. This policy will leak
   origins and paths from <a data-link-type="dfn" href="http://www.w3.org/TR/2010/REC-wsc-ui-20100812/#typesoftls">TLS-protected</a> resources to insecure origins.
   Carefully consider the impact of setting such a policy for potentially
   sensitive documents.</p>
     <h3 class="heading settled" data-dfn-type="dfn" data-export="" data-level="3.9" data-lt="The empty string" id="referrer-policy-empty-string"><span class="secno">3.9. </span><span class="content">The empty string</span><a class="self-link" href="#referrer-policy-empty-string"></a></h3>
-    <p>The empty string "" corresponds to no <a data-link-type="dfn" href="#referrer-policy">referrer policy</a>, causing a
-  fallback to a <a data-link-type="dfn" href="#referrer-policy">referrer policy</a> defined elsewhere, or in the case where
-  no such higher-level policy is available, defaulting to <a data-link-type="dfn" href="#referrer-policy-no-referrer-when-downgrade">"<code>no-referrer-when-downgrade</code>"</a>. This defaulting happens in
+    <p>The empty string "" corresponds to no <a data-link-type="dfn" href="#referrer-policy" id="ref-for-referrer-policy-6">referrer policy</a>, causing a
+  fallback to a <a data-link-type="dfn" href="#referrer-policy" id="ref-for-referrer-policy-7">referrer policy</a> defined elsewhere, or in the case where
+  no such higher-level policy is available, defaulting to <a data-link-type="dfn" href="#referrer-policy-no-referrer-when-downgrade" id="ref-for-referrer-policy-no-referrer-when-downgrade-3">"<code>no-referrer-when-downgrade</code>"</a>. This defaulting happens in
   the <a href="#determine-requests-referrer">§8.3 Determine request’s Referrer</a> algorithm.</p>
-    <div class="example" id="example-1c0fffaa"><a class="self-link" href="#example-1c0fffaa"></a> Given a HTML <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-a-element">a</a></code> element without any declared <code><a data-link-type="element-attr" href="https://html.spec.whatwg.org/multipage/semantics.html#attr-a-referrerpolicy">referrerpolicy</a></code> attribute, its referrer policy is the empty string. Thus, navigation
+    <div class="example" id="example-27ee7725"><a class="self-link" href="#example-27ee7725"></a> Given a HTML <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-a-element">a</a></code> element without any declared <code><a data-link-type="element-sub" href="https://html.spec.whatwg.org/multipage/semantics.html#attr-a-referrerpolicy">referrerpolicy</a></code> attribute, its referrer policy is the empty string. Thus, navigation
     requests initiated by clicking on that <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-a-element">a</a></code> element will be sent
-    
     with the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#concept-document-referrer-policy">referrer
     policy</a> of the <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-a-element">a</a></code> element’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-node-document">node document</a>. If that <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/dom.html#document">Document</a></code> has the empty string as its referrer policy, the <a href="#determine-requests-referrer">§8.3 Determine request’s Referrer</a> algorithm will treat the empty
-    string the same as <a data-link-type="dfn" href="#referrer-policy-no-referrer-when-downgrade">"<code>no-referrer-when-downgrade</code>"</a>. </div>
+    string the same as <a data-link-type="dfn" href="#referrer-policy-no-referrer-when-downgrade" id="ref-for-referrer-policy-no-referrer-when-downgrade-4">"<code>no-referrer-when-downgrade</code>"</a>. </div>
    </section>
    <section>
     <h2 class="heading settled" data-level="4" id="referrer-policy-delivery"><span class="secno">4. </span><span class="content">Referrer Policy Delivery</span><a class="self-link" href="#referrer-policy-delivery"></a></h2>
@@ -1388,21 +1729,21 @@
     <ul>
      <li> Via the <code>Referrer-Policy</code> HTTP header (defined
       in <a href="#referrer-policy-header">§4.1 Delivery via Referrer-Policy header</a>). 
-     <li> Via a <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#meta">meta</a></code> element with a <code><a data-link-type="element-attr" href="https://html.spec.whatwg.org/multipage/semantics.html#attr-meta-name">name</a></code> of <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/semantics.html#meta-referrer"><code>referrer</code></a>. 
+     <li> Via a <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#meta">meta</a></code> element with a <code><a data-link-type="element-sub" href="https://html.spec.whatwg.org/multipage/semantics.html#attr-meta-name">name</a></code> of <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/semantics.html#meta-referrer"><code>referrer</code></a>. 
      <li> Via a <code>referrerpolicy</code> content attribute on an <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-a-element">a</a></code>, <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-area-element">area</a></code>, <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element">img</a></code>, <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-iframe-element">iframe</a></code>, or <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-link-element">link</a></code> element. 
      <li> Via the <code><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/semantics.html#link-type-noreferrer">noreferrer</a></code> link relation on an <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-a-element">a</a></code>, <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-area-element">area</a></code>, or <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-link-element">link</a></code> element. 
      <li> Implicitly, via inheritance. 
     </ul>
     <h3 class="heading settled" data-level="4.1" id="referrer-policy-header"><span class="secno">4.1. </span><span class="content">Delivery via Referrer-Policy header</span><a class="self-link" href="#referrer-policy-header"></a></h3>
-    <p>The <code><dfn data-dfn-type="dfn" data-local-lt="referrer-policy header" data-noexport="" id="referrer-policy-header-dfn">Referrer-Policy<a class="self-link" href="#referrer-policy-header-dfn"></a></dfn></code> HTTP
+    <p>The <code><dfn class="dfn-paneled" data-dfn-type="dfn" data-local-lt="referrer-policy header" data-noexport="" id="referrer-policy-header-dfn">Referrer-Policy</dfn></code> HTTP
   header specifies the referrer policy that the user agent applies when
   determining what referrer information should be included with requests
   made, and with <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context">browsing contexts</a> created from the context of the protected resource.
   The syntax for the name and value of the header are described by the
   following ABNF grammar:</p>
-<pre>"Referrer-Policy:" 1#<a data-link-type="dfn" href="#policy-token">policy-token</a>
+<pre>"Referrer-Policy:" 1#<a data-link-type="dfn" href="#policy-token" id="ref-for-policy-token-1">policy-token</a>
 </pre>
-<pre><dfn data-dfn-type="dfn" data-export="" id="policy-token">policy-token<a class="self-link" href="#policy-token"></a></dfn>   = "no-referrer" / "no-referrer-when-downgrade" / "strict-origin" / "strict-origin-when-cross-origin" / "same-origin" / "origin" / "origin-when-cross-origin" / "unsafe-url"
+<pre><dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="policy-token">policy-token</dfn>   = "no-referrer" / "no-referrer-when-downgrade" / "strict-origin" / "strict-origin-when-cross-origin" / "same-origin" / "origin" / "origin-when-cross-origin" / "unsafe-url"
 </pre>
     <p class="note" role="note">Note: The header name does not share the HTTP Referer header’s misspelling.</p>
     <p><a href="#integration-with-fetch">§5 Integration with Fetch</a> and <a href="#integration-with-html">§6 Integration with HTML</a> describe
@@ -1419,7 +1760,7 @@
     <section class="informative">
      <h3 class="heading settled" data-level="4.2" id="referrer-policy-delivery-meta"><span class="secno">4.2. </span><span class="content">Delivery via <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#meta">meta</a></code></span><a class="self-link" href="#referrer-policy-delivery-meta"></a></h3>
      <p><em>This section is not normative.</em></p>
-     <p>The HTML Standard defines the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/semantics.html#meta-referrer"><code>referrer</code></a> keyword for the <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#meta">meta</a></code> element, which allows setting the <a data-link-type="dfn" href="#referrer-policy">referrer
+     <p>The HTML Standard defines the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/semantics.html#meta-referrer"><code>referrer</code></a> keyword for the <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#meta">meta</a></code> element, which allows setting the <a data-link-type="dfn" href="#referrer-policy" id="ref-for-referrer-policy-8">referrer
     policy</a> via markup.</p>
     </section>
     <section class="informative">
@@ -1435,8 +1776,8 @@
      <p><em>This section is not normative.</em></p>
      <p>The HTML Standard and Fetch Standard define how nested browsing contexts
     that are not created from <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">responses</a>, such as <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-iframe-element">iframe</a></code> elements with
-    their <code><a data-link-type="element-attr" href="https://html.spec.whatwg.org/multipage/embedded-content.html#attr-iframe-srcdoc">srcdoc</a></code> attribute set, or created from a blob URL, inherit
-    their <a data-link-type="dfn" href="#referrer-policy">referrer policy</a> from the creator browsing context or blob URL.</p>
+    their <code><a data-link-type="element-sub" href="https://html.spec.whatwg.org/multipage/embedded-content.html#attr-iframe-srcdoc">srcdoc</a></code> attribute set, or created from a blob URL, inherit
+    their <a data-link-type="dfn" href="#referrer-policy" id="ref-for-referrer-policy-9">referrer policy</a> from the creator browsing context or blob URL.</p>
     </section>
    </section>
    <section class="informative">
@@ -1452,7 +1793,7 @@
    <section class="informative">
     <h2 class="heading settled" data-level="6" id="integration-with-html"><span class="secno">6. </span><span class="content">Integration with HTML</span><a class="self-link" href="#integration-with-html"></a></h2>
     <p><em>This section is not normative.</em></p>
-    <p>The HTML Standard determines the <a data-link-type="dfn" href="#referrer-policy">referrer policy</a> of any response
+    <p>The HTML Standard determines the <a data-link-type="dfn" href="#referrer-policy" id="ref-for-referrer-policy-10">referrer policy</a> of any response
   received during <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#navigate">navigation</a> or while <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/workers.html#run a worker">running a worker</a>, and uses
   the result to set the resulting <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/dom.html#document">Document</a></code> or <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#workerglobalscope">WorkerGlobalScope</a></code>'s
   referrer policy. This is later used by the corresponding <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">environment
@@ -1470,10 +1811,10 @@
     <p>Implementations should keep track of a referrer policy for each stylesheet
   that should be used to create requests for resources from the respective
   stylesheet.</p>
-    <p>For external stylesheets, the referrer policy should be <a data-link-type="dfn" href="#referrer-policy-no-referrer-when-downgrade">"<code>no-referrer-when-downgrade</code>"</a> unless overwritten by an
+    <p>For external stylesheets, the referrer policy should be <a data-link-type="dfn" href="#referrer-policy-no-referrer-when-downgrade" id="ref-for-referrer-policy-no-referrer-when-downgrade-5">"<code>no-referrer-when-downgrade</code>"</a> unless overwritten by an
   `<code>Referrer-Policy</code>` header.</p>
     <p class="note" role="note">Note: If the stylesheet was loaded via a HTML <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-link-element">link</a></code> element with a
-  declared <code><a data-link-type="element-attr" href="https://html.spec.whatwg.org/multipage/semantics.html#attr-link-referrerpolicy">referrerpolicy</a></code>, this referrer policy will not affect the
+  declared <code><a data-link-type="element-sub" href="https://html.spec.whatwg.org/multipage/semantics.html#attr-link-referrerpolicy">referrerpolicy</a></code>, this referrer policy will not affect the
   requests for resources referenced from the stylesheet.</p>
     <p>For inline stylesheets, and styles applied via an <code>style</code> attribute on an element, the referrer policy is the containing <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/dom.html#document">Document</a></code>'s
   referrer policy.  Both the value of the referrer and the value of the
@@ -1481,13 +1822,13 @@
    </section>
    <section>
     <h2 class="heading settled" data-level="8" id="algorithms"><span class="secno">8. </span><span class="content">Algorithms</span><a class="self-link" href="#algorithms"></a></h2>
-    <h3 class="heading settled" data-level="8.1" id="parse-referrer-policy-from-header"><span class="secno">8.1. </span><span class="content"> Parse a referrer policy from a <a data-link-type="dfn" href="#referrer-policy-header-dfn"><code>Referrer-Policy</code></a> header </span><a class="self-link" href="#parse-referrer-policy-from-header"></a></h3>
-    <p>Given a <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#response">Response</a></code> <var>response</var>, the following steps return a <a data-link-type="dfn" href="#referrer-policy">referrer policy</a> according to <var>response</var>’s `<code>Referrer-Policy</code>` header:</p>
+    <h3 class="heading settled" data-level="8.1" id="parse-referrer-policy-from-header"><span class="secno">8.1. </span><span class="content"> Parse a referrer policy from a <a data-link-type="dfn" href="#referrer-policy-header-dfn" id="ref-for-referrer-policy-header-dfn-1"><code>Referrer-Policy</code></a> header </span><a class="self-link" href="#parse-referrer-policy-from-header"></a></h3>
+    <p>Given a <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#response">Response</a></code> <var>response</var>, the following steps return a <a data-link-type="dfn" href="#referrer-policy" id="ref-for-referrer-policy-11">referrer policy</a> according to <var>response</var>’s `<code>Referrer-Policy</code>` header:</p>
     <ol>
      <li> Let <var>policy-tokens</var> be the result of <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-header-parse">parsing</a> `<code>Referrer-Policy</code>` in <var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-header-list">header list</a>. 
      <li> Let <var>policy</var> be the empty string. 
      <li>
-       For each <var>token</var> in <var>policy-tokens</var>, if <var>token</var> is a <a data-link-type="dfn" href="#referrer-policy">referrer
+       For each <var>token</var> in <var>policy-tokens</var>, if <var>token</var> is a <a data-link-type="dfn" href="#referrer-policy" id="ref-for-referrer-policy-12">referrer
       policy</a> and <var>token</var> is not the empty string, then set <var>policy</var> to <var>token</var>. 
       <p class="note" role="note">Note: This algorithm loops over multiple policy values to allow
 	  deployment of new policy values with fallbacks for older user
@@ -1537,17 +1878,17 @@
       "<code>no-referrer</code>", Fetch will not call into this algorithm.</p>
      <li> Let <var>referrerURL</var> be the result of <a href="#strip-url">stripping <var>referrerSource</var> for use as a referrer.</a> 
      <li> Let <var>referrerOrigin</var> be the result of <a href="#strip-url">stripping <var>referrerSource</var> for use as a
-      referrer</a>, with the <code><a data-link-type="dfn" href="#origin-only-flag">origin-only flag</a></code> set to <code>true</code>. 
+      referrer</a>, with the <code><a data-link-type="dfn" href="#origin-only-flag" id="ref-for-origin-only-flag-1">origin-only flag</a></code> set to <code>true</code>. 
      <li>
        Execute the statements corresponding to the value of <var>policy</var>: 
       <dl class="switch">
-       <dt><a data-link-type="dfn" href="#referrer-policy-no-referrer">"<code>no-referrer</code>"</a>
+       <dt><a data-link-type="dfn" href="#referrer-policy-no-referrer" id="ref-for-referrer-policy-no-referrer-3">"<code>no-referrer</code>"</a>
        <dd>Return <code>no referrer</code>
-       <dt><a data-link-type="dfn" href="#referrer-policy-origin">"<code>origin</code>"</a>
+       <dt><a data-link-type="dfn" href="#referrer-policy-origin" id="ref-for-referrer-policy-origin-4">"<code>origin</code>"</a>
        <dd>Return <var>referrerOrigin</var>
-       <dt><a data-link-type="dfn" href="#referrer-policy-unsafe-url">"<code>unsafe-url</code>"</a>
+       <dt><a data-link-type="dfn" href="#referrer-policy-unsafe-url" id="ref-for-referrer-policy-unsafe-url-3">"<code>unsafe-url</code>"</a>
        <dd>Return <var>referrerURL</var>.
-       <dt><a data-link-type="dfn" href="#referrer-policy-strict-origin">"<code>strict-origin</code>"</a>
+       <dt><a data-link-type="dfn" href="#referrer-policy-strict-origin" id="ref-for-referrer-policy-strict-origin-5">"<code>strict-origin</code>"</a>
        <dd>
         <ol>
          <li>
@@ -1559,10 +1900,10 @@
           </ol>
          <li>Return <var>referrerOrigin</var>. 
         </ol>
-       <dt><a data-link-type="dfn" href="#referrer-policy-strict-origin-when-cross-origin">"<code>strict-origin-when-cross-origin</code>"</a>
+       <dt><a data-link-type="dfn" href="#referrer-policy-strict-origin-when-cross-origin" id="ref-for-referrer-policy-strict-origin-when-cross-origin-4">"<code>strict-origin-when-cross-origin</code>"</a>
        <dd>
         <ol>
-         <li> If <var>request</var> is a <a data-link-type="dfn" href="#same-origin-request">same-origin request</a>, then
+         <li> If <var>request</var> is a <a data-link-type="dfn" href="#same-origin-request" id="ref-for-same-origin-request-7">same-origin request</a>, then
               return <var>referrerURL</var>. 
          <li>
            If <var>environment</var> is not null: 
@@ -1576,21 +1917,21 @@
           </ol>
          <li>Return <var>referrerOrigin</var>. 
         </ol>
-       <dt><a data-link-type="dfn" href="#referrer-policy-same-origin">"<code>same-origin</code>"</a>
+       <dt><a data-link-type="dfn" href="#referrer-policy-same-origin" id="ref-for-referrer-policy-same-origin-3">"<code>same-origin</code>"</a>
        <dd>
         <ol>
-         <li> If <var>request</var> is a <a data-link-type="dfn" href="#same-origin-request">same-origin request</a>, then
+         <li> If <var>request</var> is a <a data-link-type="dfn" href="#same-origin-request" id="ref-for-same-origin-request-8">same-origin request</a>, then
               return <var>referrerURL</var>. 
          <li> Otherwise, return <code>no referrer</code>. 
         </ol>
-       <dt><a data-link-type="dfn" href="#referrer-policy-origin-when-cross-origin">"<code>origin-when-cross-origin</code>"</a>
+       <dt><a data-link-type="dfn" href="#referrer-policy-origin-when-cross-origin" id="ref-for-referrer-policy-origin-when-cross-origin-5">"<code>origin-when-cross-origin</code>"</a>
        <dd>
         <ol>
-         <li> If <var>request</var> is a <a data-link-type="dfn" href="#cross-origin-request">cross-origin request</a>, then
+         <li> If <var>request</var> is a <a data-link-type="dfn" href="#cross-origin-request" id="ref-for-cross-origin-request-7">cross-origin request</a>, then
               return <var>referrerOrigin</var>. 
          <li> Otherwise, return <var>referrerURL</var>. 
         </ol>
-       <dt><a data-link-type="dfn" href="#referrer-policy-no-referrer-when-downgrade">"<code>no-referrer-when-downgrade</code>"</a>
+       <dt><a data-link-type="dfn" href="#referrer-policy-no-referrer-when-downgrade" id="ref-for-referrer-policy-no-referrer-when-downgrade-6">"<code>no-referrer-when-downgrade</code>"</a>
        <dd>
         <ol>
          <li>
@@ -1603,14 +1944,14 @@
          <li>Return <var>referrerURL</var>. 
         </ol>
       </dl>
-      <p class="note" role="note">Note: Fetch will ensure <var>request</var>’s <a data-link-type="dfn" href="#referrer-policy">referrer policy</a> is not the
+      <p class="note" role="note">Note: Fetch will ensure <var>request</var>’s <a data-link-type="dfn" href="#referrer-policy" id="ref-for-referrer-policy-13">referrer policy</a> is not the
       empty string before calling this algorithm.</p>
     </ol>
     <h3 class="heading settled" data-level="8.4" id="strip-url"><span class="secno">8.4. </span><span class="content"> Strip <var>url</var> for use as a referrer </span><a class="self-link" href="#strip-url"></a></h3>
     <p>Certain portions of URLs MUST not be included when sending a URL as the value
   of a `<code>Referer</code>` header: a URLs fragment, username, and password
   components should be stripped from the URL before it’s sent out. This
-  algorithm accepts a <code><dfn data-dfn-type="dfn" data-noexport="" id="origin-only-flag">origin-only flag<a class="self-link" href="#origin-only-flag"></a></dfn></code>, which defaults
+  algorithm accepts a <code><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="origin-only-flag">origin-only flag</dfn></code>, which defaults
   to <code>false</code>. If set to <code>true</code>, the algorithm will
   additionally remove the URL’s path and query components, leaving only the
   scheme, host, and port.</p>
@@ -1622,13 +1963,65 @@
      <li> Set <var>url</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-password">password</a> to <code>null</code>. 
      <li> Set <var>url</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#concept-url-fragment">fragment</a> to <code>null</code>. 
      <li>
-       If the <code><a data-link-type="dfn" href="#origin-only-flag">origin-only flag</a></code> is <code>true</code>,
+       If the <code><a data-link-type="dfn" href="#origin-only-flag" id="ref-for-origin-only-flag-2">origin-only flag</a></code> is <code>true</code>,
       then: 
       <ol>
        <li> Set <var>url</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-path">path</a> to <code>null</code>. 
        <li> Set <var>url</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-query">query</a> to <code>null</code>. 
       </ol>
      <li> Return <var>url</var>. 
+    </ol>
+    <h3 class="heading settled" data-level="8.5" id="ancestor-origin"><span class="secno">8.5. </span><span class="content"> Determine the Ancestor Origin availble to a Location </span><a class="self-link" href="#ancestor-origin"></a></h3>
+     Given a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#location">Location</a> <var>location</var> and a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context">browsing context</a> <var>context</var> we can determine what origin information for <var>context</var> should be included in <var>location</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#concept-location-ancestor-origins-array">ancestor origins array</a>. 
+    <ol>
+     <li>Let <var>document</var> be <var>context</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#active-document">active document</a>.
+     <li>Let <var>documentOrigin</var> be <var>document</var>’s <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc6454#section-3.2">origin</a>.
+     <li>If <var>documentOrigin</var> is an <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin-opaque">opaque origin</a>, return <code>"null"</code>. 
+     <li>Let <var>locationOrigin</var> be <var>location</var>’s relevant <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document">Document</a>’s <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc6454#section-3.2">origin</a>. 
+     <li>Let <var>policy</var> be <var>document</var>’s <a data-link-type="dfn" href="#referrer-policy" id="ref-for-referrer-policy-14">referrer policy</a>.
+     <li>
+       Execute the statements corresponding to the value of <var>policy</var>: 
+      <dl class="switch">
+       <dt><a data-link-type="dfn" href="#referrer-policy-no-referrer" id="ref-for-referrer-policy-no-referrer-4">"<code>no-referrer</code>"</a>
+       <dd>Return <code>"null"</code>
+       <dt><a data-link-type="dfn" href="#referrer-policy-origin" id="ref-for-referrer-policy-origin-5">"<code>origin</code>"</a>
+       <dd>Return <var>documentOrigin</var>.
+       <dt><a data-link-type="dfn" href="#referrer-policy-unsafe-url" id="ref-for-referrer-policy-unsafe-url-4">"<code>unsafe-url</code>"</a>
+       <dd>Return <var>documentOrigin</var>.
+       <dt><a data-link-type="dfn" href="#referrer-policy-strict-origin" id="ref-for-referrer-policy-strict-origin-6">"<code>strict-origin</code>"</a>
+       <dd>
+        <ol>
+         <li> If <var>context</var> is <a data-link-type="dfn" href="http://www.w3.org/TR/2010/REC-wsc-ui-20100812/#typesoftls">TLS-protected</a> <em>and</em> <var>locationOrigin</var> is not an <a data-link-type="dfn" href="https://w3c.github.io/webappsec/specs/mixedcontent/#a-priori-authenticated-url"><em>a priori</em> authenticated
+              URL</a>, return <code>"null"</code>. 
+         <li> Return <var>documentOrigin</var> 
+        </ol>
+       <dt><a data-link-type="dfn" href="#referrer-policy-strict-origin-when-cross-origin" id="ref-for-referrer-policy-strict-origin-when-cross-origin-5">"<code>strict-origin-when-cross-origin</code>"</a>
+       <dd>
+        <ol>
+         <li> If <var>documentOrigin</var> and <var>locationOrigin</var> are <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#same-origin">same origin</a>, return <var>documentOrigin</var>. 
+         <li> If <var>context</var> is <a data-link-type="dfn" href="http://www.w3.org/TR/2010/REC-wsc-ui-20100812/#typesoftls">TLS-protected</a> <em>and</em> <var>locationOrigin</var> is not an <a data-link-type="dfn" href="https://w3c.github.io/webappsec/specs/mixedcontent/#a-priori-authenticated-url"><em>a priori</em> authenticated
+              URL</a>, return <code>"null"</code>. 
+         <li> Return <var>documentOrigin</var> 
+        </ol>
+       <dt><a data-link-type="dfn" href="#referrer-policy-same-origin" id="ref-for-referrer-policy-same-origin-4">"<code>same-origin</code>"</a>
+       <dd>
+        <ol>
+         <li> If <var>documentOrigin</var> and <var>locationOrigin</var> are <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#same-origin">same origin</a>, return <var>documentOrigin</var>. 
+         <li> Otherwise, return <code>"null"</code>. 
+        </ol>
+       <dt><a data-link-type="dfn" href="#referrer-policy-origin-when-cross-origin" id="ref-for-referrer-policy-origin-when-cross-origin-6">"<code>origin-when-cross-origin</code>"</a>
+       <dd>
+        <ol>
+         <li> Return <var>documentOrigin</var>. 
+        </ol>
+       <dt><a data-link-type="dfn" href="#referrer-policy-no-referrer-when-downgrade" id="ref-for-referrer-policy-no-referrer-when-downgrade-7">"<code>no-referrer-when-downgrade</code>"</a>
+       <dd>
+        <ol>
+         <li> If <var>context</var> is <a data-link-type="dfn" href="http://www.w3.org/TR/2010/REC-wsc-ui-20100812/#typesoftls">TLS-protected</a> <em>and</em> <var>locationOrigin</var> is not an <a data-link-type="dfn" href="https://w3c.github.io/webappsec/specs/mixedcontent/#a-priori-authenticated-url"><em>a priori</em> authenticated
+              URL</a>, return <code>"null"</code>. 
+         <li> Return <var>documentOrigin</var> 
+        </ol>
+      </dl>
     </ol>
    </section>
    <section>
@@ -1638,22 +2031,22 @@
   agents from offering options to users which would change the information
   sent out via a `<code>Referer</code>` header. For instance, user agents
   MAY allow users to suppress the referrer header entirely, regardless of the
-  active <a data-link-type="dfn" href="#referrer-policy">referrer policy</a> on a page.</p>
+  active <a data-link-type="dfn" href="#referrer-policy" id="ref-for-referrer-policy-15">referrer policy</a> on a page.</p>
    </section>
    <section>
     <h2 class="heading settled" data-level="10" id="security"><span class="secno">10. </span><span class="content">Security Considerations</span><a class="self-link" href="#security"></a></h2>
     <h3 class="heading settled" data-level="10.1" id="information-leakage"><span class="secno">10.1. </span><span class="content">Information Leakage</span><a class="self-link" href="#information-leakage"></a></h3>
-    <p>The <a data-link-type="dfn" href="#referrer-policy">referrer policies</a> <a data-link-type="dfn" href="#referrer-policy-origin">"<code>origin</code>"</a>, <a data-link-type="dfn" href="#referrer-policy-origin-when-cross-origin">"<code>origin-when-cross-origin</code>"</a> and <a data-link-type="dfn" href="#referrer-policy-unsafe-url">"<code>unsafe-url</code>"</a> might leak the origin and the URL of
+    <p>The <a data-link-type="dfn" href="#referrer-policy" id="ref-for-referrer-policy-16">referrer policies</a> <a data-link-type="dfn" href="#referrer-policy-origin" id="ref-for-referrer-policy-origin-6">"<code>origin</code>"</a>, <a data-link-type="dfn" href="#referrer-policy-origin-when-cross-origin" id="ref-for-referrer-policy-origin-when-cross-origin-7">"<code>origin-when-cross-origin</code>"</a> and <a data-link-type="dfn" href="#referrer-policy-unsafe-url" id="ref-for-referrer-policy-unsafe-url-5">"<code>unsafe-url</code>"</a> might leak the origin and the URL of
   a secure site respectively via insecure transport.</p>
     <p>Those three policies are included in the spec nevertheless to lower the friction
   of sites adopting secure transport.</p>
     <p>Authors wanting to ensure that they do not leak any more information than
-  the default policy should instead use the policy states <a data-link-type="dfn" href="#referrer-policy-same-origin">"<code>same-origin</code>"</a>, <a data-link-type="dfn" href="#referrer-policy-strict-origin">"<code>strict-origin</code>"</a>, <a data-link-type="dfn" href="#referrer-policy-strict-origin-when-cross-origin">"<code>strict-origin-when-cross-origin</code>"</a> or <a data-link-type="dfn" href="#referrer-policy-no-referrer">"<code>no-referrer</code>"</a>.</p>
+  the default policy should instead use the policy states <a data-link-type="dfn" href="#referrer-policy-same-origin" id="ref-for-referrer-policy-same-origin-5">"<code>same-origin</code>"</a>, <a data-link-type="dfn" href="#referrer-policy-strict-origin" id="ref-for-referrer-policy-strict-origin-7">"<code>strict-origin</code>"</a>, <a data-link-type="dfn" href="#referrer-policy-strict-origin-when-cross-origin" id="ref-for-referrer-policy-strict-origin-when-cross-origin-6">"<code>strict-origin-when-cross-origin</code>"</a> or <a data-link-type="dfn" href="#referrer-policy-no-referrer" id="ref-for-referrer-policy-no-referrer-5">"<code>no-referrer</code>"</a>.</p>
     <h3 class="heading settled" data-level="10.2" id="downgrade"><span class="secno">10.2. </span><span class="content">Downgrade to less strict policies</span><a class="self-link" href="#downgrade"></a></h3>
-    <p>The spec does not forbid downgrading to less strict policies, e.g., from <a data-link-type="dfn" href="#referrer-policy-no-referrer">"<code>no-referrer</code>"</a> to <a data-link-type="dfn" href="#referrer-policy-unsafe-url">"<code>unsafe-url</code>"</a>.</p>
+    <p>The spec does not forbid downgrading to less strict policies, e.g., from <a data-link-type="dfn" href="#referrer-policy-no-referrer" id="ref-for-referrer-policy-no-referrer-6">"<code>no-referrer</code>"</a> to <a data-link-type="dfn" href="#referrer-policy-unsafe-url" id="ref-for-referrer-policy-unsafe-url-6">"<code>unsafe-url</code>"</a>.</p>
     <p>On the one hand, it is not clear which policy is more strict for all possible
-  pairs of policies: While <a data-link-type="dfn" href="#referrer-policy-no-referrer-when-downgrade">"<code>no-referrer-when-downgrade</code>"</a> will
-  not leak any information over insecure transport, and <a data-link-type="dfn" href="#referrer-policy-origin">"<code>origin</code>"</a> will, the latter reveals less information
+  pairs of policies: While <a data-link-type="dfn" href="#referrer-policy-no-referrer-when-downgrade" id="ref-for-referrer-policy-no-referrer-when-downgrade-8">"<code>no-referrer-when-downgrade</code>"</a> will
+  not leak any information over insecure transport, and <a data-link-type="dfn" href="#referrer-policy-origin" id="ref-for-referrer-policy-origin-7">"<code>origin</code>"</a> will, the latter reveals less information
   across cross-origin navigations.</p>
     <p>On the other hand, allowing for setting less strict policies enables authors
   to define safe fallbacks as described in <a href="#unknown-policy-values">§11.1 Unknown Policy Values</a>.</p>
@@ -1666,9 +2059,9 @@
   referrer policy, the value of the latest one will be used. This makes
   it possible to deploy new policy values.</p>
     <div class="example" id="example-e42fe91b"><a class="self-link" href="#example-e42fe91b"></a> Suppose older user agents don’t understand
-    the <a data-link-type="dfn" href="#referrer-policy-unsafe-url">"<code>unsafe-url</code>"</a> policy. A site can specify
-    an <a data-link-type="dfn" href="#referrer-policy-origin">"<code>origin</code>"</a> policy followed by an <a data-link-type="dfn" href="#referrer-policy-unsafe-url">"<code>unsafe-url</code>"</a> policy: older user agents will ignore the
-    unknown <a data-link-type="dfn" href="#referrer-policy-unsafe-url">"<code>unsafe-url</code>"</a> value and use <a data-link-type="dfn" href="#referrer-policy-origin">"<code>origin</code>"</a>, while newer user agents will use <a data-link-type="dfn" href="#referrer-policy-unsafe-url">"<code>unsafe-url</code>"</a> because it is the last to be processed. </div>
+    the <a data-link-type="dfn" href="#referrer-policy-unsafe-url" id="ref-for-referrer-policy-unsafe-url-7">"<code>unsafe-url</code>"</a> policy. A site can specify
+    an <a data-link-type="dfn" href="#referrer-policy-origin" id="ref-for-referrer-policy-origin-8">"<code>origin</code>"</a> policy followed by an <a data-link-type="dfn" href="#referrer-policy-unsafe-url" id="ref-for-referrer-policy-unsafe-url-8">"<code>unsafe-url</code>"</a> policy: older user agents will ignore the
+    unknown <a data-link-type="dfn" href="#referrer-policy-unsafe-url" id="ref-for-referrer-policy-unsafe-url-9">"<code>unsafe-url</code>"</a> value and use <a data-link-type="dfn" href="#referrer-policy-origin" id="ref-for-referrer-policy-origin-9">"<code>origin</code>"</a>, while newer user agents will use <a data-link-type="dfn" href="#referrer-policy-unsafe-url" id="ref-for-referrer-policy-unsafe-url-10">"<code>unsafe-url</code>"</a> because it is the last to be processed. </div>
     <p>This behavior does not, however, apply to
   the <code>referrerpolicy</code> attribute. Authors may dynamically set
   and get the <code>referrerpolicy</code> attribute to detect whether a
@@ -1682,22 +2075,22 @@
   <h2 class="no-ref no-num heading settled" id="conformance"><span class="content">Conformance</span><a class="self-link" href="#conformance"></a></h2>
   <h3 class="no-ref no-num heading settled" id="conventions"><span class="content">Document conventions</span><a class="self-link" href="#conventions"></a></h3>
   <p>Conformance requirements are expressed with a combination of
-    descriptive assertions and RFC 2119 terminology. The key words "MUST",
-    "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT",
-    "RECOMMENDED", "MAY", and "OPTIONAL" in the normative parts of this
+    descriptive assertions and RFC 2119 terminology. The key words “MUST”,
+    “MUST NOT”, “REQUIRED”, “SHALL”, “SHALL NOT”, “SHOULD”, “SHOULD NOT”,
+    “RECOMMENDED”, “MAY”, and “OPTIONAL” in the normative parts of this
     document are to be interpreted as described in RFC 2119.
     However, for readability, these words do not appear in all uppercase
     letters in this specification. </p>
   <p>All of the text of this specification is normative except sections
     explicitly marked as non-normative, examples, and notes. <a data-link-type="biblio" href="#biblio-rfc2119">[RFC2119]</a></p>
-  <p>Examples in this specification are introduced with the words "for example"
+  <p>Examples in this specification are introduced with the words “for example”
     or are set apart from the normative text with <code>class="example"</code>,
     like this: </p>
   <div class="example" id="example-f839f6c8">
    <a class="self-link" href="#example-f839f6c8"></a> 
    <p>This is an example of an informative example.</p>
   </div>
-  <p>Informative notes begin with the word "Note" and are set apart from the
+  <p>Informative notes begin with the word “Note” and are set apart from the
     normative text with <code>class="note"</code>, like this: </p>
   <p class="note" role="note">Note, this is an informative note.</p>
   <h3 class="no-ref no-num heading settled" id="conformant-algorithms"><span class="content">Conformant Algorithms</span><a class="self-link" href="#conformant-algorithms"></a></h3>
@@ -1710,31 +2103,81 @@
     particular, the algorithms defined in this specification are intended to
     be easy to understand and are not intended to be performant. Implementers
     are encouraged to optimize.</p>
-  <h2 class="no-num heading settled" id="index"><span class="content">Index</span><a class="self-link" href="#index"></a></h2>
-  <h3 class="no-num heading settled" id="index-defined-here"><span class="content">Terms defined by this specification</span><a class="self-link" href="#index-defined-here"></a></h3>
-  <ul class="indexlist">
+<script src="https://www.w3.org/scripts/TR/2016/fixup.js"></script>
+  <h2 class="no-num no-ref heading settled" id="index"><span class="content">Index</span><a class="self-link" href="#index"></a></h2>
+  <h3 class="no-num no-ref heading settled" id="index-defined-here"><span class="content">Terms defined by this specification</span><a class="self-link" href="#index-defined-here"></a></h3>
+  <ul class="index">
+   <li><a href="#dom-referrerpolicy">""</a><span>, in §3</span>
    <li><a href="#cross-origin-request">cross-origin request</a><span>, in §2</span>
-   <li><a href="#referrer-policy-no-referrer">"no-referrer"</a><span>, in §3</span>
-   <li><a href="#referrer-policy-no-referrer-when-downgrade">"no-referrer-when-downgrade"</a><span>, in §3.1</span>
-   <li><a href="#referrer-policy-origin">"origin"</a><span>, in §3.3</span>
+   <li>
+    "no-referrer"
+    <ul>
+     <li><a href="#dom-referrerpolicy-no-referrer">enum-value for ReferrerPolicy</a><span>, in §3</span>
+     <li><a href="#referrer-policy-no-referrer">definition of</a><span>, in §3</span>
+    </ul>
+   <li><a href="#dom-referrerpolicy-no-referrer">no-referrer</a><span>, in §3</span>
+   <li><a href="#dom-referrerpolicy-no-referrer-when-downgrade">no-referrer-when-downgrade</a><span>, in §3</span>
+   <li>
+    "no-referrer-when-downgrade"
+    <ul>
+     <li><a href="#dom-referrerpolicy-no-referrer-when-downgrade">enum-value for ReferrerPolicy</a><span>, in §3</span>
+     <li><a href="#referrer-policy-no-referrer-when-downgrade">definition of</a><span>, in §3.1</span>
+    </ul>
+   <li><a href="#dom-referrerpolicy-origin">origin</a><span>, in §3</span>
+   <li>
+    "origin"
+    <ul>
+     <li><a href="#dom-referrerpolicy-origin">enum-value for ReferrerPolicy</a><span>, in §3</span>
+     <li><a href="#referrer-policy-origin">definition of</a><span>, in §3.3</span>
+    </ul>
    <li><a href="#origin-only-flag">origin-only flag</a><span>, in §8.4</span>
-   <li><a href="#referrer-policy-origin-when-cross-origin">"origin-when-cross-origin"</a><span>, in §3.5</span>
+   <li><a href="#dom-referrerpolicy-origin-when-cross-origin">origin-when-cross-origin</a><span>, in §3</span>
+   <li>
+    "origin-when-cross-origin"
+    <ul>
+     <li><a href="#dom-referrerpolicy-origin-when-cross-origin">enum-value for ReferrerPolicy</a><span>, in §3</span>
+     <li><a href="#referrer-policy-origin-when-cross-origin">definition of</a><span>, in §3.5</span>
+    </ul>
    <li><a href="#policy-token">policy-token</a><span>, in §4.1</span>
    <li><a href="#enumdef-referrerpolicy">ReferrerPolicy</a><span>, in §3</span>
-   <li><a href="#referrer-policy-header-dfn">Referrer-Policy</a><span>, in §4.1</span>
    <li><a href="#referrer-policy">referrer policy</a><span>, in §3</span>
+   <li><a href="#referrer-policy-header-dfn">Referrer-Policy</a><span>, in §4.1</span>
    <li><a href="#referrer-policy-header-dfn">referrer-policy header</a><span>, in §4.1</span>
-   <li><a href="#referrer-policy-same-origin">"same-origin"</a><span>, in §3.2</span>
-   <li><a href="#same-origin-request">same-origin request</a><span>, in §2</span>
-   <li><a href="#referrer-policy-strict-origin">"strict-origin"</a><span>, in §3.4</span>
-   <li><a href="#referrer-policy-strict-origin-when-cross-origin">"strict-origin-when-cross-origin"</a><span>, in §3.6</span>
-   <li><a href="#referrer-policy-empty-string">The empty string</a><span>, in §3.8</span>
-   <li><a href="#referrer-policy-unsafe-url">"unsafe-url"</a><span>, in §3.7</span>
-  </ul>
-  <h3 class="no-num heading settled" id="index-defined-elsewhere"><span class="content">Terms defined by reference</span><a class="self-link" href="#index-defined-elsewhere"></a></h3>
-  <ul class="indexlist">
    <li>
-    <a data-link-type="biblio" href="#biblio-fetch">[FETCH]</a> defines the following terms:
+    "same-origin"
+    <ul>
+     <li><a href="#dom-referrerpolicy-same-origin">enum-value for ReferrerPolicy</a><span>, in §3</span>
+     <li><a href="#referrer-policy-same-origin">definition of</a><span>, in §3.2</span>
+    </ul>
+   <li><a href="#dom-referrerpolicy-same-origin">same-origin</a><span>, in §3</span>
+   <li><a href="#same-origin-request">same-origin request</a><span>, in §2</span>
+   <li><a href="#dom-referrerpolicy-strict-origin">strict-origin</a><span>, in §3</span>
+   <li>
+    "strict-origin"
+    <ul>
+     <li><a href="#dom-referrerpolicy-strict-origin">enum-value for ReferrerPolicy</a><span>, in §3</span>
+     <li><a href="#referrer-policy-strict-origin">definition of</a><span>, in §3.4</span>
+    </ul>
+   <li>
+    "strict-origin-when-cross-origin"
+    <ul>
+     <li><a href="#dom-referrerpolicy-strict-origin-when-cross-origin">enum-value for ReferrerPolicy</a><span>, in §3</span>
+     <li><a href="#referrer-policy-strict-origin-when-cross-origin">definition of</a><span>, in §3.6</span>
+    </ul>
+   <li><a href="#dom-referrerpolicy-strict-origin-when-cross-origin">strict-origin-when-cross-origin</a><span>, in §3</span>
+   <li><a href="#referrer-policy-empty-string">The empty string</a><span>, in §3.8</span>
+   <li><a href="#dom-referrerpolicy-unsafe-url">unsafe-url</a><span>, in §3</span>
+   <li>
+    "unsafe-url"
+    <ul>
+     <li><a href="#dom-referrerpolicy-unsafe-url">enum-value for ReferrerPolicy</a><span>, in §3</span>
+     <li><a href="#referrer-policy-unsafe-url">definition of</a><span>, in §3.7</span>
+    </ul>
+  </ul>
+  <h3 class="no-num no-ref heading settled" id="index-defined-elsewhere"><span class="content">Terms defined by reference</span><a class="self-link" href="#index-defined-elsewhere"></a></h3>
+  <ul class="index">
+   <li>
+    <a data-link-type="biblio">[FETCH]</a> defines the following terms:
     <ul>
      <li><a href="https://fetch.spec.whatwg.org/#request">Request</a>
      <li><a href="https://fetch.spec.whatwg.org/#response">Response</a>
@@ -1749,11 +2192,13 @@
      <li><a href="https://fetch.spec.whatwg.org/#concept-request-url">url</a>
     </ul>
    <li>
-    <a data-link-type="biblio" href="#biblio-html">[HTML]</a> defines the following terms:
+    <a data-link-type="biblio">[HTML]</a> defines the following terms:
     <ul>
      <li><a href="https://html.spec.whatwg.org/multipage/dom.html#document">Document</a>
      <li><a href="https://html.spec.whatwg.org/multipage/semantics.html#the-a-element">a</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/browsers.html#active-document">active document</a>
      <li><a href="https://html.spec.whatwg.org/multipage/embedded-content.html#an-iframe-srcdoc-document">an iframe srcdoc document</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/infrastructure.html#concept-location-ancestor-origins-array">ancestor origins array</a>
      <li><a href="https://html.spec.whatwg.org/multipage/browsers.html#concept-document-window">associated document</a>
      <li><a href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context">browsing context</a>
      <li><a href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context-container">browsing context container</a>
@@ -1763,6 +2208,7 @@
      <li><a href="https://html.spec.whatwg.org/multipage/infrastructure.html#concept-url-fragment">fragment</a>
      <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global">global object</a>
      <li><a href="https://html.spec.whatwg.org/multipage/semantics.html#the-link-element">link</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/infrastructure.html#location">location</a>
      <li><a href="https://html.spec.whatwg.org/multipage/semantics.html#attr-meta-name">name</a>
      <li><a href="https://html.spec.whatwg.org/multipage/browsers.html#navigate">navigation</a>
      <li><a href="https://html.spec.whatwg.org/multipage/semantics.html#link-type-noreferrer">noreferrer</a>
@@ -1773,41 +2219,42 @@
      <li><a href="https://html.spec.whatwg.org/multipage/workers.html#run a worker">running a worker</a>
     </ul>
    <li>
-    <a data-link-type="biblio" href="#biblio-mix">[MIX]</a> defines the following terms:
+    <a data-link-type="biblio">[MIX]</a> defines the following terms:
     <ul>
      <li><a href="https://w3c.github.io/webappsec/specs/mixedcontent/#a-priori-authenticated-url">a priori authenticated url</a>
     </ul>
    <li>
-    <a data-link-type="biblio" href="#biblio-rfc6454">[RFC6454]</a> defines the following terms:
+    <a data-link-type="biblio">[RFC6454]</a> defines the following terms:
     <ul>
      <li><a href="https://tools.ietf.org/html/rfc6454#section-6.2">ascii serialization of an origin</a>
      <li><a href="https://tools.ietf.org/html/rfc6454#section-3.2">origin</a>
      <li><a href="https://tools.ietf.org/html/rfc6454#section-5">the same</a>
     </ul>
    <li>
-    <a data-link-type="biblio" href="#biblio-rfc7231">[RFC7231]</a> defines the following terms:
+    <a data-link-type="biblio">[RFC7231]</a> defines the following terms:
     <ul>
      <li><a href="https://tools.ietf.org/html/rfc7231#section-5.5.2">referer</a>
     </ul>
    <li>
-    <a data-link-type="biblio" href="#biblio-url">[url]</a> defines the following terms:
+    <a data-link-type="biblio">[WHATWG-URL]</a> defines the following terms:
     <ul>
      <li><a href="https://url.spec.whatwg.org#local-scheme">local scheme</a>
      <li><a href="https://url.spec.whatwg.org#url">url</a>
     </ul>
    <li>
-    <a data-link-type="biblio" href="#biblio-wsc-ui">[wsc-ui]</a> defines the following terms:
+    <a data-link-type="biblio">[wsc-ui]</a> defines the following terms:
     <ul>
      <li><a href="http://www.w3.org/TR/2010/REC-wsc-ui-20100812/#typesoftls">tls-protected</a>
     </ul>
    <li>
-    <a data-link-type="biblio" href="#biblio-dom-ls">[dom-ls]</a> defines the following terms:
+    <a data-link-type="biblio">[WHATWG-DOM]</a> defines the following terms:
     <ul>
+     <li><a href="https://dom.spec.whatwg.org/#concept-document">document</a>
      <li><a href="https://dom.spec.whatwg.org/#concept-node-document">node document</a>
      <li><a href="https://dom.spec.whatwg.org/#concept-document-url">url</a>
     </ul>
    <li>
-    <a data-link-type="biblio" href="#biblio-html">[HTML]</a> defines the following terms:
+    <a data-link-type="biblio">[HTML]</a> defines the following terms:
     <ul>
      <li><a href="https://html.spec.whatwg.org/multipage/browsers.html#window">Window</a>
      <li><a href="https://html.spec.whatwg.org/multipage/workers.html#workerglobalscope">WorkerGlobalScope</a>
@@ -1815,10 +2262,11 @@
      <li><a href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-iframe-element">iframe</a>
      <li><a href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element">img</a>
      <li><a href="https://html.spec.whatwg.org/multipage/semantics.html#meta">meta</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/browsers.html#same-origin">same origin</a>
      <li><a href="https://html.spec.whatwg.org/multipage/embedded-content.html#attr-iframe-srcdoc">srcdoc</a>
     </ul>
    <li>
-    <a data-link-type="biblio" href="#biblio-url">[url]</a> defines the following terms:
+    <a data-link-type="biblio">[WHATWG-URL]</a> defines the following terms:
     <ul>
      <li><a href="https://url.spec.whatwg.org/#concept-url-password">password</a>
      <li><a href="https://url.spec.whatwg.org/#concept-url-path">path</a>
@@ -1827,46 +2275,264 @@
      <li><a href="https://url.spec.whatwg.org/#concept-url-username">username</a>
     </ul>
   </ul>
-  <h2 class="no-num heading settled" id="references"><span class="content">References</span><a class="self-link" href="#references"></a></h2>
-  <h3 class="no-num heading settled" id="normative"><span class="content">Normative References</span><a class="self-link" href="#normative"></a></h3>
+  <h2 class="no-num no-ref heading settled" id="references"><span class="content">References</span><a class="self-link" href="#references"></a></h2>
+  <h3 class="no-num no-ref heading settled" id="normative"><span class="content">Normative References</span><a class="self-link" href="#normative"></a></h3>
   <dl>
-   <dt id="biblio-fetch"><a class="self-link" href="#biblio-fetch"></a>[FETCH]
+   <dt id="biblio-fetch">[FETCH]
    <dd>Anne van Kesteren. <a href="http://fetch.spec.whatwg.org/">Fetch</a>. Living Standard. URL: <a href="http://fetch.spec.whatwg.org/">http://fetch.spec.whatwg.org/</a>
-   <dt id="biblio-html"><a class="self-link" href="#biblio-html"></a>[HTML]
+   <dt id="biblio-html">[HTML]
    <dd>Ian Hickson. <a href="https://html.spec.whatwg.org/multipage/">HTML Standard</a>. Living Standard. URL: <a href="https://html.spec.whatwg.org/multipage/">https://html.spec.whatwg.org/multipage/</a>
-   <dt id="biblio-mix"><a class="self-link" href="#biblio-mix"></a>[MIX]
+   <dt id="biblio-mix">[MIX]
    <dd>Mike West. <a href="https://w3c.github.io/webappsec/specs/mixedcontent/">Mixed Content</a>. ED. URL: <a href="https://w3c.github.io/webappsec/specs/mixedcontent/">https://w3c.github.io/webappsec/specs/mixedcontent/</a>
-   <dt id="biblio-rfc6454"><a class="self-link" href="#biblio-rfc6454"></a>[RFC6454]
-   <dd>Adam Barth. <a href="http://www.ietf.org/rfc/rfc6454.txt">The Web Origin Concept</a>. RFC. URL: <a href="http://www.ietf.org/rfc/rfc6454.txt">http://www.ietf.org/rfc/rfc6454.txt</a>
-   <dt id="biblio-rfc7231"><a class="self-link" href="#biblio-rfc7231"></a>[RFC7231]
-   <dd>Roy T. Fielding; Julian F. Reschke. <a href="http://www.ietf.org/rfc/rfc7231.txt">HTTP/1.1 Semantics and Content</a>. RFC. URL: <a href="http://www.ietf.org/rfc/rfc7231.txt">http://www.ietf.org/rfc/rfc7231.txt</a>
-   <dt id="biblio-dom-ls"><a class="self-link" href="#biblio-dom-ls"></a>[DOM-LS]
-   <dd>Document Object Model URL: <a href="https://dom.spec.whatwg.org/">https://dom.spec.whatwg.org/</a>
-   <dt id="biblio-rfc2119"><a class="self-link" href="#biblio-rfc2119"></a>[RFC2119]
+   <dt id="biblio-rfc2119">[RFC2119]
    <dd>S. Bradner. <a href="https://tools.ietf.org/html/rfc2119">Key words for use in RFCs to Indicate Requirement Levels</a>. March 1997. Best Current Practice. URL: <a href="https://tools.ietf.org/html/rfc2119">https://tools.ietf.org/html/rfc2119</a>
-   <dt id="biblio-url"><a class="self-link" href="#biblio-url"></a>[URL]
-   <dd>Anne van Kesteren; Sam Ruby. <a href="http://www.w3.org/TR/url-1/">URL</a>. 9 December 2014. WD. URL: <a href="http://www.w3.org/TR/url-1/">http://www.w3.org/TR/url-1/</a>
-   <dt id="biblio-wsc-ui"><a class="self-link" href="#biblio-wsc-ui"></a>[WSC-UI]
-   <dd>Thomas Roessler; Anil Saldhana. <a href="http://www.w3.org/TR/wsc-ui/">Web Security Context: User Interface Guidelines</a>. 12 August 2010. REC. URL: <a href="http://www.w3.org/TR/wsc-ui/">http://www.w3.org/TR/wsc-ui/</a>
+   <dt id="biblio-rfc6454">[RFC6454]
+   <dd>Adam Barth. <a href="http://www.ietf.org/rfc/rfc6454.txt">The Web Origin Concept</a>. RFC. URL: <a href="http://www.ietf.org/rfc/rfc6454.txt">http://www.ietf.org/rfc/rfc6454.txt</a>
+   <dt id="biblio-rfc7231">[RFC7231]
+   <dd>Roy T. Fielding; Julian F. Reschke. <a href="http://www.ietf.org/rfc/rfc7231.txt">HTTP/1.1 Semantics and Content</a>. RFC. URL: <a href="http://www.ietf.org/rfc/rfc7231.txt">http://www.ietf.org/rfc/rfc7231.txt</a>
+   <dt id="biblio-whatwg-dom">[WHATWG-DOM]
+   <dd>Anne van Kesteren. <a href="https://dom.spec.whatwg.org/">DOM Standard</a>. Living Standard. URL: <a href="https://dom.spec.whatwg.org/">https://dom.spec.whatwg.org/</a>
+   <dt id="biblio-whatwg-url">[WHATWG-URL]
+   <dd>Anne van Kesteren. <a href="https://url.spec.whatwg.org/">URL Standard</a>. Living Standard. URL: <a href="https://url.spec.whatwg.org/">https://url.spec.whatwg.org/</a>
+   <dt id="biblio-wsc-ui">[WSC-UI]
+   <dd>Thomas Roessler; Anil Saldhana. <a href="https://www.w3.org/TR/wsc-ui/">Web Security Context: User Interface Guidelines</a>. 12 August 2010. REC. URL: <a href="https://www.w3.org/TR/wsc-ui/">https://www.w3.org/TR/wsc-ui/</a>
   </dl>
-  <h3 class="no-num heading settled" id="informative"><span class="content">Informative References</span><a class="self-link" href="#informative"></a></h3>
+  <h3 class="no-num no-ref heading settled" id="informative"><span class="content">Informative References</span><a class="self-link" href="#informative"></a></h3>
   <dl>
-   <dt id="biblio-capability-urls"><a class="self-link" href="#biblio-capability-urls"></a>[CAPABILITY-URLS]
+   <dt id="biblio-capability-urls">[CAPABILITY-URLS]
    <dd>Jenni Tennison. <a href="http://www.w3.org/TR/capability-urls/">Capability URLs</a>. WD. URL: <a href="http://www.w3.org/TR/capability-urls/">http://www.w3.org/TR/capability-urls/</a>
   </dl>
-  <h2 class="no-num heading settled" id="idl-index"><span class="content">IDL Index</span><a class="self-link" href="#idl-index"></a></h2>
-<pre class="idl">enum <a href="#enumdef-referrerpolicy">ReferrerPolicy</a> {
-  "",
-  "no-referrer",
-  "no-referrer-when-downgrade",
-  "same-origin",
-  "origin",
-  "strict-origin",
-  "origin-when-cross-origin",
-  "strict-origin-when-cross-origin",
-  "unsafe-url"
+  <h2 class="no-num no-ref heading settled" id="idl-index"><span class="content">IDL Index</span><a class="self-link" href="#idl-index"></a></h2>
+<pre class="idl def">enum <a href="#enumdef-referrerpolicy">ReferrerPolicy</a> {
+  <a href="#dom-referrerpolicy">""</a>,
+  <a href="#dom-referrerpolicy-no-referrer">"no-referrer"</a>,
+  <a href="#dom-referrerpolicy-no-referrer-when-downgrade">"no-referrer-when-downgrade"</a>,
+  <a href="#dom-referrerpolicy-same-origin">"same-origin"</a>,
+  <a href="#dom-referrerpolicy-origin">"origin"</a>,
+  <a href="#dom-referrerpolicy-strict-origin">"strict-origin"</a>,
+  <a href="#dom-referrerpolicy-origin-when-cross-origin">"origin-when-cross-origin"</a>,
+  <a href="#dom-referrerpolicy-strict-origin-when-cross-origin">"strict-origin-when-cross-origin"</a>,
+  <a href="#dom-referrerpolicy-unsafe-url">"unsafe-url"</a>
 };
 
 </pre>
- </body>
-</html>
+  <aside class="dfn-panel" data-for="same-origin-request">
+   <b><a href="#same-origin-request">#same-origin-request</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-same-origin-request-1">2. Key Concepts and Terminology</a>
+    <li><a href="#ref-for-same-origin-request-2">3.3. "same-origin"</a>
+    <li><a href="#ref-for-same-origin-request-3">3.4. "origin"</a>
+    <li><a href="#ref-for-same-origin-request-4">3.6. "origin-when-cross-origin"</a>
+    <li><a href="#ref-for-same-origin-request-5">3.7. "strict-origin-when-cross-origin"</a>
+    <li><a href="#ref-for-same-origin-request-6">3.8. "unsafe-url"</a>
+    <li><a href="#ref-for-same-origin-request-7">8.3. 
+    Determine request’s Referrer </a> <a href="#ref-for-same-origin-request-8">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="cross-origin-request">
+   <b><a href="#cross-origin-request">#cross-origin-request</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-cross-origin-request-1">3.3. "same-origin"</a>
+    <li><a href="#ref-for-cross-origin-request-2">3.4. "origin"</a>
+    <li><a href="#ref-for-cross-origin-request-3">3.6. "origin-when-cross-origin"</a> <a href="#ref-for-cross-origin-request-4">(2)</a>
+    <li><a href="#ref-for-cross-origin-request-5">3.7. "strict-origin-when-cross-origin"</a>
+    <li><a href="#ref-for-cross-origin-request-6">3.8. "unsafe-url"</a>
+    <li><a href="#ref-for-cross-origin-request-7">8.3. 
+    Determine request’s Referrer </a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="referrer-policy">
+   <b><a href="#referrer-policy">#referrer-policy</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-referrer-policy-1">2. Key Concepts and Terminology</a> <a href="#ref-for-referrer-policy-2">(2)</a> <a href="#ref-for-referrer-policy-3">(3)</a> <a href="#ref-for-referrer-policy-4">(4)</a>
+    <li><a href="#ref-for-referrer-policy-5">3. Referrer Policies</a>
+    <li><a href="#ref-for-referrer-policy-6">3.9. The empty string</a> <a href="#ref-for-referrer-policy-7">(2)</a>
+    <li><a href="#ref-for-referrer-policy-8">4.2. Delivery via meta</a>
+    <li><a href="#ref-for-referrer-policy-9">4.4. Nested browsing contexts</a>
+    <li><a href="#ref-for-referrer-policy-10">6. Integration with HTML</a>
+    <li><a href="#ref-for-referrer-policy-11">8.1. 
+    Parse a referrer policy from a Referrer-Policy header </a> <a href="#ref-for-referrer-policy-12">(2)</a>
+    <li><a href="#ref-for-referrer-policy-13">8.3. 
+    Determine request’s Referrer </a>
+    <li><a href="#ref-for-referrer-policy-14">8.5. 
+    Determine the Ancestor Origin availble to a Location </a>
+    <li><a href="#ref-for-referrer-policy-15">9.1. User Controls</a>
+    <li><a href="#ref-for-referrer-policy-16">10.1. Information Leakage</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="referrer-policy-no-referrer">
+   <b><a href="#referrer-policy-no-referrer">#referrer-policy-no-referrer</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-referrer-policy-no-referrer-1">3.1. "no-referrer"</a> <a href="#ref-for-referrer-policy-no-referrer-2">(2)</a>
+    <li><a href="#ref-for-referrer-policy-no-referrer-3">8.3. 
+    Determine request’s Referrer </a>
+    <li><a href="#ref-for-referrer-policy-no-referrer-4">8.5. 
+    Determine the Ancestor Origin availble to a Location </a>
+    <li><a href="#ref-for-referrer-policy-no-referrer-5">10.1. Information Leakage</a>
+    <li><a href="#ref-for-referrer-policy-no-referrer-6">10.2. Downgrade to less strict policies</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="referrer-policy-no-referrer-when-downgrade">
+   <b><a href="#referrer-policy-no-referrer-when-downgrade">#referrer-policy-no-referrer-when-downgrade</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-referrer-policy-no-referrer-when-downgrade-1">3.2. "no-referrer-when-downgrade"</a> <a href="#ref-for-referrer-policy-no-referrer-when-downgrade-2">(2)</a>
+    <li><a href="#ref-for-referrer-policy-no-referrer-when-downgrade-3">3.9. The empty string</a> <a href="#ref-for-referrer-policy-no-referrer-when-downgrade-4">(2)</a>
+    <li><a href="#ref-for-referrer-policy-no-referrer-when-downgrade-5">7. Integration with CSS</a>
+    <li><a href="#ref-for-referrer-policy-no-referrer-when-downgrade-6">8.3. 
+    Determine request’s Referrer </a>
+    <li><a href="#ref-for-referrer-policy-no-referrer-when-downgrade-7">8.5. 
+    Determine the Ancestor Origin availble to a Location </a>
+    <li><a href="#ref-for-referrer-policy-no-referrer-when-downgrade-8">10.2. Downgrade to less strict policies</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="referrer-policy-same-origin">
+   <b><a href="#referrer-policy-same-origin">#referrer-policy-same-origin</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-referrer-policy-same-origin-1">3.3. "same-origin"</a> <a href="#ref-for-referrer-policy-same-origin-2">(2)</a>
+    <li><a href="#ref-for-referrer-policy-same-origin-3">8.3. 
+    Determine request’s Referrer </a>
+    <li><a href="#ref-for-referrer-policy-same-origin-4">8.5. 
+    Determine the Ancestor Origin availble to a Location </a>
+    <li><a href="#ref-for-referrer-policy-same-origin-5">10.1. Information Leakage</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="referrer-policy-origin">
+   <b><a href="#referrer-policy-origin">#referrer-policy-origin</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-referrer-policy-origin-1">3.4. "origin"</a> <a href="#ref-for-referrer-policy-origin-2">(2)</a> <a href="#ref-for-referrer-policy-origin-3">(3)</a>
+    <li><a href="#ref-for-referrer-policy-origin-4">8.3. 
+    Determine request’s Referrer </a>
+    <li><a href="#ref-for-referrer-policy-origin-5">8.5. 
+    Determine the Ancestor Origin availble to a Location </a>
+    <li><a href="#ref-for-referrer-policy-origin-6">10.1. Information Leakage</a>
+    <li><a href="#ref-for-referrer-policy-origin-7">10.2. Downgrade to less strict policies</a>
+    <li><a href="#ref-for-referrer-policy-origin-8">11.1. Unknown Policy Values</a> <a href="#ref-for-referrer-policy-origin-9">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="referrer-policy-strict-origin">
+   <b><a href="#referrer-policy-strict-origin">#referrer-policy-strict-origin</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-referrer-policy-strict-origin-1">3.4. "origin"</a>
+    <li><a href="#ref-for-referrer-policy-strict-origin-2">3.5. "strict-origin"</a> <a href="#ref-for-referrer-policy-strict-origin-3">(2)</a> <a href="#ref-for-referrer-policy-strict-origin-4">(3)</a>
+    <li><a href="#ref-for-referrer-policy-strict-origin-5">8.3. 
+    Determine request’s Referrer </a>
+    <li><a href="#ref-for-referrer-policy-strict-origin-6">8.5. 
+    Determine the Ancestor Origin availble to a Location </a>
+    <li><a href="#ref-for-referrer-policy-strict-origin-7">10.1. Information Leakage</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="referrer-policy-origin-when-cross-origin">
+   <b><a href="#referrer-policy-origin-when-cross-origin">#referrer-policy-origin-when-cross-origin</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-referrer-policy-origin-when-cross-origin-1">3.6. "origin-when-cross-origin"</a> <a href="#ref-for-referrer-policy-origin-when-cross-origin-2">(2)</a> <a href="#ref-for-referrer-policy-origin-when-cross-origin-3">(3)</a> <a href="#ref-for-referrer-policy-origin-when-cross-origin-4">(4)</a>
+    <li><a href="#ref-for-referrer-policy-origin-when-cross-origin-5">8.3. 
+    Determine request’s Referrer </a>
+    <li><a href="#ref-for-referrer-policy-origin-when-cross-origin-6">8.5. 
+    Determine the Ancestor Origin availble to a Location </a>
+    <li><a href="#ref-for-referrer-policy-origin-when-cross-origin-7">10.1. Information Leakage</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="referrer-policy-strict-origin-when-cross-origin">
+   <b><a href="#referrer-policy-strict-origin-when-cross-origin">#referrer-policy-strict-origin-when-cross-origin</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-referrer-policy-strict-origin-when-cross-origin-1">3.6. "origin-when-cross-origin"</a>
+    <li><a href="#ref-for-referrer-policy-strict-origin-when-cross-origin-2">3.7. "strict-origin-when-cross-origin"</a> <a href="#ref-for-referrer-policy-strict-origin-when-cross-origin-3">(2)</a>
+    <li><a href="#ref-for-referrer-policy-strict-origin-when-cross-origin-4">8.3. 
+    Determine request’s Referrer </a>
+    <li><a href="#ref-for-referrer-policy-strict-origin-when-cross-origin-5">8.5. 
+    Determine the Ancestor Origin availble to a Location </a>
+    <li><a href="#ref-for-referrer-policy-strict-origin-when-cross-origin-6">10.1. Information Leakage</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="referrer-policy-unsafe-url">
+   <b><a href="#referrer-policy-unsafe-url">#referrer-policy-unsafe-url</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-referrer-policy-unsafe-url-1">3.8. "unsafe-url"</a> <a href="#ref-for-referrer-policy-unsafe-url-2">(2)</a>
+    <li><a href="#ref-for-referrer-policy-unsafe-url-3">8.3. 
+    Determine request’s Referrer </a>
+    <li><a href="#ref-for-referrer-policy-unsafe-url-4">8.5. 
+    Determine the Ancestor Origin availble to a Location </a>
+    <li><a href="#ref-for-referrer-policy-unsafe-url-5">10.1. Information Leakage</a>
+    <li><a href="#ref-for-referrer-policy-unsafe-url-6">10.2. Downgrade to less strict policies</a>
+    <li><a href="#ref-for-referrer-policy-unsafe-url-7">11.1. Unknown Policy Values</a> <a href="#ref-for-referrer-policy-unsafe-url-8">(2)</a> <a href="#ref-for-referrer-policy-unsafe-url-9">(3)</a> <a href="#ref-for-referrer-policy-unsafe-url-10">(4)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="referrer-policy-header-dfn">
+   <b><a href="#referrer-policy-header-dfn">#referrer-policy-header-dfn</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-referrer-policy-header-dfn-1">8.1. 
+    Parse a referrer policy from a Referrer-Policy header </a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="policy-token">
+   <b><a href="#policy-token">#policy-token</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-policy-token-1">4.1. Delivery via Referrer-Policy header</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="origin-only-flag">
+   <b><a href="#origin-only-flag">#origin-only-flag</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-origin-only-flag-1">8.3. 
+    Determine request’s Referrer </a>
+    <li><a href="#ref-for-origin-only-flag-2">8.4. 
+    Strip url for use as a referrer </a>
+   </ul>
+  </aside>
+<script>/* script-dfn-panel */
+
+        document.body.addEventListener("click", function(e) {
+            var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
+            // Find the dfn element or panel, if any, that was clicked on.
+            var el = e.target;
+            var target;
+            var hitALink = false;
+            while(el.parentElement) {
+                if(el.tagName == "A") {
+                    // Clicking on a link in a <dfn> shouldn't summon the panel
+                    hitALink = true;
+                }
+                if(el.classList.contains("dfn-paneled")) {
+                    target = "dfn";
+                    break;
+                }
+                if(el.classList.contains("dfn-panel")) {
+                    target = "dfn-panel";
+                    break;
+                }
+                el = el.parentElement;
+            }
+            if(target != "dfn-panel") {
+                // Turn off any currently "on" or "activated" panels.
+                queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
+                    el.classList.remove("on");
+                    el.classList.remove("activated");
+                });
+            }
+            if(target == "dfn" && !hitALink) {
+                // open the panel
+                var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
+                if(dfnPanel) {
+                    console.log(dfnPanel);
+                    dfnPanel.classList.add("on");
+                    var rect = el.getBoundingClientRect();
+                    dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
+                    dfnPanel.style.top = window.scrollY + rect.top + "px";
+                    var panelRect = dfnPanel.getBoundingClientRect();
+                    var panelWidth = panelRect.right - panelRect.left;
+                    if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
+                        // Reposition, because the panel is overflowing
+                        dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
+                    }
+                } else {
+                    console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
+                }
+            } else if(target == "dfn-panel") {
+                // Switch it to "activated" state, which pins it.
+                el.classList.add("activated");
+                el.style.left = null;
+                el.style.top = null;
+            }
+
+        });
+        </script>

--- a/index.html
+++ b/index.html
@@ -1826,8 +1826,8 @@ Possible extra rowspan handling
        For each <var>token</var> in <var>policy-tokens</var>, if <var>token</var> is a <a data-link-type="dfn" href="#referrer-policy" id="ref-for-referrer-policy-12">referrer
       policy</a> and <var>token</var> is not the empty string, then set <var>policy</var> to <var>token</var>. 
       <p class="note" role="note">Note: This algorithm loops over multiple policy values to allow
-	  deployment of new policy values with fallbacks for older user
-	  agents, as described in <a href="#unknown-policy-values">§11.1 Unknown Policy Values</a>.</p>
+    deployment of new policy values with fallbacks for older user
+    agents, as described in <a href="#unknown-policy-values">§11.1 Unknown Policy Values</a>.</p>
      <li> Return <var>policy</var>. 
     </ol>
     <h3 class="heading settled" data-level="8.2" id="set-requests-referrer-policy-on-redirect"><span class="secno">8.2. </span><span class="content"> Set <var>request</var>’s referrer policy on redirect </span><a class="self-link" href="#set-requests-referrer-policy-on-redirect"></a></h3>
@@ -1989,7 +1989,7 @@ Possible extra rowspan handling
        <dd>
         <ol>
          <li> If <var>context</var> is <a data-link-type="dfn" href="http://www.w3.org/TR/2010/REC-wsc-ui-20100812/#typesoftls">TLS-protected</a> <em>and</em> <var>locationURL</var> is not a <a data-link-type="dfn" href="https://w3c.github.io/webappsec-secure-contexts/#potentially-trustworthy-url">potentially trustworthy URL</a>,
-							return <code>"null"</code>. 
+              return <code>"null"</code>. 
          <li> Return the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#unicode-serialisation-of-an-origin">Unicode serialization</a> of <var>documentOrigin</var> 
         </ol>
        <dt><a data-link-type="dfn" href="#referrer-policy-strict-origin-when-cross-origin" id="ref-for-referrer-policy-strict-origin-when-cross-origin-5">"<code>strict-origin-when-cross-origin</code>"</a>
@@ -1997,7 +1997,7 @@ Possible extra rowspan handling
         <ol>
          <li> If <var>documentOrigin</var> and <var>locationOrigin</var> are <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#same-origin">same origin</a>, return  the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#unicode-serialisation-of-an-origin">Unicode serialization</a> of <var>documentOrigin</var>. 
          <li> If <var>context</var> is <a data-link-type="dfn" href="http://www.w3.org/TR/2010/REC-wsc-ui-20100812/#typesoftls">TLS-protected</a> <em>and</em> <var>locationURL</var> is not a <a data-link-type="dfn" href="https://w3c.github.io/webappsec-secure-contexts/#potentially-trustworthy-url">potentially trustworthy URL</a>,
-							return <code>"null"</code>. 
+              return <code>"null"</code>. 
          <li> Return the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#unicode-serialisation-of-an-origin">Unicode serialization</a> of <var>documentOrigin</var> 
         </ol>
        <dt><a data-link-type="dfn" href="#referrer-policy-same-origin" id="ref-for-referrer-policy-same-origin-4">"<code>same-origin</code>"</a>

--- a/index.html
+++ b/index.html
@@ -1985,41 +1985,41 @@ Possible extra rowspan handling
        <dt><a data-link-type="dfn" href="#referrer-policy-no-referrer" id="ref-for-referrer-policy-no-referrer-4">"<code>no-referrer</code>"</a>
        <dd>Return <code>"null"</code>
        <dt><a data-link-type="dfn" href="#referrer-policy-origin" id="ref-for-referrer-policy-origin-5">"<code>origin</code>"</a>
-       <dd>Return <var>documentOrigin</var>.
+       <dd>Return the <a data-link-type="dfn">Unicode serialization</a> of <var>documentOrigin</var>.
        <dt><a data-link-type="dfn" href="#referrer-policy-unsafe-url" id="ref-for-referrer-policy-unsafe-url-4">"<code>unsafe-url</code>"</a>
-       <dd>Return <var>documentOrigin</var>.
+       <dd>Return  the <a data-link-type="dfn">Unicode serialization</a> of <var>documentOrigin</var>.
        <dt><a data-link-type="dfn" href="#referrer-policy-strict-origin" id="ref-for-referrer-policy-strict-origin-6">"<code>strict-origin</code>"</a>
        <dd>
         <ol>
          <li> If <var>context</var> is <a data-link-type="dfn" href="http://www.w3.org/TR/2010/REC-wsc-ui-20100812/#typesoftls">TLS-protected</a> <em>and</em> <var>locationOrigin</var> is not an <a data-link-type="dfn" href="https://w3c.github.io/webappsec/specs/mixedcontent/#a-priori-authenticated-url"><em>a priori</em> authenticated
               URL</a>, return <code>"null"</code>. 
-         <li> Return <var>documentOrigin</var> 
+         <li> Return the <a data-link-type="dfn">Unicode serialization</a> of <var>documentOrigin</var> 
         </ol>
        <dt><a data-link-type="dfn" href="#referrer-policy-strict-origin-when-cross-origin" id="ref-for-referrer-policy-strict-origin-when-cross-origin-5">"<code>strict-origin-when-cross-origin</code>"</a>
        <dd>
         <ol>
-         <li> If <var>documentOrigin</var> and <var>locationOrigin</var> are <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#same-origin">same origin</a>, return <var>documentOrigin</var>. 
+         <li> If <var>documentOrigin</var> and <var>locationOrigin</var> are <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#same-origin">same origin</a>, return  the <a data-link-type="dfn">Unicode serialization</a> of <var>documentOrigin</var>. 
          <li> If <var>context</var> is <a data-link-type="dfn" href="http://www.w3.org/TR/2010/REC-wsc-ui-20100812/#typesoftls">TLS-protected</a> <em>and</em> <var>locationOrigin</var> is not an <a data-link-type="dfn" href="https://w3c.github.io/webappsec/specs/mixedcontent/#a-priori-authenticated-url"><em>a priori</em> authenticated
               URL</a>, return <code>"null"</code>. 
-         <li> Return <var>documentOrigin</var> 
+         <li> Return the <a data-link-type="dfn">Unicode serialization</a> of <var>documentOrigin</var> 
         </ol>
        <dt><a data-link-type="dfn" href="#referrer-policy-same-origin" id="ref-for-referrer-policy-same-origin-4">"<code>same-origin</code>"</a>
        <dd>
         <ol>
-         <li> If <var>documentOrigin</var> and <var>locationOrigin</var> are <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#same-origin">same origin</a>, return <var>documentOrigin</var>. 
+         <li> If <var>documentOrigin</var> and <var>locationOrigin</var> are <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#same-origin">same origin</a>, return the <a data-link-type="dfn">Unicode serialization</a> of <var>documentOrigin</var>. 
          <li> Otherwise, return <code>"null"</code>. 
         </ol>
        <dt><a data-link-type="dfn" href="#referrer-policy-origin-when-cross-origin" id="ref-for-referrer-policy-origin-when-cross-origin-6">"<code>origin-when-cross-origin</code>"</a>
        <dd>
         <ol>
-         <li> Return <var>documentOrigin</var>. 
+         <li> Return the <a data-link-type="dfn">Unicode serialization</a> of <var>documentOrigin</var>. 
         </ol>
        <dt><a data-link-type="dfn" href="#referrer-policy-no-referrer-when-downgrade" id="ref-for-referrer-policy-no-referrer-when-downgrade-7">"<code>no-referrer-when-downgrade</code>"</a>
        <dd>
         <ol>
          <li> If <var>context</var> is <a data-link-type="dfn" href="http://www.w3.org/TR/2010/REC-wsc-ui-20100812/#typesoftls">TLS-protected</a> <em>and</em> <var>locationOrigin</var> is not an <a data-link-type="dfn" href="https://w3c.github.io/webappsec/specs/mixedcontent/#a-priori-authenticated-url"><em>a priori</em> authenticated
               URL</a>, return <code>"null"</code>. 
-         <li> Return <var>documentOrigin</var> 
+         <li> Return the <a data-link-type="dfn">Unicode serialization</a> of <var>documentOrigin</var> 
         </ol>
       </dl>
     </ol>

--- a/index.src.html
+++ b/index.src.html
@@ -54,7 +54,6 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/multipage/
       text: browsing context
       text: browsing context; for: Document; url: concept-document-bc
       text: parent browsing context
-      text: ancestor browsing context
       text: browsing context container
       text: child browsing context
       text: creating a new Document object
@@ -66,7 +65,6 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/multipage/
       text: sandboxed origin browsing context flag
       text: sandboxing flag set
       text: top-level browsing context
-			text: unicode serialization url: unicode-serialisation-of-an-origin
     urlPrefix: infrastructure.html
       text: ascii case-insensitive match; url: ascii-case-insensitive
       text: fragment; url: concept-url-fragment
@@ -86,7 +84,6 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/multipage/
       text: limited to only known values
       text: referrer policy attribute
       text: location
-      text: ancestor origins array; url: concept-location-ancestor-origins-array
     urlPrefix: webappapis.html
       text: queue a task
       text: task source
@@ -961,12 +958,12 @@ spec: HTML; type: element; text: link;
     </li>
   </ol>
 
-  <h3 id="ancestor-origin">
-    Determine the Ancestor Origin availble to a Location
+  <h3 id="origin-for-location">
+    Determine the origin serialization available to a Location
   </h3>
-  Given a <a>Location</a> <var>location</var> and a <a>browsing context</a> <var>context</var>
-  we can determine what origin information for <var>context</var> should be included in
-  <var>location</var>'s <a>ancestor origins array</a>.
+  Given a <a>Location</a> <var>location</var> and a <a>browsing context</a> <var>context</var>,
+  determine what serialized <a>origin</a> <var>context</var>'s <a>referrer policy</a>
+	allows exposing to <var>location</var>.
 
   <ol>
     <li>Let <var>document</var> be <var>context</var>'s <a>active document</a>.</li>

--- a/index.src.html
+++ b/index.src.html
@@ -65,7 +65,7 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/multipage/
       text: sandboxed origin browsing context flag
       text: sandboxing flag set
       text: top-level browsing context
-			text: unicode serialization; url: unicode-serialisation-of-an-origin
+      text: unicode serialization; url: unicode-serialisation-of-an-origin
     urlPrefix: infrastructure.html
       text: ascii case-insensitive match; url: ascii-case-insensitive
       text: fragment; url: concept-url-fragment
@@ -450,7 +450,7 @@ spec: HTML; type: element; text: link;
   </ul>
 
   Requests from <a>TLS-protected</a> <a>request clients</a> to non-
-	<a>potentially trustworthy URL</a>s, on the other hand, will contain no
+  <a>potentially trustworthy URL</a>s, on the other hand, will contain no
   referrer information. A <code><a>Referer</a></code> HTTP header will not be
   sent.
 
@@ -705,9 +705,9 @@ spec: HTML; type: element; text: link;
       policy</a> and |token| is not the empty string, then set |policy|
       to |token|.
 
-	  Note: This algorithm loops over multiple policy values to allow
-	  deployment of new policy values with fallbacks for older user
-	  agents, as described in [[#unknown-policy-values]].
+    Note: This algorithm loops over multiple policy values to allow
+    deployment of new policy values with fallbacks for older user
+    agents, as described in [[#unknown-policy-values]].
     </li>
     <li>
       Return |policy|.
@@ -964,7 +964,7 @@ spec: HTML; type: element; text: link;
   </h3>
   Given a <a>Location</a> <var>location</var> and a <a>browsing context</a> <var>context</var>,
   determine what serialized <a>origin</a> <var>context</var>'s <a>referrer policy</a>
-	allows exposing to <var>location</var>.
+  allows exposing to <var>location</var>.
 
   <ol>
     <li>Let <var>document</var> be <var>context</var>'s <a>active document</a>.</li>
@@ -992,7 +992,7 @@ spec: HTML; type: element; text: link;
             <li>
               If <var>context</var> is <a>TLS-protected</a> <em>and</em>
               <var>locationURL</var> is not a <a>potentially trustworthy URL</a>,
-							return <code>"null"</code>.
+              return <code>"null"</code>.
             </li>
             <li>
               Return the <a>Unicode serialization</a> of <var>documentOrigin</var>
@@ -1006,12 +1006,12 @@ spec: HTML; type: element; text: link;
             <li>
               If <var>documentOrigin</var> and <var>locationOrigin</var>
               are <a>same origin</a>, return  the <a>Unicode serialization</a> of 
-							<var>documentOrigin</var>.
+              <var>documentOrigin</var>.
             </li>
             <li>
               If <var>context</var> is <a>TLS-protected</a> <em>and</em>
               <var>locationURL</var> is not a <a>potentially trustworthy URL</a>,
-							return <code>"null"</code>.
+              return <code>"null"</code>.
             </li>
             <li>
               Return the <a>Unicode serialization</a> of <var>documentOrigin</var>
@@ -1025,7 +1025,7 @@ spec: HTML; type: element; text: link;
             <li>
               If <var>documentOrigin</var> and <var>locationOrigin</var>
               are <a>same origin</a>, return the <a>Unicode serialization</a> of
-							<var>documentOrigin</var>.
+              <var>documentOrigin</var>.
             </li>
             <li>
               Otherwise, return <code>"null"</code>.
@@ -1119,7 +1119,7 @@ spec: HTML; type: element; text: link;
   it possible to deploy new policy values.
 
   <div class="example">
-  	Suppose older user agents don't understand
+    Suppose older user agents don't understand
     the <a>"<code>unsafe-url</code>"</a> policy. A site can specify
     an <a>"<code>origin</code>"</a> policy followed by an
     <a>"<code>unsafe-url</code>"</a> policy: older user agents will ignore the

--- a/index.src.html
+++ b/index.src.html
@@ -107,6 +107,7 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/multipage/
     urlPrefix: semantics.html
       text: name; for: meta; url: attr-meta-name
       text: referrerpolicy; for: a; url: attr-a-referrerpolicy
+      text: referrerpolicy; for: link; url: attr-link-referrerpolicy
 spec: MIX; urlPrefix: https://w3c.github.io/webappsec/specs/mixedcontent/
   type: dfn
     text: a priori authenticated URL

--- a/index.src.html
+++ b/index.src.html
@@ -84,6 +84,8 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/multipage/
       text: reflect
       text: limited to only known values
       text: referrer policy attribute
+      text: location
+      text: ancestor origins array; url: concept-location-ancestor-origins-array
     urlPrefix: webappapis.html
       text: queue a task
       text: task source
@@ -955,6 +957,103 @@ spec: HTML; type: element; text: link;
     </li>
     <li>
       Return <var>url</var>.
+    </li>
+  </ol>
+
+  <h3 id="ancestor-origin">
+    Determine the Ancestor Origin availble to a Location
+  </h3>
+  Given a <a>Location</a> <var>location</var> and a <a>browsing context</a> <var>context</var>
+  we can determine what origin information for <var>context</var> should be included in
+  <var>location</var>'s <a>ancestor origins array</a>.
+
+  <ol>
+    <li>Let <var>document</var> be <var>context</var>'s <a>active document</a>.</li>
+    <li>Let <var>documentOrigin</var> be <var>document</var>'s <a>origin</a>.</li>
+    <li>If <var>documentOrigin</var> is an <a>opaque origin</a>, return <code>"null"</code>.
+    <li>Let <var>locationOrigin</var> be <var>location</var>'s relevant <a>Document</a>'s <a>origin</a>.
+    <li>Let <var>policy</var> be <var>document</var>'s <a>referrer policy</a>.</li>
+    <li>
+      Execute the statements corresponding to the value of <var>policy</var>:
+
+      <dl class="switch">
+        <dt><a>"<code>no-referrer</code>"</a></dt>
+        <dd>Return <code>"null"</code></dd>
+
+        <dt><a>"<code>origin</code>"</a></dt>
+        <dd>Return <var>documentOrigin</var>.</dd>
+
+        <dt><a>"<code>unsafe-url</code>"</a></dt>
+        <dd>Return <var>documentOrigin</var>.</dd>
+
+        <dt><a>"<code>strict-origin</code>"</a></dt>
+        <dd>
+          <ol>
+            <li>
+              If <var>context</var> is <a>TLS-protected</a> <em>and</em>
+              <var>locationOrigin</var> is not an <a><em>a priori</em> authenticated
+              URL</a>, return <code>"null"</code>.
+            </li>
+            <li>
+              Return <var>documentOrigin</var>
+            </li>
+          </ol>
+        </dd>
+
+        <dt><a>"<code>strict-origin-when-cross-origin</code>"</a></dt>
+        <dd>
+          <ol>
+            <li>
+              If <var>documentOrigin</var> and <var>locationOrigin</var>
+              are <a>same origin</a>, return <var>documentOrigin</var>.
+            </li>
+            <li>
+              If <var>context</var> is <a>TLS-protected</a> <em>and</em>
+              <var>locationOrigin</var> is not an <a><em>a priori</em> authenticated
+              URL</a>, return <code>"null"</code>.
+            </li>
+            <li>
+              Return <var>documentOrigin</var>
+            </li>
+          </ol>
+        </dd>
+
+        <dt><a>"<code>same-origin</code>"</a></dt>
+        <dd>
+          <ol>
+            <li>
+              If <var>documentOrigin</var> and <var>locationOrigin</var>
+              are <a>same origin</a>, return <var>documentOrigin</var>.
+            </li>
+            <li>
+              Otherwise, return <code>"null"</code>.
+            </li>
+          </ol>
+        </dd>
+
+        <dt><a>"<code>origin-when-cross-origin</code>"</a></dt>
+        <dd>
+          <ol>
+            <li>
+              Return <var>documentOrigin</var>.
+            </li>
+          </ol>
+        </dd>
+
+        <dt><a>"<code>no-referrer-when-downgrade</code>"</a></dt>
+        <dd>
+          <ol>
+            <li>
+              If <var>context</var> is <a>TLS-protected</a> <em>and</em>
+              <var>locationOrigin</var> is not an <a><em>a priori</em> authenticated
+              URL</a>, return <code>"null"</code>.
+            </li>
+            <li>
+              Return <var>documentOrigin</var>
+            </li>
+          </ol>
+        </dd>
+      </dl>
     </li>
   </ol>
 

--- a/index.src.html
+++ b/index.src.html
@@ -66,6 +66,7 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/multipage/
       text: sandboxed origin browsing context flag
       text: sandboxing flag set
       text: top-level browsing context
+			text: unicode serialization url: unicode-serialisation-of-an-origin
     urlPrefix: infrastructure.html
       text: ascii case-insensitive match; url: ascii-case-insensitive
       text: fragment; url: concept-url-fragment
@@ -981,10 +982,10 @@ spec: HTML; type: element; text: link;
         <dd>Return <code>"null"</code></dd>
 
         <dt><a>"<code>origin</code>"</a></dt>
-        <dd>Return <var>documentOrigin</var>.</dd>
+        <dd>Return the <a>Unicode serialization</a> of <var>documentOrigin</var>.</dd>
 
         <dt><a>"<code>unsafe-url</code>"</a></dt>
-        <dd>Return <var>documentOrigin</var>.</dd>
+        <dd>Return  the <a>Unicode serialization</a> of <var>documentOrigin</var>.</dd>
 
         <dt><a>"<code>strict-origin</code>"</a></dt>
         <dd>
@@ -995,7 +996,7 @@ spec: HTML; type: element; text: link;
               URL</a>, return <code>"null"</code>.
             </li>
             <li>
-              Return <var>documentOrigin</var>
+              Return the <a>Unicode serialization</a> of <var>documentOrigin</var>
             </li>
           </ol>
         </dd>
@@ -1005,7 +1006,8 @@ spec: HTML; type: element; text: link;
           <ol>
             <li>
               If <var>documentOrigin</var> and <var>locationOrigin</var>
-              are <a>same origin</a>, return <var>documentOrigin</var>.
+              are <a>same origin</a>, return  the <a>Unicode serialization</a> of 
+							<var>documentOrigin</var>.
             </li>
             <li>
               If <var>context</var> is <a>TLS-protected</a> <em>and</em>
@@ -1013,7 +1015,7 @@ spec: HTML; type: element; text: link;
               URL</a>, return <code>"null"</code>.
             </li>
             <li>
-              Return <var>documentOrigin</var>
+              Return the <a>Unicode serialization</a> of <var>documentOrigin</var>
             </li>
           </ol>
         </dd>
@@ -1023,7 +1025,8 @@ spec: HTML; type: element; text: link;
           <ol>
             <li>
               If <var>documentOrigin</var> and <var>locationOrigin</var>
-              are <a>same origin</a>, return <var>documentOrigin</var>.
+              are <a>same origin</a>, return the <a>Unicode serialization</a> of
+							<var>documentOrigin</var>.
             </li>
             <li>
               Otherwise, return <code>"null"</code>.
@@ -1035,7 +1038,7 @@ spec: HTML; type: element; text: link;
         <dd>
           <ol>
             <li>
-              Return <var>documentOrigin</var>.
+              Return the <a>Unicode serialization</a> of <var>documentOrigin</var>.
             </li>
           </ol>
         </dd>
@@ -1049,7 +1052,7 @@ spec: HTML; type: element; text: link;
               URL</a>, return <code>"null"</code>.
             </li>
             <li>
-              Return <var>documentOrigin</var>
+              Return the <a>Unicode serialization</a> of <var>documentOrigin</var>
             </li>
           </ol>
         </dd>


### PR DESCRIPTION
Define an algorithm to redact origin to "null" in the location.ancestorOrigins array if the referrer policy for the context would not send a referrer to that location.

See: https://github.com/whatwg/html/issues/1918
