### PR TITLE
Relax ABNF for invalid policy tokens

### DIFF
--- a/index.html
+++ b/index.html
@@ -1423,7 +1423,7 @@ pre.idl.highlight { color: #708090; }
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1>Referrer Policy</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-03-07">7 March 2017</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-03-09">9 March 2017</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1759,11 +1759,16 @@ pre.idl.highlight { color: #708090; }
   made, and with <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context">browsing contexts</a> created from the context of the protected resource.
   The syntax for the name and value of the header are described by the
   following <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc5234#">ABNF</a> grammar:</p>
-<pre>"Referrer-Policy:" 1#<a data-link-type="dfn" href="#policy-token" id="ref-for-policy-token-1">policy-token</a>
+<pre>"Referrer-Policy:" 1#(<a data-link-type="dfn" href="#policy-token" id="ref-for-policy-token-1">policy-token</a> / <a data-link-type="dfn" href="#extension-token" id="ref-for-extension-token-1">extension-token</a>)
 </pre>
-<pre><dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="policy-token">policy-token</dfn>   = 1*( <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc5234#appendix-B.1">ALPHA</a> / "-" )
+<pre><dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="policy-token">policy-token</dfn> = "no-referrer" / "no-referrer-when-downgrade" / "strict-origin" / "strict-origin-when-cross-origin" / "same-origin" / "origin" / "origin-when-cross-origin" / "unsafe-url"
+<dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="extension-token">extension-token</dfn> = 1*( <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc5234#appendix-B.1">ALPHA</a> / "-" )
 </pre>
     <p class="note" role="note"><span>Note:</span> The header name does not share the HTTP Referer header’s misspelling.</p>
+    <p class="note" role="note"><span>Note:</span> The purpose of <a data-link-type="dfn" href="#extension-token" id="ref-for-extension-token-2">extension-token</a> is so that browsers do not fail to
+  parse the entire header field if it includes an unknown policy
+  value. <a href="#unknown-policy-values">§11.1 Unknown Policy Values</a> describes in greater detail how new policy
+  values can be deployed.</p>
     <p><a href="#integration-with-fetch">§5 Integration with Fetch</a> and <a href="#integration-with-html">§6 Integration with HTML</a> describe
   how the <code>Referrer-Policy</code> header is processed.</p>
     <section class="informative">
@@ -2096,6 +2101,7 @@ Referrer-Policy: unsafe-url
    <li><a href="#dom-referrerpolicy">""</a><span>, in §3</span>
    <li><a href="#cross-origin-request">cross-origin request</a><span>, in §2</span>
    <li><a href="#determine-requests-referrer">Determine request’s Referrer</a><span>, in §8.2</span>
+   <li><a href="#extension-token">extension-token</a><span>, in §4.1</span>
    <li>
     "no-referrer"
     <ul>
@@ -2454,6 +2460,12 @@ Referrer-Policy: unsafe-url
    <b><a href="#policy-token">#policy-token</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-policy-token-1">4.1. Delivery via Referrer-Policy header</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="extension-token">
+   <b><a href="#extension-token">#extension-token</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-extension-token-1">4.1. Delivery via Referrer-Policy header</a> <a href="#ref-for-extension-token-2">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="cssstylesheet-referrer-policy">

--- a/index.html
+++ b/index.html
@@ -1423,7 +1423,7 @@ pre.idl.highlight { color: #708090; }
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1>Referrer Policy</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-03-06">6 March 2017</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-03-07">7 March 2017</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1758,10 +1758,10 @@ pre.idl.highlight { color: #708090; }
   determining what referrer information should be included with requests
   made, and with <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context">browsing contexts</a> created from the context of the protected resource.
   The syntax for the name and value of the header are described by the
-  following ABNF grammar:</p>
+  following <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc5234#">ABNF</a> grammar:</p>
 <pre>"Referrer-Policy:" 1#<a data-link-type="dfn" href="#policy-token" id="ref-for-policy-token-1">policy-token</a>
 </pre>
-<pre><dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="policy-token">policy-token</dfn>   = "no-referrer" / "no-referrer-when-downgrade" / "strict-origin" / "strict-origin-when-cross-origin" / "same-origin" / "origin" / "origin-when-cross-origin" / "unsafe-url"
+<pre><dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="policy-token">policy-token</dfn>   = 1*( <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc5234#appendix-B.1">ALPHA</a> / "-" )
 </pre>
     <p class="note" role="note"><span>Note:</span> The header name does not share the HTTP Referer header’s misspelling.</p>
     <p><a href="#integration-with-fetch">§5 Integration with Fetch</a> and <a href="#integration-with-html">§6 Integration with HTML</a> describe
@@ -2038,13 +2038,13 @@ pre.idl.highlight { color: #708090; }
     the <a data-link-type="dfn" href="#referrer-policy-unsafe-url" id="ref-for-referrer-policy-unsafe-url-6">"<code>unsafe-url</code>"</a> policy. A site can specify
     an <a data-link-type="dfn" href="#referrer-policy-origin" id="ref-for-referrer-policy-origin-7">"<code>origin</code>"</a> policy followed by an <a data-link-type="dfn" href="#referrer-policy-unsafe-url" id="ref-for-referrer-policy-unsafe-url-7">"<code>unsafe-url</code>"</a> policy: older user agents will ignore the
     unknown <a data-link-type="dfn" href="#referrer-policy-unsafe-url" id="ref-for-referrer-policy-unsafe-url-8">"<code>unsafe-url</code>"</a> value and use <a data-link-type="dfn" href="#referrer-policy-origin" id="ref-for-referrer-policy-origin-8">"<code>origin</code>"</a>, while newer user agents will use <a data-link-type="dfn" href="#referrer-policy-unsafe-url" id="ref-for-referrer-policy-unsafe-url-9">"<code>unsafe-url</code>"</a> because it is the last to be processed. </div>
-    <div class="example" id="example-bb161dbb">
-     <a class="self-link" href="#example-bb161dbb"></a> To specify multiple policy values in the Referrer-Policy header, a site can
+    <div class="example" id="example-af01a355">
+     <a class="self-link" href="#example-af01a355"></a> To specify multiple policy values in the Referrer-Policy header, a site can
     send multiple Referrer-Policy headers: 
 <pre>Referrer-Policy: no-referrer
 Referrer-Policy: unsafe-url
 </pre>
-     <p>or multiple comma-separated header values:</p>
+     <p>or, equivalently, multiple comma-separated header values:</p>
 <pre>Referrer-Policy: no-referrer,unsafe-url
 </pre>
     </div>
@@ -2239,6 +2239,12 @@ Referrer-Policy: unsafe-url
      <li><a href="https://html.spec.whatwg.org/multipage/embedded-content.html#attr-iframe-srcdoc">srcdoc</a>
     </ul>
    <li>
+    <a data-link-type="biblio">[rfc5234]</a> defines the following terms:
+    <ul>
+     <li><a href="https://tools.ietf.org/html/rfc5234#">abnf</a>
+     <li><a href="https://tools.ietf.org/html/rfc5234#appendix-B.1">alpha</a>
+    </ul>
+   <li>
     <a data-link-type="biblio">[RFC7231]</a> defines the following terms:
     <ul>
      <li><a href="https://tools.ietf.org/html/rfc7231#section-5.5.2">referer</a>
@@ -2279,6 +2285,8 @@ Referrer-Policy: unsafe-url
    <dd>Anne van Kesteren; et al. <a href="https://html.spec.whatwg.org/multipage/">HTML Standard</a>. Living Standard. URL: <a href="https://html.spec.whatwg.org/multipage/">https://html.spec.whatwg.org/multipage/</a>
    <dt id="biblio-rfc2119">[RFC2119]
    <dd>S. Bradner. <a href="https://tools.ietf.org/html/rfc2119">Key words for use in RFCs to Indicate Requirement Levels</a>. March 1997. Best Current Practice. URL: <a href="https://tools.ietf.org/html/rfc2119">https://tools.ietf.org/html/rfc2119</a>
+   <dt id="biblio-rfc5234">[RFC5234]
+   <dd>D. Crocker, Ed.; P. Overell. <a href="https://tools.ietf.org/html/rfc5234">Augmented BNF for Syntax Specifications: ABNF</a>. January 2008. Internet Standard. URL: <a href="https://tools.ietf.org/html/rfc5234">https://tools.ietf.org/html/rfc5234</a>
    <dt id="biblio-rfc7231">[RFC7231]
    <dd>Roy T. Fielding; Julian F. Reschke. <a href="http://www.ietf.org/rfc/rfc7231.txt">HTTP/1.1 Semantics and Content</a>. RFC. URL: <a href="http://www.ietf.org/rfc/rfc7231.txt">http://www.ietf.org/rfc/rfc7231.txt</a>
    <dt id="biblio-secure-contexts">[SECURE-CONTEXTS]

--- a/index.html
+++ b/index.html
@@ -1423,7 +1423,7 @@ pre.idl.highlight { color: #708090; }
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1>Referrer Policy</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-03-09">9 March 2017</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-03-13">13 March 2017</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1753,22 +1753,23 @@ pre.idl.highlight { color: #708090; }
      <li> Implicitly, via inheritance. 
     </ul>
     <h3 class="heading settled" data-level="4.1" id="referrer-policy-header"><span class="secno">4.1. </span><span class="content">Delivery via Referrer-Policy header</span><a class="self-link" href="#referrer-policy-header"></a></h3>
-    <p>The <code><dfn class="dfn-paneled" data-dfn-type="dfn" data-local-lt="referrer-policy header" data-noexport="" id="referrer-policy-header-dfn">Referrer-Policy</dfn></code> HTTP
-  header specifies the referrer policy that the user agent applies when
-  determining what referrer information should be included with requests
-  made, and with <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context">browsing contexts</a> created from the context of the protected resource.
-  The syntax for the name and value of the header are described by the
-  following <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#abnf">ABNF</a> grammar:</p>
-<pre>"Referrer-Policy:" 1#(<a data-link-type="dfn" href="#policy-token" id="ref-for-policy-token-1">policy-token</a> / <a data-link-type="dfn" href="#extension-token" id="ref-for-extension-token-1">extension-token</a>)
+    <p>The <code><dfn class="dfn-paneled" data-dfn-type="dfn" data-local-lt="referrer-policy header" data-noexport="" id="referrer-policy-header-dfn">Referrer-Policy</dfn></code> HTTP header
+  specifies the referrer policy that the user agent applies when determining
+  what referrer information should be included with requests made, and with <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context">browsing contexts</a> created from the context of the protected
+  resource.</p>
+    <p>The syntax for the name and value of the header are described by the following
+  ABNF grammar. ABNF is defined in <a data-link-type="biblio" href="#biblio-rfc5234">[RFC5234]</a>, and the <code>#rule</code> ABNF
+  extension used below is defined in <a href="https://tools.ietf.org/html/rfc7230#section-7">Section 7</a> of <a data-link-type="biblio" href="#biblio-rfc7230">[RFC7230]</a>.</p>
+<pre>"Referrer-Policy:" 1#(<a data-link-type="grammar" href="#grammardef-policy-token" id="ref-for-grammardef-policy-token-1">policy-token</a> / <a data-link-type="grammar" href="#grammardef-extension-token" id="ref-for-grammardef-extension-token-1">extension-token</a>)
 </pre>
-<pre><dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="policy-token">policy-token</dfn> = "no-referrer" / "no-referrer-when-downgrade" / "strict-origin" / "strict-origin-when-cross-origin" / "same-origin" / "origin" / "origin-when-cross-origin" / "unsafe-url"
-<dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="extension-token">extension-token</dfn> = 1*( <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc5234#appendix-B.1">ALPHA</a> / "-" )
+<pre><dfn class="dfn-paneled" data-dfn-type="grammar" data-export="" id="grammardef-policy-token">policy-token</dfn> = "no-referrer" / "no-referrer-when-downgrade" / "strict-origin" / "strict-origin-when-cross-origin" / "same-origin" / "origin" / "origin-when-cross-origin" / "unsafe-url"
+<dfn class="dfn-paneled" data-dfn-type="grammar" data-export="" id="grammardef-extension-token">extension-token</dfn> = 1*( <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc5234#appendix-B.1">ALPHA</a> / "-" )
 </pre>
     <p class="note" role="note"><span>Note:</span> The header name does not share the HTTP Referer header’s misspelling.</p>
-    <p class="note" role="note"><span>Note:</span> The purpose of <a data-link-type="dfn" href="#extension-token" id="ref-for-extension-token-2">extension-token</a> is so that browsers do not fail to
-  parse the entire header field if it includes an unknown policy
-  value. <a href="#unknown-policy-values">§11.1 Unknown Policy Values</a> describes in greater detail how new policy
-  values can be deployed.</p>
+    <p class="note" role="note"><span>Note:</span> The purpose of <a data-link-type="grammar" href="#grammardef-extension-token" id="ref-for-grammardef-extension-token-2">extension-token</a> is so that
+  browsers do not fail to parse the entire header field if it includes an
+  unknown policy value. <a href="#unknown-policy-values">§11.1 Unknown Policy Values</a> describes in greater detail
+  how new policy values can be deployed.</p>
     <p><a href="#integration-with-fetch">§5 Integration with Fetch</a> and <a href="#integration-with-html">§6 Integration with HTML</a> describe
   how the <code>Referrer-Policy</code> header is processed.</p>
     <section class="informative">
@@ -2101,7 +2102,7 @@ Referrer-Policy: unsafe-url
    <li><a href="#dom-referrerpolicy">""</a><span>, in §3</span>
    <li><a href="#cross-origin-request">cross-origin request</a><span>, in §2</span>
    <li><a href="#determine-requests-referrer">Determine request’s Referrer</a><span>, in §8.2</span>
-   <li><a href="#extension-token">extension-token</a><span>, in §4.1</span>
+   <li><a href="#grammardef-extension-token">extension-token</a><span>, in §4.1</span>
    <li>
     "no-referrer"
     <ul>
@@ -2131,7 +2132,7 @@ Referrer-Policy: unsafe-url
      <li><a href="#dom-referrerpolicy-origin-when-cross-origin">enum-value for ReferrerPolicy</a><span>, in §3</span>
      <li><a href="#referrer-policy-origin-when-cross-origin">definition of</a><span>, in §3.5</span>
     </ul>
-   <li><a href="#policy-token">policy-token</a><span>, in §4.1</span>
+   <li><a href="#grammardef-policy-token">policy-token</a><span>, in §4.1</span>
    <li><a href="#enumdef-referrerpolicy">ReferrerPolicy</a><span>, in §3</span>
    <li>
     referrer policy
@@ -2196,7 +2197,6 @@ Referrer-Policy: unsafe-url
     <ul>
      <li><a href="https://fetch.spec.whatwg.org/#request">Request</a>
      <li><a href="https://fetch.spec.whatwg.org/#response">Response</a>
-     <li><a href="https://fetch.spec.whatwg.org/#abnf">abnf</a>
      <li><a href="https://fetch.spec.whatwg.org/#concept-request-client">client</a>
      <li><a href="https://fetch.spec.whatwg.org/#concept-request-current-url">current url</a>
      <li><a href="https://fetch.spec.whatwg.org/#extract-header-list-values">extracting header list values</a>
@@ -2246,7 +2246,7 @@ Referrer-Policy: unsafe-url
      <li><a href="https://html.spec.whatwg.org/multipage/embedded-content.html#attr-iframe-srcdoc">srcdoc</a>
     </ul>
    <li>
-    <a data-link-type="biblio">[rfc5234]</a> defines the following terms:
+    <a data-link-type="biblio">[RFC5234]</a> defines the following terms:
     <ul>
      <li><a href="https://tools.ietf.org/html/rfc5234#appendix-B.1">alpha</a>
     </ul>
@@ -2293,6 +2293,8 @@ Referrer-Policy: unsafe-url
    <dd>S. Bradner. <a href="https://tools.ietf.org/html/rfc2119">Key words for use in RFCs to Indicate Requirement Levels</a>. March 1997. Best Current Practice. URL: <a href="https://tools.ietf.org/html/rfc2119">https://tools.ietf.org/html/rfc2119</a>
    <dt id="biblio-rfc5234">[RFC5234]
    <dd>D. Crocker, Ed.; P. Overell. <a href="https://tools.ietf.org/html/rfc5234">Augmented BNF for Syntax Specifications: ABNF</a>. January 2008. Internet Standard. URL: <a href="https://tools.ietf.org/html/rfc5234">https://tools.ietf.org/html/rfc5234</a>
+   <dt id="biblio-rfc7230">[RFC7230]
+   <dd>R. Fielding, Ed.; J. Reschke, Ed.. <a href="https://tools.ietf.org/html/rfc7230">Hypertext Transfer Protocol (HTTP/1.1): Message Syntax and Routing</a>. June 2014. Proposed Standard. URL: <a href="https://tools.ietf.org/html/rfc7230">https://tools.ietf.org/html/rfc7230</a>
    <dt id="biblio-rfc7231">[RFC7231]
    <dd>Roy T. Fielding; Julian F. Reschke. <a href="http://www.ietf.org/rfc/rfc7231.txt">HTTP/1.1 Semantics and Content</a>. RFC. URL: <a href="http://www.ietf.org/rfc/rfc7231.txt">http://www.ietf.org/rfc/rfc7231.txt</a>
    <dt id="biblio-secure-contexts">[SECURE-CONTEXTS]
@@ -2456,16 +2458,16 @@ Referrer-Policy: unsafe-url
     Parse a referrer policy from a Referrer-Policy header </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="policy-token">
-   <b><a href="#policy-token">#policy-token</a></b><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="grammardef-policy-token">
+   <b><a href="#grammardef-policy-token">#grammardef-policy-token</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-policy-token-1">4.1. Delivery via Referrer-Policy header</a>
+    <li><a href="#ref-for-grammardef-policy-token-1">4.1. Delivery via Referrer-Policy header</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="extension-token">
-   <b><a href="#extension-token">#extension-token</a></b><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="grammardef-extension-token">
+   <b><a href="#grammardef-extension-token">#grammardef-extension-token</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-extension-token-1">4.1. Delivery via Referrer-Policy header</a> <a href="#ref-for-extension-token-2">(2)</a>
+    <li><a href="#ref-for-grammardef-extension-token-1">4.1. Delivery via Referrer-Policy header</a> <a href="#ref-for-grammardef-extension-token-2">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="cssstylesheet-referrer-policy">

--- a/index.html
+++ b/index.html
@@ -1176,7 +1176,8 @@ Possible extra rowspan handling
 		}
 	}
 </style>
-  <meta content="Bikeshed version 6aa0219b7426f80ce4f3a9e687f521fc0ec917f4" name="generator">
+  <meta content="Bikeshed version 26ea3a45cb5052b41bc87174096f9f0093d5064f" name="generator">
+  <link href="http://www.w3.org/TR/referrer-policy/" rel="canonical">
 <style>/* style-md-lists */
 
             /* This is a weird hack for me not yet following the commonmark spec
@@ -1423,7 +1424,7 @@ pre.idl.highlight { color: #708090; }
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1>Referrer Policy</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-03-13">13 March 2017</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-03-28">28 March 2017</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1793,7 +1794,7 @@ pre.idl.highlight { color: #708090; }
      <p><em>This section is not normative.</em></p>
      <p>The HTML Standard defines the concept of <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#referrer-policy-attribute">referrer policy
     attributes</a> which applies to several of its elements, for example:</p>
-<pre class="example" id="example-4214a796"><a class="self-link" href="#example-4214a796"></a><code class="lang-html highlight"><span class="nt">&lt;a</span> <span class="na">href=</span><span class="s">"http://example.com"</span> <span class="na">referrerpolicy=</span><span class="s">"origin"</span><span class="nt">></span>
+<pre class="example" id="example-4214a796"><a class="self-link" href="#example-4214a796"></a><code class="lang-html highlight"><span class="p">&lt;</span><span class="nt">a</span> <span class="na">href</span><span class="o">=</span><span class="s">"http://example.com"</span> <span class="na">referrerpolicy</span><span class="o">=</span><span class="s">"origin"</span><span class="p">></span>
 </code></pre>
     </section>
     <section class="informative">

--- a/index.html
+++ b/index.html
@@ -1758,7 +1758,7 @@ pre.idl.highlight { color: #708090; }
   determining what referrer information should be included with requests
   made, and with <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context">browsing contexts</a> created from the context of the protected resource.
   The syntax for the name and value of the header are described by the
-  following <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc5234#">ABNF</a> grammar:</p>
+  following <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#abnf">ABNF</a> grammar:</p>
 <pre>"Referrer-Policy:" 1#(<a data-link-type="dfn" href="#policy-token" id="ref-for-policy-token-1">policy-token</a> / <a data-link-type="dfn" href="#extension-token" id="ref-for-extension-token-1">extension-token</a>)
 </pre>
 <pre><dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="policy-token">policy-token</dfn> = "no-referrer" / "no-referrer-when-downgrade" / "strict-origin" / "strict-origin-when-cross-origin" / "same-origin" / "origin" / "origin-when-cross-origin" / "unsafe-url"
@@ -2196,6 +2196,7 @@ Referrer-Policy: unsafe-url
     <ul>
      <li><a href="https://fetch.spec.whatwg.org/#request">Request</a>
      <li><a href="https://fetch.spec.whatwg.org/#response">Response</a>
+     <li><a href="https://fetch.spec.whatwg.org/#abnf">abnf</a>
      <li><a href="https://fetch.spec.whatwg.org/#concept-request-client">client</a>
      <li><a href="https://fetch.spec.whatwg.org/#concept-request-current-url">current url</a>
      <li><a href="https://fetch.spec.whatwg.org/#extract-header-list-values">extracting header list values</a>
@@ -2247,7 +2248,6 @@ Referrer-Policy: unsafe-url
    <li>
     <a data-link-type="biblio">[rfc5234]</a> defines the following terms:
     <ul>
-     <li><a href="https://tools.ietf.org/html/rfc5234#">abnf</a>
      <li><a href="https://tools.ietf.org/html/rfc5234#appendix-B.1">alpha</a>
     </ul>
    <li>

--- a/index.src.html
+++ b/index.src.html
@@ -22,6 +22,9 @@ spec: CSSOM-1; urlPrefix: https://drafts.csswg.org/cssom-1/
     text: location; url: concept-css-style-sheet-location
     text: owner node; for: CSSStyleDeclaration; url: cssstyledeclaration-owner-node
     text: owner node; for: CSSStyleSheet; url: concept-css-style-sheet-owner-node
+spec: Fetch; urlPrefix: https://fetch.spec.whatwg.org/
+  type: dfn
+    text: ABNF; url: abnf
 spec: HTML; urlPrefix: https://html.spec.whatwg.org/multipage/
   type: dfn
     urlPrefix: semantics.html
@@ -97,7 +100,6 @@ spec: WSC-UI; urlPrefix: http://www.w3.org/TR/2010/REC-wsc-ui-20100812/
     text: TLS-protected; url: typesoftls
 spec: RFC5234; urlPrefix: https://tools.ietf.org/html/rfc5234
   type: dfn
-    text: ABNF; url:
     text: ALPHA; url: appendix-B.1
 spec: RFC7231; urlPrefix: https://tools.ietf.org/html/rfc7231
   type: dfn

--- a/index.src.html
+++ b/index.src.html
@@ -22,9 +22,6 @@ spec: CSSOM-1; urlPrefix: https://drafts.csswg.org/cssom-1/
     text: location; url: concept-css-style-sheet-location
     text: owner node; for: CSSStyleDeclaration; url: cssstyledeclaration-owner-node
     text: owner node; for: CSSStyleSheet; url: concept-css-style-sheet-owner-node
-spec: Fetch; urlPrefix: https://fetch.spec.whatwg.org/
-  type: dfn
-    text: ABNF; url: abnf
 spec: HTML; urlPrefix: https://html.spec.whatwg.org/multipage/
   type: dfn
     urlPrefix: semantics.html
@@ -99,7 +96,7 @@ spec: WSC-UI; urlPrefix: http://www.w3.org/TR/2010/REC-wsc-ui-20100812/
   type: dfn
     text: TLS-protected; url: typesoftls
 spec: RFC5234; urlPrefix: https://tools.ietf.org/html/rfc5234
-  type: dfn
+  type: grammar
     text: ALPHA; url: appendix-B.1
 spec: RFC7231; urlPrefix: https://tools.ietf.org/html/rfc7231
   type: dfn
@@ -519,28 +516,32 @@ spec: html; type: element; text: a;
   <h3 id="referrer-policy-header">Delivery via Referrer-Policy header</h3>
 
   The <code><dfn local-lt="referrer-policy header"
-  id="referrer-policy-header-dfn">Referrer-Policy</dfn></code> HTTP
-  header specifies the referrer policy that the user agent applies when
-  determining what referrer information should be included with requests
-  made, and with
-  <a for=/>browsing contexts</a> created from the context of the protected resource.
-  The syntax for the name and value of the header are described by the
-  following <a>ABNF</a> grammar:
+  id="referrer-policy-header-dfn">Referrer-Policy</dfn></code> HTTP header
+  specifies the referrer policy that the user agent applies when determining
+  what referrer information should be included with requests made, and with
+  <a for=/>browsing contexts</a> created from the context of the protected
+  resource.
 
-  <pre>
+  The syntax for the name and value of the header are described by the following
+  ABNF grammar. ABNF is defined in [[!RFC5234]], and the <code>#rule</code> ABNF
+  extension used below is defined in
+  <a href="https://tools.ietf.org/html/rfc7230#section-7">Section 7</a> of
+  [[!RFC7230]].
+
+  <pre dfn-type="grammar" link-type="grammar">
     "Referrer-Policy:" 1#(<a>policy-token</a> / <a>extension-token</a>)
   </pre>
-  <pre>
+  <pre dfn-type="grammar" link-type="grammar">
     <dfn export>policy-token</dfn> = "no-referrer" / "no-referrer-when-downgrade" / "strict-origin" / "strict-origin-when-cross-origin" / "same-origin" / "origin" / "origin-when-cross-origin" / "unsafe-url"
     <dfn>extension-token</dfn> = 1*( <a>ALPHA</a> / "-" )
   </pre>
 
   Note: The header name does not share the HTTP Referer header's misspelling.
 
-  Note: The purpose of <a>extension-token</a> is so that browsers do not fail to
-  parse the entire header field if it includes an unknown policy
-  value. [[#unknown-policy-values]] describes in greater detail how new policy
-  values can be deployed.
+  Note: The purpose of <a link-type="grammar">extension-token</a> is so that
+  browsers do not fail to parse the entire header field if it includes an
+  unknown policy value.  [[#unknown-policy-values]] describes in greater detail
+  how new policy values can be deployed.
 
   [[#integration-with-fetch]] and [[#integration-with-html]] describe
   how the <code>Referrer-Policy</code> header is processed.

--- a/index.src.html
+++ b/index.src.html
@@ -95,6 +95,10 @@ spec: SECURE-CONTEXTS; urlPrefix: https://w3c.github.io/webappsec-secure-context
 spec: WSC-UI; urlPrefix: http://www.w3.org/TR/2010/REC-wsc-ui-20100812/
   type: dfn
     text: TLS-protected; url: typesoftls
+spec: RFC5234; urlPrefix: https://tools.ietf.org/html/rfc5234
+  type: dfn
+    text: ABNF; url:
+    text: ALPHA; url: appendix-B.1
 spec: RFC7231; urlPrefix: https://tools.ietf.org/html/rfc7231
   type: dfn
     text: referer; url: section-5.5.2
@@ -519,13 +523,13 @@ spec: html; type: element; text: a;
   made, and with
   <a for=/>browsing contexts</a> created from the context of the protected resource.
   The syntax for the name and value of the header are described by the
-  following ABNF grammar:
+  following <a>ABNF</a> grammar:
 
   <pre>
     "Referrer-Policy:" 1#<a>policy-token</a>
   </pre>
   <pre>
-    <dfn export>policy-token</dfn>   = "no-referrer" / "no-referrer-when-downgrade" / "strict-origin" / "strict-origin-when-cross-origin" / "same-origin" / "origin" / "origin-when-cross-origin" / "unsafe-url"
+    <dfn export>policy-token</dfn>   = 1*( <a>ALPHA</a> / "-" )
   </pre>
 
   Note: The header name does not share the HTTP Referer header's misspelling.

--- a/index.src.html
+++ b/index.src.html
@@ -526,13 +526,19 @@ spec: html; type: element; text: a;
   following <a>ABNF</a> grammar:
 
   <pre>
-    "Referrer-Policy:" 1#<a>policy-token</a>
+    "Referrer-Policy:" 1#(<a>policy-token</a> / <a>extension-token</a>)
   </pre>
   <pre>
-    <dfn export>policy-token</dfn>   = 1*( <a>ALPHA</a> / "-" )
+    <dfn export>policy-token</dfn> = "no-referrer" / "no-referrer-when-downgrade" / "strict-origin" / "strict-origin-when-cross-origin" / "same-origin" / "origin" / "origin-when-cross-origin" / "unsafe-url"
+    <dfn>extension-token</dfn> = 1*( <a>ALPHA</a> / "-" )
   </pre>
 
   Note: The header name does not share the HTTP Referer header's misspelling.
+
+  Note: The purpose of <a>extension-token</a> is so that browsers do not fail to
+  parse the entire header field if it includes an unknown policy
+  value. [[#unknown-policy-values]] describes in greater detail how new policy
+  values can be deployed.
 
   [[#integration-with-fetch]] and [[#integration-with-html]] describe
   how the <code>Referrer-Policy</code> header is processed.


### PR DESCRIPTION
@annevk pointed out in https://github.com/w3c/web-platform-tests/pull/5054#issuecomment-284664280 that when `policy-token` is defined as a collection of literals corresponding to the valid referrer policies, the browser should technically completely disregard a header of the form `Referrer-Policy: origin, blah`. Instead, we want the browser to ignore `blah` as an unknown policy value and fall back to `origin`.

So this PR relaxes the ABNF of the `Referrer-Policy` header to parse invalid policy values.