### PR TITLE
Add a link to web-platform-tests to the top of the spec

### DIFF
--- a/index.html
+++ b/index.html
@@ -1176,7 +1176,7 @@ Possible extra rowspan handling
 		}
 	}
 </style>
-  <meta content="Bikeshed version 0f4697271bbbaeef35323d2211ff865ee6dd1178" name="generator">
+  <meta content="Bikeshed version 2694cf87482eb631bb8582afc69be1fae22f2bff" name="generator">
   <link href="http://www.w3.org/TR/referrer-policy/" rel="canonical">
 <style>/* style-md-lists */
 
@@ -1424,7 +1424,7 @@ pre.idl.highlight { color: #708090; }
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1>Referrer Policy</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-03-30">30 March 2017</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-04-20">20 April 2017</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1441,14 +1441,16 @@ pre.idl.highlight { color: #708090; }
      <dt class="editor">Editors:
      <dd class="editor p-author h-card vcard" data-editor-id="49402"><a class="p-name fn u-email email" href="mailto:eisinger@google.com">Jochen Eisinger</a> (<span class="p-org org">Google Inc.</span>)
      <dd class="editor p-author h-card vcard" data-editor-id="76989"><a class="p-name fn u-email email" href="mailto:estark@google.com">Emily Stark</a> (<span class="p-org org">Google Inc.</span>)
+     <dt>Tests:
+     <dd><span><a href="https://github.com/w3c/web-platform-tests/tree/master/referrer-policy">web-platform-tests referrer-policy/</a> (<a href="https://github.com/w3c/web-platform-tests/labels/referrer-policy">ongoing work</a>)</span>
     </dl>
    </div>
    <div data-fill-with="warning"></div>
    <p class="copyright" data-fill-with="copyright"><a href="https://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 2017 <a href="https://www.w3.org/"><abbr title="World Wide Web Consortium">W3C</abbr></a><sup>®</sup> (<a href="https://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>, <a href="https://www.ercim.eu/"><abbr title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>, <a href="https://www.keio.ac.jp/">Keio</a>, <a href="http://ev.buaa.edu.cn/">Beihang</a>). W3C <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>, <a href="https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and <a href="https://www.w3.org/Consortium/Legal/copyright-documents">document use</a> rules apply. </p>
    <hr title="Separator for header">
   </div>
-  <h2 class="no-num no-toc no-ref heading settled" id="abstract"><span class="content">Abstract</span></h2>
   <div class="p-summary" data-fill-with="abstract">
+   <h2 class="no-num no-toc no-ref heading settled" id="abstract"><span class="content">Abstract</span></h2>
    <p>This document describes how an author can set a referrer policy for documents they create, and the impact of such a policy on the <code>Referer</code> HTTP header for outgoing requests and navigations.</p>
   </div>
   <h2 class="no-num no-toc no-ref heading settled" id="status"><span class="content">Status of this document</span></h2>
@@ -2318,16 +2320,16 @@ Referrer-Policy: unsafe-url
    <dd>Jeni Tennison. <a href="https://www.w3.org/TR/capability-urls/">Good Practices for Capability URLs</a>. URL: <a href="https://www.w3.org/TR/capability-urls/">https://www.w3.org/TR/capability-urls/</a>
   </dl>
   <h2 class="no-num no-ref heading settled" id="idl-index"><span class="content">IDL Index</span><a class="self-link" href="#idl-index"></a></h2>
-<pre class="idl def"><span class="kt">enum</span> <a class="nv" href="#enumdef-referrerpolicy">ReferrerPolicy</a> {
-  <a class="s" href="#dom-referrerpolicy">""</a>,
-  <a class="s" href="#dom-referrerpolicy-no-referrer">"no-referrer"</a>,
-  <a class="s" href="#dom-referrerpolicy-no-referrer-when-downgrade">"no-referrer-when-downgrade"</a>,
-  <a class="s" href="#dom-referrerpolicy-same-origin">"same-origin"</a>,
-  <a class="s" href="#dom-referrerpolicy-origin">"origin"</a>,
-  <a class="s" href="#dom-referrerpolicy-strict-origin">"strict-origin"</a>,
-  <a class="s" href="#dom-referrerpolicy-origin-when-cross-origin">"origin-when-cross-origin"</a>,
-  <a class="s" href="#dom-referrerpolicy-strict-origin-when-cross-origin">"strict-origin-when-cross-origin"</a>,
-  <a class="s" href="#dom-referrerpolicy-unsafe-url">"unsafe-url"</a>
+<pre class="idl highlight def"><span class="kt"><span class="kt">enum</span></span> <a class="nv" href="#enumdef-referrerpolicy"><span class="nv">ReferrerPolicy</span></a> {
+  <a class="s" href="#dom-referrerpolicy"><span class="s">""</span></a>,
+  <a class="s" href="#dom-referrerpolicy-no-referrer"><span class="s">"no-referrer"</span></a>,
+  <a class="s" href="#dom-referrerpolicy-no-referrer-when-downgrade"><span class="s">"no-referrer-when-downgrade"</span></a>,
+  <a class="s" href="#dom-referrerpolicy-same-origin"><span class="s">"same-origin"</span></a>,
+  <a class="s" href="#dom-referrerpolicy-origin"><span class="s">"origin"</span></a>,
+  <a class="s" href="#dom-referrerpolicy-strict-origin"><span class="s">"strict-origin"</span></a>,
+  <a class="s" href="#dom-referrerpolicy-origin-when-cross-origin"><span class="s">"origin-when-cross-origin"</span></a>,
+  <a class="s" href="#dom-referrerpolicy-strict-origin-when-cross-origin"><span class="s">"strict-origin-when-cross-origin"</span></a>,
+  <a class="s" href="#dom-referrerpolicy-unsafe-url"><span class="s">"unsafe-url"</span></a>
 };
 
 </pre>

--- a/index.src.html
+++ b/index.src.html
@@ -13,6 +13,7 @@ Version History: https://github.com/w3c/webappsec-referrer-policy/commits/master
 Indent: 2
 Ignored Vars: requestURL
 Repository: w3c/webappsec-referrer-policy
+!Tests: <a href=https://github.com/w3c/web-platform-tests/tree/master/referrer-policy>web-platform-tests referrer-policy/</a> (<a href=https://github.com/w3c/web-platform-tests/labels/referrer-policy>ongoing work</a>)
 </pre>
 
 <pre class="anchors">


### PR DESCRIPTION
This is similar to https://github.com/w3c/webappsec-csp/pull/206