### PR TITLE
Undo change of shortname, and instead mark the spec as unlevelled

### DIFF
--- a/index.html
+++ b/index.html
@@ -1433,7 +1433,7 @@ pre.idl.highlight { color: #708090; }
      <dt>Version History:
      <dd><a href="https://github.com/w3c/webappsec-referrer-policy/commits/master/index.src.html">https://github.com/w3c/webappsec-referrer-policy/commits/master/index.src.html</a>
      <dt>Feedback:
-     <dd><span><a href="mailto:public-webappsec@w3.org?subject=%5Breferrer-policy%5D%20YOUR%20TOPIC%20HERE">public-webappsec@w3.org</a> with subject line “<kbd>[referrer-policy] <i data-lt="">… message topic …</i></kbd>” (<a href="https://lists.w3.org/Archives/Public/public-webappsec/" rel="discussion">archives</a>)</span>
+     <dd><span><a href="mailto:public-webappsec@w3.org?subject=%5Breferrer%5D%20YOUR%20TOPIC%20HERE">public-webappsec@w3.org</a> with subject line “<kbd>[referrer] <i data-lt="">… message topic …</i></kbd>” (<a href="https://lists.w3.org/Archives/Public/public-webappsec/" rel="discussion">archives</a>)</span>
      <dt>Issue Tracking:
      <dd><a href="https://github.com/w3c/webappsec-referrer-policy/issues/">GitHub</a>
      <dd><a href="#issues-index">Inline In Spec</a>
@@ -1457,12 +1457,12 @@ pre.idl.highlight { color: #708090; }
 	Its publication here does not imply endorsement of its contents by W3C.
 	Don’t cite this document other than as work in progress. </p>
    <p> <strong>Changes to this document may be tracked at <a href="https://github.com/w3c/webappsec">https://github.com/w3c/webappsec</a>.</strong> </p>
-   <p> The (<a href="https://lists.w3.org/Archives/Public/public-webappsec/">archived</a>) public mailing list <a href="mailto:public-webappsec@w3.org?Subject=%5Breferrer-policy%5D%20PUT%20SUBJECT%20HERE">public-webappsec@w3.org</a> (see <a href="https://www.w3.org/Mail/Request">instructions</a>)
+   <p> The (<a href="https://lists.w3.org/Archives/Public/public-webappsec/">archived</a>) public mailing list <a href="mailto:public-webappsec@w3.org?Subject=%5Breferrer%5D%20PUT%20SUBJECT%20HERE">public-webappsec@w3.org</a> (see <a href="https://www.w3.org/Mail/Request">instructions</a>)
 	is preferred for discussion of this specification.
 	When sending e-mail,
-	please put the text “referrer-policy” in the subject,
+	please put the text “referrer” in the subject,
 	preferably like this:
-	“[referrer-policy] <em>…summary of comment…</em>” </p>
+	“[referrer] <em>…summary of comment…</em>” </p>
    <p> This document was produced by the <a href="https://www.w3.org/2011/webappsec/">Web Application Security Working Group</a>. </p>
    <p> This document was produced by a group operating under
 	the <a href="https://www.w3.org/Consortium/Patent-Policy-20040205/">5 February 2004 W3C Patent Policy</a>.

--- a/index.src.html
+++ b/index.src.html
@@ -2,9 +2,9 @@
 <pre class="metadata">
 Status: ED
 ED: https://w3c.github.io/webappsec-referrer-policy/
-Shortname: referrer-policy
+Shortname: REFERRER
 TR: http://www.w3.org/TR/referrer-policy/
-Level: 1
+Level: none
 Editor: Jochen Eisinger 49402, Google Inc., eisinger@google.com
 Editor: Emily Stark 76989, Google Inc., estark@google.com
 Group: webappsec


### PR DESCRIPTION
Hopefully this will make specberus happy.