### PR TITLE
rel="noreferrer" is not supported for <link> elements

### DIFF
--- a/index.html
+++ b/index.html
@@ -992,57 +992,93 @@ Possible extra rowspan handling
 	.toc > li li          { font-weight: normal; }
 	.toc > li li li       { font-size:   95%;    }
 	.toc > li li li li    { font-size:   90%;    }
+	.toc > li li li li .secno { font-size: 85%; }
 	.toc > li li li li li { font-size:   85%;    }
+	.toc > li li li li li .secno { font-size: 100%; }
 
-	.toc > li             { margin: 1.5rem 0;    }
-	.toc > li li          { margin: 0.3rem 0;    }
-	.toc > li li li       { margin-left: 2rem;   }
+	/* @supports not (display:grid) { */
+		.toc > li             { margin: 1.5rem 0;    }
+		.toc > li li          { margin: 0.3rem 0;    }
+		.toc > li li li       { margin-left: 2rem;   }
 
-	/* Section numbers in a column of their own */
-	.toc .secno {
-		float: left;
-		width: 4rem;
-		white-space: nowrap;
-	}
-	.toc > li li li li .secno {
-		font-size: 85%;
-	}
-	.toc > li li li li li .secno {
-		font-size: 100%;
-	}
+		/* Section numbers in a column of their own */
+		.toc .secno {
+			float: left;
+			width: 4rem;
+			white-space: nowrap;
+		}
 
-	:not(li) > .toc              { margin-left:  5rem; }
-	.toc .secno                  { margin-left: -5rem; }
-	.toc > li li li .secno       { margin-left: -7rem; }
-	.toc > li li li li .secno    { margin-left: -9rem; }
-	.toc > li li li li li .secno { margin-left: -11rem; }
+		.toc li {
+			clear: both;
+		}
 
-	/* Tighten up indentation in narrow ToCs */
-	@media (max-width: 30em) {
-		:not(li) > .toc              { margin-left:  4rem; }
-		.toc .secno                  { margin-left: -4rem; }
-		.toc > li li li              { margin-left:  1rem; }
-		.toc > li li li .secno       { margin-left: -5rem; }
-		.toc > li li li li .secno    { margin-left: -6rem; }
-		.toc > li li li li li .secno { margin-left: -7rem; }
-	}
-	@media screen and (min-width: 78em) {
-		body:not(.toc-inline) :not(li) > .toc              { margin-left:  4rem; }
-		body:not(.toc-inline) .toc .secno                  { margin-left: -4rem; }
-		body:not(.toc-inline) .toc > li li li              { margin-left:  1rem; }
-		body:not(.toc-inline) .toc > li li li .secno       { margin-left: -5rem; }
-		body:not(.toc-inline) .toc > li li li li .secno    { margin-left: -6rem; }
-		body:not(.toc-inline) .toc > li li li li li .secno { margin-left: -7rem; }
-	}
-	body.toc-sidebar #toc :not(li) > .toc              { margin-left:  4rem; }
-	body.toc-sidebar #toc .toc .secno                  { margin-left: -4rem; }
-	body.toc-sidebar #toc .toc > li li li              { margin-left:  1rem; }
-	body.toc-sidebar #toc .toc > li li li .secno       { margin-left: -5rem; }
-	body.toc-sidebar #toc .toc > li li li li .secno    { margin-left: -6rem; }
-	body.toc-sidebar #toc .toc > li li li li li .secno { margin-left: -7rem; }
+		:not(li) > .toc              { margin-left:  5rem; }
+		.toc .secno                  { margin-left: -5rem; }
+		.toc > li li li .secno       { margin-left: -7rem; }
+		.toc > li li li li .secno    { margin-left: -9rem; }
+		.toc > li li li li li .secno { margin-left: -11rem; }
 
-	.toc li {
-		clear: both;
+		/* Tighten up indentation in narrow ToCs */
+		@media (max-width: 30em) {
+			:not(li) > .toc              { margin-left:  4rem; }
+			.toc .secno                  { margin-left: -4rem; }
+			.toc > li li li              { margin-left:  1rem; }
+			.toc > li li li .secno       { margin-left: -5rem; }
+			.toc > li li li li .secno    { margin-left: -6rem; }
+			.toc > li li li li li .secno { margin-left: -7rem; }
+		}
+	/* } */
+
+	@supports (display:grid) {
+		/* Use #toc over .toc to override non-@supports rules. */
+		#toc {
+			display: grid;
+			align-content: start;
+			grid-template-columns: auto 1fr;
+			grid-column-gap: 1rem;
+			column-gap: 1rem;
+			grid-row-gap: .6rem;
+			row-gap: .6rem;
+		}
+		#toc h2 {
+			grid-column: 1 / -1;
+			margin-bottom: 0;
+		}
+		#toc ol,
+		#toc li,
+		#toc a {
+			display: contents;
+			/* Switch <a> to subgrid when supported */
+		}
+		#toc span {
+			margin: 0;
+		}
+		#toc > .toc > li > a > span {
+			/* The spans of the top-level list,
+			   comprising the first items of each top-level section. */
+			margin-top: 1.1rem;
+		}
+		#toc#toc .secno { /* Ugh, need more specificity to override base.css */
+			grid-column: 1;
+			width: auto;
+			margin-left: 0;
+		}
+		#toc .content {
+			grid-column: 2;
+			width: auto;
+			margin-right: 1rem;
+		}
+		#toc .content:hover {
+			background: rgba(75%, 75%, 75%, .25);
+			border-bottom: 3px solid #054572;
+			margin-bottom: -3px;
+		}
+		#toc li li li .content {
+			margin-left: 1rem;
+		}
+		#toc li li li li .content {
+			margin-left: 2rem;
+		}
 	}
 
 
@@ -1176,9 +1212,9 @@ Possible extra rowspan handling
 		}
 	}
 </style>
-  <meta content="Bikeshed version 67155cabad72a8ab669a7d4421c90e2999a29b68" name="generator">
+  <meta content="Bikeshed version 018be3f805d3272ce699a232398d6e3902d1ea8d" name="generator">
   <link href="http://www.w3.org/TR/referrer-policy/" rel="canonical">
-  <meta content="a900fb2f8c41513a9dd8f9fbd7e3c72abc861bb9" name="document-revision">
+  <meta content="cd3894ac6bdc097abed1b8584d8e96bb0fca00ec" name="document-revision">
 <style>/* style-md-lists */
 
 /* This is a weird hack for me not yet following the commonmark spec
@@ -1328,104 +1364,104 @@ pre .property::before, pre .property::after {
 }</style>
 <style>/* style-dfn-panel */
 
-        .dfn-panel {
-            position: absolute;
-            z-index: 35;
-            height: auto;
-            width: -webkit-fit-content;
-            width: fit-content;
-            max-width: 300px;
-            max-height: 500px;
-            overflow: auto;
-            padding: 0.5em 0.75em;
-            font: small Helvetica Neue, sans-serif, Droid Sans Fallback;
-            background: #DDDDDD;
-            color: black;
-            border: outset 0.2em;
-        }
-        .dfn-panel:not(.on) { display: none; }
-        .dfn-panel * { margin: 0; padding: 0; text-indent: 0; }
-        .dfn-panel > b { display: block; }
-        .dfn-panel a { color: black; }
-        .dfn-panel a:not(:hover) { text-decoration: none !important; border-bottom: none !important; }
-        .dfn-panel > b + b { margin-top: 0.25em; }
-        .dfn-panel ul { padding: 0; }
-        .dfn-panel li { list-style: inside; }
-        .dfn-panel.activated {
-            display: inline-block;
-            position: fixed;
-            left: .5em;
-            bottom: 2em;
-            margin: 0 auto;
-            max-width: calc(100vw - 1.5em - .4em - .5em);
-            max-height: 30vh;
-        }
+.dfn-panel {
+    position: absolute;
+    z-index: 35;
+    height: auto;
+    width: -webkit-fit-content;
+    width: fit-content;
+    max-width: 300px;
+    max-height: 500px;
+    overflow: auto;
+    padding: 0.5em 0.75em;
+    font: small Helvetica Neue, sans-serif, Droid Sans Fallback;
+    background: #DDDDDD;
+    color: black;
+    border: outset 0.2em;
+}
+.dfn-panel:not(.on) { display: none; }
+.dfn-panel * { margin: 0; padding: 0; text-indent: 0; }
+.dfn-panel > b { display: block; }
+.dfn-panel a { color: black; }
+.dfn-panel a:not(:hover) { text-decoration: none !important; border-bottom: none !important; }
+.dfn-panel > b + b { margin-top: 0.25em; }
+.dfn-panel ul { padding: 0; }
+.dfn-panel li { list-style: inside; }
+.dfn-panel.activated {
+    display: inline-block;
+    position: fixed;
+    left: .5em;
+    bottom: 2em;
+    margin: 0 auto;
+    max-width: calc(100vw - 1.5em - .4em - .5em);
+    max-height: 30vh;
+}
 
-        .dfn-paneled { cursor: pointer; }
-        </style>
+.dfn-paneled { cursor: pointer; }
+</style>
 <style>/* style-syntax-highlighting */
 pre.idl.highlight { color: #708090; }
 .highlight:not(.idl) { background: hsl(24, 20%, 95%); }
 code.highlight { padding: .1em; border-radius: .3em; }
 pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em 0; overflow: auto; border-radius: 0; }
-.highlight .c { color: #708090 } /* Comment */
-.highlight .k { color: #990055 } /* Keyword */
-.highlight .l { color: #000000 } /* Literal */
-.highlight .n { color: #0077aa } /* Name */
-.highlight .o { color: #999999 } /* Operator */
-.highlight .p { color: #999999 } /* Punctuation */
-.highlight .cm { color: #708090 } /* Comment.Multiline */
-.highlight .cp { color: #708090 } /* Comment.Preproc */
-.highlight .c1 { color: #708090 } /* Comment.Single */
-.highlight .cs { color: #708090 } /* Comment.Special */
-.highlight .kc { color: #990055 } /* Keyword.Constant */
-.highlight .kd { color: #990055 } /* Keyword.Declaration */
-.highlight .kn { color: #990055 } /* Keyword.Namespace */
-.highlight .kp { color: #990055 } /* Keyword.Pseudo */
-.highlight .kr { color: #990055 } /* Keyword.Reserved */
-.highlight .kt { color: #990055 } /* Keyword.Type */
-.highlight .ld { color: #000000 } /* Literal.Date */
-.highlight .m { color: #000000 } /* Literal.Number */
-.highlight .s { color: #a67f59 } /* Literal.String */
-.highlight .na { color: #0077aa } /* Name.Attribute */
-.highlight .nc { color: #0077aa } /* Name.Class */
-.highlight .no { color: #0077aa } /* Name.Constant */
-.highlight .nd { color: #0077aa } /* Name.Decorator */
-.highlight .ni { color: #0077aa } /* Name.Entity */
-.highlight .ne { color: #0077aa } /* Name.Exception */
-.highlight .nf { color: #0077aa } /* Name.Function */
-.highlight .nl { color: #0077aa } /* Name.Label */
-.highlight .nn { color: #0077aa } /* Name.Namespace */
-.highlight .py { color: #0077aa } /* Name.Property */
-.highlight .nt { color: #669900 } /* Name.Tag */
-.highlight .nv { color: #222222 } /* Name.Variable */
-.highlight .ow { color: #999999 } /* Operator.Word */
-.highlight .mb { color: #000000 } /* Literal.Number.Bin */
-.highlight .mf { color: #000000 } /* Literal.Number.Float */
-.highlight .mh { color: #000000 } /* Literal.Number.Hex */
-.highlight .mi { color: #000000 } /* Literal.Number.Integer */
-.highlight .mo { color: #000000 } /* Literal.Number.Oct */
-.highlight .sb { color: #a67f59 } /* Literal.String.Backtick */
-.highlight .sc { color: #a67f59 } /* Literal.String.Char */
-.highlight .sd { color: #a67f59 } /* Literal.String.Doc */
-.highlight .s2 { color: #a67f59 } /* Literal.String.Double */
-.highlight .se { color: #a67f59 } /* Literal.String.Escape */
-.highlight .sh { color: #a67f59 } /* Literal.String.Heredoc */
-.highlight .si { color: #a67f59 } /* Literal.String.Interpol */
-.highlight .sx { color: #a67f59 } /* Literal.String.Other */
-.highlight .sr { color: #a67f59 } /* Literal.String.Regex */
-.highlight .s1 { color: #a67f59 } /* Literal.String.Single */
-.highlight .ss { color: #a67f59 } /* Literal.String.Symbol */
-.highlight .vc { color: #0077aa } /* Name.Variable.Class */
-.highlight .vg { color: #0077aa } /* Name.Variable.Global */
-.highlight .vi { color: #0077aa } /* Name.Variable.Instance */
-.highlight .il { color: #000000 } /* Literal.Number.Integer.Long */
+c-[a] { color: #990055 } /* Keyword.Declaration */
+c-[b] { color: #990055 } /* Keyword.Type */
+c-[c] { color: #708090 } /* Comment */
+c-[d] { color: #708090 } /* Comment.Multiline */
+c-[e] { color: #0077aa } /* Name.Attribute */
+c-[f] { color: #669900 } /* Name.Tag */
+c-[g] { color: #222222 } /* Name.Variable */
+c-[k] { color: #990055 } /* Keyword */
+c-[l] { color: #000000 } /* Literal */
+c-[m] { color: #000000 } /* Literal.Number */
+c-[n] { color: #0077aa } /* Name */
+c-[o] { color: #999999 } /* Operator */
+c-[p] { color: #999999 } /* Punctuation */
+c-[s] { color: #a67f59 } /* Literal.String */
+c-[t] { color: #a67f59 } /* Literal.String.Single */
+c-[u] { color: #a67f59 } /* Literal.String.Double */
+c-[cp] { color: #708090 } /* Comment.Preproc */
+c-[c1] { color: #708090 } /* Comment.Single */
+c-[cs] { color: #708090 } /* Comment.Special */
+c-[kc] { color: #990055 } /* Keyword.Constant */
+c-[kn] { color: #990055 } /* Keyword.Namespace */
+c-[kp] { color: #990055 } /* Keyword.Pseudo */
+c-[kr] { color: #990055 } /* Keyword.Reserved */
+c-[ld] { color: #000000 } /* Literal.Date */
+c-[nc] { color: #0077aa } /* Name.Class */
+c-[no] { color: #0077aa } /* Name.Constant */
+c-[nd] { color: #0077aa } /* Name.Decorator */
+c-[ni] { color: #0077aa } /* Name.Entity */
+c-[ne] { color: #0077aa } /* Name.Exception */
+c-[nf] { color: #0077aa } /* Name.Function */
+c-[nl] { color: #0077aa } /* Name.Label */
+c-[nn] { color: #0077aa } /* Name.Namespace */
+c-[py] { color: #0077aa } /* Name.Property */
+c-[ow] { color: #999999 } /* Operator.Word */
+c-[mb] { color: #000000 } /* Literal.Number.Bin */
+c-[mf] { color: #000000 } /* Literal.Number.Float */
+c-[mh] { color: #000000 } /* Literal.Number.Hex */
+c-[mi] { color: #000000 } /* Literal.Number.Integer */
+c-[mo] { color: #000000 } /* Literal.Number.Oct */
+c-[sb] { color: #a67f59 } /* Literal.String.Backtick */
+c-[sc] { color: #a67f59 } /* Literal.String.Char */
+c-[sd] { color: #a67f59 } /* Literal.String.Doc */
+c-[se] { color: #a67f59 } /* Literal.String.Escape */
+c-[sh] { color: #a67f59 } /* Literal.String.Heredoc */
+c-[si] { color: #a67f59 } /* Literal.String.Interpol */
+c-[sx] { color: #a67f59 } /* Literal.String.Other */
+c-[sr] { color: #a67f59 } /* Literal.String.Regex */
+c-[ss] { color: #a67f59 } /* Literal.String.Symbol */
+c-[vc] { color: #0077aa } /* Name.Variable.Class */
+c-[vg] { color: #0077aa } /* Name.Variable.Global */
+c-[vi] { color: #0077aa } /* Name.Variable.Instance */
+c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
 </style>
  <body class="h-entry">
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1>Referrer Policy</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-11-05">5 November 2017</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2018-10-25">25 October 2018</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1435,7 +1471,7 @@ pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em
      <dt>Version History:
      <dd><a href="https://github.com/w3c/webappsec-referrer-policy/commits/master/index.src.html">https://github.com/w3c/webappsec-referrer-policy/commits/master/index.src.html</a>
      <dt>Feedback:
-     <dd><span><a href="mailto:public-webappsec@w3.org?subject=%5Breferrer-policy%5D%20YOUR%20TOPIC%20HERE">public-webappsec@w3.org</a> with subject line “<kbd>[referrer-policy] <i data-lt="">… message topic …</i></kbd>” (<a href="https://lists.w3.org/Archives/Public/public-webappsec/" rel="discussion">archives</a>)</span>
+     <dd><span><a href="mailto:public-webappsec@w3.org?subject=%5BREFERRER-POLICY%5D%20YOUR%20TOPIC%20HERE">public-webappsec@w3.org</a> with subject line “<kbd>[REFERRER-POLICY] <i data-lt>… message topic …</i></kbd>” (<a href="https://lists.w3.org/Archives/Public/public-webappsec/" rel="discussion">archives</a>)</span>
      <dt>Issue Tracking:
      <dd><a href="https://github.com/w3c/webappsec-referrer-policy/issues/">GitHub</a>
      <dd><a href="#issues-index">Inline In Spec</a>
@@ -1447,7 +1483,7 @@ pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em
     </dl>
    </div>
    <div data-fill-with="warning"></div>
-   <p class="copyright" data-fill-with="copyright"><a href="https://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 2017 <a href="https://www.w3.org/"><abbr title="World Wide Web Consortium">W3C</abbr></a><sup>®</sup> (<a href="https://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>, <a href="https://www.ercim.eu/"><abbr title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>, <a href="https://www.keio.ac.jp/">Keio</a>, <a href="http://ev.buaa.edu.cn/">Beihang</a>). W3C <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>, <a href="https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and <a href="https://www.w3.org/Consortium/Legal/copyright-documents">document use</a> rules apply. </p>
+   <p class="copyright" data-fill-with="copyright"><a href="https://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 2018 <a href="https://www.w3.org/"><abbr title="World Wide Web Consortium">W3C</abbr></a><sup>®</sup> (<a href="https://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>, <a href="https://www.ercim.eu/"><abbr title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>, <a href="https://www.keio.ac.jp/">Keio</a>, <a href="http://ev.buaa.edu.cn/">Beihang</a>). W3C <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>, <a href="https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and <a href="https://www.w3.org/Consortium/Legal/copyright-documents">document use</a> rules apply. </p>
    <hr title="Separator for header">
   </div>
   <div class="p-summary" data-fill-with="abstract">
@@ -1461,19 +1497,19 @@ pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em
 	Its publication here does not imply endorsement of its contents by W3C.
 	Don’t cite this document other than as work in progress. </p>
    <p> <strong>Changes to this document may be tracked at <a href="https://github.com/w3c/webappsec">https://github.com/w3c/webappsec</a>.</strong> </p>
-   <p> The (<a href="https://lists.w3.org/Archives/Public/public-webappsec/">archived</a>) public mailing list <a href="mailto:public-webappsec@w3.org?Subject=%5Breferrer-policy%5D%20PUT%20SUBJECT%20HERE">public-webappsec@w3.org</a> (see <a href="https://www.w3.org/Mail/Request">instructions</a>)
+   <p> The (<a href="https://lists.w3.org/Archives/Public/public-webappsec/">archived</a>) public mailing list <a href="mailto:public-webappsec@w3.org?Subject=%5BREFERRER-POLICY%5D%20PUT%20SUBJECT%20HERE">public-webappsec@w3.org</a> (see <a href="https://www.w3.org/Mail/Request">instructions</a>)
 	is preferred for discussion of this specification.
 	When sending e-mail,
-	please put the text “referrer-policy” in the subject,
+	please put the text “REFERRER-POLICY” in the subject,
 	preferably like this:
-	“[referrer-policy] <em>…summary of comment…</em>” </p>
+	“[REFERRER-POLICY] <em>…summary of comment…</em>” </p>
    <p> This document was produced by the <a href="https://www.w3.org/2011/webappsec/">Web Application Security Working Group</a>. </p>
    <p> This document was produced by a group operating under
-	the <a href="https://www.w3.org/Consortium/Patent-Policy-20040205/">5 February 2004 W3C Patent Policy</a>.
+	the <a href="https://www.w3.org/Consortium/Patent-Policy/">W3C Patent Policy</a>.
 	W3C maintains a <a href="https://www.w3.org/2004/01/pp-impl/49309/status" rel="disclosure">public list of any patent disclosures</a> made in connection with the deliverables of the group;
 	that page also includes instructions for disclosing a patent.
-	An individual who has actual knowledge of a patent which the individual believes contains <a href="https://www.w3.org/Consortium/Patent-Policy-20040205/#def-essential">Essential Claim(s)</a> must disclose the information in accordance with <a href="https://www.w3.org/Consortium/Patent-Policy-20040205/#sec-Disclosure">section 6 of the W3C Patent Policy</a>. </p>
-   <p> This document is governed by the <a href="https://www.w3.org/2017/Process-20170301/" id="w3c_process_revision">1 March 2017 W3C Process Document</a>. </p>
+	An individual who has actual knowledge of a patent which the individual believes contains <a href="https://www.w3.org/Consortium/Patent-Policy/#def-essential">Essential Claim(s)</a> must disclose the information in accordance with <a href="https://www.w3.org/Consortium/Patent-Policy/#sec-Disclosure">section 6 of the W3C Patent Policy</a>. </p>
+   <p> This document is governed by the <a href="https://www.w3.org/2018/Process-20180201/" id="w3c_process_revision">1 February 2018 W3C Process Document</a>. </p>
    <p></p>
   </div>
   <div data-fill-with="at-risk"></div>
@@ -1604,30 +1640,30 @@ pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em
       prefetching, or performing navigations. This document defines the various
       behaviors for each <a data-link-type="dfn" href="#referrer-policy" id="ref-for-referrer-policy②">referrer policy</a>. 
       <p>Every <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object" id="ref-for-environment-settings-object">environment settings object</a> has an algorithm for obtaining a <a data-link-type="dfn" href="#referrer-policy" id="ref-for-referrer-policy③">referrer policy</a>, which is used by default for all <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request">requests</a> with that <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object" id="ref-for-environment-settings-object①">environment settings object</a> as their <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client" id="ref-for-concept-request-client">client</a>.</p>
-     <dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="same-origin-request">same-origin request</dfn>
+     <dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="same-origin-request">same-origin request</dfn>
      <dd> A <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#request" id="ref-for-request">Request</a></code> <var>request</var> is a <strong>same-origin request</strong> if <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-origin" id="ref-for-concept-request-origin">origin</a> and the <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-origin" id="ref-for-concept-url-origin">origin</a> of <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-current-url" id="ref-for-concept-request-current-url">current url</a> are <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#same-origin" id="ref-for-same-origin">the same</a>. 
-     <dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="cross-origin-request">cross-origin request</dfn>
+     <dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="cross-origin-request">cross-origin request</dfn>
      <dd> A <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#request" id="ref-for-request①">Request</a></code> is a <strong>cross-origin request</strong> if it is <em>not</em> <a data-link-type="dfn" href="#same-origin-request" id="ref-for-same-origin-request">same-origin</a>. 
     </dl>
    </section>
    <section>
     <h2 class="heading settled" data-level="3" id="referrer-policies"><span class="secno">3. </span><span class="content">Referrer Policies</span><span id="referrer-policy-states"></span><a class="self-link" href="#referrer-policies"></a></h2>
-    <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="referrer-policy">referrer policy</dfn> is the empty string, "<code>no-referrer</code>",
+    <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-export id="referrer-policy">referrer policy</dfn> is the empty string, "<code>no-referrer</code>",
   "<code>no-referrer-when-downgrade</code>", "<code>same-origin</code>",
   "<code>origin</code>", "<code>strict-origin</code>",
   "<code>origin-when-cross-origin</code>",
   "<code>strict-origin-when-cross-origin</code>", or
   "<code>unsafe-url</code>".</p>
-<pre class="idl highlight def"><span class="kt">enum</span> <dfn class="nv idl-code" data-dfn-type="enum" data-export="" id="enumdef-referrerpolicy"><code>ReferrerPolicy</code><a class="self-link" href="#enumdef-referrerpolicy"></a></dfn> {
-  <dfn class="s idl-code" data-dfn-for="ReferrerPolicy" data-dfn-type="enum-value" data-export="" data-lt="&quot;&quot;|" id="dom-referrerpolicy"><code>""</code><a class="self-link" href="#dom-referrerpolicy"></a></dfn>,
-  <dfn class="s idl-code" data-dfn-for="ReferrerPolicy" data-dfn-type="enum-value" data-export="" data-lt="&quot;no-referrer&quot;|no-referrer" id="dom-referrerpolicy-no-referrer"><code>"no-referrer"</code><a class="self-link" href="#dom-referrerpolicy-no-referrer"></a></dfn>,
-  <dfn class="s idl-code" data-dfn-for="ReferrerPolicy" data-dfn-type="enum-value" data-export="" data-lt="&quot;no-referrer-when-downgrade&quot;|no-referrer-when-downgrade" id="dom-referrerpolicy-no-referrer-when-downgrade"><code>"no-referrer-when-downgrade"</code><a class="self-link" href="#dom-referrerpolicy-no-referrer-when-downgrade"></a></dfn>,
-  <dfn class="s idl-code" data-dfn-for="ReferrerPolicy" data-dfn-type="enum-value" data-export="" data-lt="&quot;same-origin&quot;|same-origin" id="dom-referrerpolicy-same-origin"><code>"same-origin"</code><a class="self-link" href="#dom-referrerpolicy-same-origin"></a></dfn>,
-  <dfn class="s idl-code" data-dfn-for="ReferrerPolicy" data-dfn-type="enum-value" data-export="" data-lt="&quot;origin&quot;|origin" id="dom-referrerpolicy-origin"><code>"origin"</code><a class="self-link" href="#dom-referrerpolicy-origin"></a></dfn>,
-  <dfn class="s idl-code" data-dfn-for="ReferrerPolicy" data-dfn-type="enum-value" data-export="" data-lt="&quot;strict-origin&quot;|strict-origin" id="dom-referrerpolicy-strict-origin"><code>"strict-origin"</code><a class="self-link" href="#dom-referrerpolicy-strict-origin"></a></dfn>,
-  <dfn class="s idl-code" data-dfn-for="ReferrerPolicy" data-dfn-type="enum-value" data-export="" data-lt="&quot;origin-when-cross-origin&quot;|origin-when-cross-origin" id="dom-referrerpolicy-origin-when-cross-origin"><code>"origin-when-cross-origin"</code><a class="self-link" href="#dom-referrerpolicy-origin-when-cross-origin"></a></dfn>,
-  <dfn class="s idl-code" data-dfn-for="ReferrerPolicy" data-dfn-type="enum-value" data-export="" data-lt="&quot;strict-origin-when-cross-origin&quot;|strict-origin-when-cross-origin" id="dom-referrerpolicy-strict-origin-when-cross-origin"><code>"strict-origin-when-cross-origin"</code><a class="self-link" href="#dom-referrerpolicy-strict-origin-when-cross-origin"></a></dfn>,
-  <dfn class="s idl-code" data-dfn-for="ReferrerPolicy" data-dfn-type="enum-value" data-export="" data-lt="&quot;unsafe-url&quot;|unsafe-url" id="dom-referrerpolicy-unsafe-url"><code>"unsafe-url"</code><a class="self-link" href="#dom-referrerpolicy-unsafe-url"></a></dfn>
+<pre class="idl highlight def"><c- b>enum</c-> <dfn class="idl-code" data-dfn-type="enum" data-export id="enumdef-referrerpolicy"><code><c- g>ReferrerPolicy</c-></code><a class="self-link" href="#enumdef-referrerpolicy"></a></dfn> {
+  <dfn class="idl-code" data-dfn-for="ReferrerPolicy" data-dfn-type="enum-value" data-export id="dom-referrerpolicy"><code><c- s>""</c-></code><a class="self-link" href="#dom-referrerpolicy"></a></dfn>,
+  <dfn class="idl-code" data-dfn-for="ReferrerPolicy" data-dfn-type="enum-value" data-export id="dom-referrerpolicy-no-referrer"><code><c- s>"no-referrer"</c-></code><a class="self-link" href="#dom-referrerpolicy-no-referrer"></a></dfn>,
+  <dfn class="idl-code" data-dfn-for="ReferrerPolicy" data-dfn-type="enum-value" data-export id="dom-referrerpolicy-no-referrer-when-downgrade"><code><c- s>"no-referrer-when-downgrade"</c-></code><a class="self-link" href="#dom-referrerpolicy-no-referrer-when-downgrade"></a></dfn>,
+  <dfn class="idl-code" data-dfn-for="ReferrerPolicy" data-dfn-type="enum-value" data-export id="dom-referrerpolicy-same-origin"><code><c- s>"same-origin"</c-></code><a class="self-link" href="#dom-referrerpolicy-same-origin"></a></dfn>,
+  <dfn class="idl-code" data-dfn-for="ReferrerPolicy" data-dfn-type="enum-value" data-export id="dom-referrerpolicy-origin"><code><c- s>"origin"</c-></code><a class="self-link" href="#dom-referrerpolicy-origin"></a></dfn>,
+  <dfn class="idl-code" data-dfn-for="ReferrerPolicy" data-dfn-type="enum-value" data-export id="dom-referrerpolicy-strict-origin"><code><c- s>"strict-origin"</c-></code><a class="self-link" href="#dom-referrerpolicy-strict-origin"></a></dfn>,
+  <dfn class="idl-code" data-dfn-for="ReferrerPolicy" data-dfn-type="enum-value" data-export id="dom-referrerpolicy-origin-when-cross-origin"><code><c- s>"origin-when-cross-origin"</c-></code><a class="self-link" href="#dom-referrerpolicy-origin-when-cross-origin"></a></dfn>,
+  <dfn class="idl-code" data-dfn-for="ReferrerPolicy" data-dfn-type="enum-value" data-export id="dom-referrerpolicy-strict-origin-when-cross-origin"><code><c- s>"strict-origin-when-cross-origin"</c-></code><a class="self-link" href="#dom-referrerpolicy-strict-origin-when-cross-origin"></a></dfn>,
+  <dfn class="idl-code" data-dfn-for="ReferrerPolicy" data-dfn-type="enum-value" data-export id="dom-referrerpolicy-unsafe-url"><code><c- s>"unsafe-url"</c-></code><a class="self-link" href="#dom-referrerpolicy-unsafe-url"></a></dfn>
 };
 </pre>
     <p>Each possible <a data-link-type="dfn" href="#referrer-policy" id="ref-for-referrer-policy④">referrer policy</a> is explained below. A detailed
@@ -1636,37 +1672,38 @@ pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em
   default baseline policy for requests when that <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object" id="ref-for-environment-settings-object③">environment settings
   object</a> is used as a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client" id="ref-for-concept-request-client①">request client</a>. This policy may be tightened
   for specific requests via mechanisms like the <code><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/semantics.html#link-type-noreferrer" id="ref-for-link-type-noreferrer①">noreferrer</a></code> link type.</p>
-    <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-export="" data-level="3.1" data-lt="&quot;no-referrer&quot;" id="referrer-policy-no-referrer"><span class="secno">3.1. </span><span class="content">"<code>no-referrer</code>"</span><span id="referrer-policy-state-no-referrer"></span></h3>
+    <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-export data-level="3.1" data-lt="&quot;no-referrer&quot;" id="referrer-policy-no-referrer"><span class="secno">3.1. </span><span class="content">"<code>no-referrer</code>"</span><span id="referrer-policy-state-no-referrer"></span></h3>
     <p>The simplest policy is <a data-link-type="dfn" href="#referrer-policy-no-referrer" id="ref-for-referrer-policy-no-referrer">"<code>no-referrer</code>"</a>, which specifies
   that no referrer information is to be sent along with requests made from a
   particular <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client" id="ref-for-concept-request-client②">request client</a> to any <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin" id="ref-for-concept-origin">origin</a>. The header will be
   omitted entirely.</p>
-    <div class="example" id="example-df4273ed"><a class="self-link" href="#example-df4273ed"></a> If a document at <code>https://example.com/page.html</code> sets a policy of <a data-link-type="dfn" href="#referrer-policy-no-referrer" id="ref-for-referrer-policy-no-referrer①">"<code>no-referrer</code>"</a>, then navigations to <code>https://example.com/</code> (or any other URL) would send no <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc7231#section-5.5.2" id="ref-for-section-5.5.2③"><code>Referer</code></a> header. </div>
-    <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-export="" data-level="3.2" data-lt="&quot;no-referrer-when-downgrade&quot;" id="referrer-policy-no-referrer-when-downgrade"><span class="secno">3.2. </span><span class="content">"<code>no-referrer-when-downgrade</code>"</span><span id="referrer-policy-state-no-referrer-when-downgrade"></span></h3>
+    <div class="example" id="example-13e0f89b"><a class="self-link" href="#example-13e0f89b"></a> If a document at <code>https://example.com/page.html</code> sets a policy of <a data-link-type="dfn" href="#referrer-policy-no-referrer" id="ref-for-referrer-policy-no-referrer①">"<code>no-referrer</code>"</a>, then navigations to <code>https://example.com/</code> (or any other URL) would send no <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc7231#section-5.5.2" id="ref-for-section-5.5.2③"><code>Referer</code></a> header. </div>
+    <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-export data-level="3.2" data-lt="&quot;no-referrer-when-downgrade&quot;" id="referrer-policy-no-referrer-when-downgrade"><span class="secno">3.2. </span><span class="content">"<code>no-referrer-when-downgrade</code>"</span><span id="referrer-policy-state-no-referrer-when-downgrade"></span></h3>
     <p>The <a data-link-type="dfn" href="#referrer-policy-no-referrer-when-downgrade" id="ref-for-referrer-policy-no-referrer-when-downgrade">"<code>no-referrer-when-downgrade</code>"</a> policy sends a full URL
-  along with requests from a <a data-link-type="dfn" href="http://www.w3.org/TR/2010/REC-wsc-ui-20100812/#typesoftls" id="ref-for-typesoftls">TLS-protected</a> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object" id="ref-for-environment-settings-object④">environment settings
-  object</a> to a <a data-link-type="dfn" href="https://w3c.github.io/webappsec-secure-contexts/#potentially-trustworthy-url" id="ref-for-potentially-trustworthy-url">potentially trustworthy URL</a>, and requests from <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client" id="ref-for-concept-request-client③">clients</a> which are <em>not</em> <a data-link-type="dfn" href="http://www.w3.org/TR/2010/REC-wsc-ui-20100812/#typesoftls" id="ref-for-typesoftls①">TLS-protected</a> to any <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin" id="ref-for-concept-origin①">origin</a>.</p>
-    <p>Requests from <a data-link-type="dfn" href="http://www.w3.org/TR/2010/REC-wsc-ui-20100812/#typesoftls" id="ref-for-typesoftls②">TLS-protected</a> <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client" id="ref-for-concept-request-client④">clients</a> to non- <a data-link-type="dfn" href="https://w3c.github.io/webappsec-secure-contexts/#potentially-trustworthy-url" id="ref-for-potentially-trustworthy-url①">potentially trustworthy URL</a>s, on the other hand, will contain no
+  along with requests from <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object" id="ref-for-environment-settings-object④">environment settings objects</a> whose <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#https-state" id="ref-for-https-state">HTTPS state</a> is "`modern`" to a <a data-link-type="dfn" href="https://w3c.github.io/webappsec-secure-contexts/#potentially-trustworthy-url" id="ref-for-potentially-trustworthy-url">potentially trustworthy URL</a>, and requests from <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client" id="ref-for-concept-request-client③">clients</a> whose <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#https-state" id="ref-for-https-state①">HTTPS state</a> is not "`modern`"
+  to any <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin" id="ref-for-concept-origin①">origin</a>.</p>
+    <p>Requests from <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client" id="ref-for-concept-request-client④">clients</a> whose <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#https-state" id="ref-for-https-state②">HTTPS state</a> is "`modern`"
+  to non-<a data-link-type="dfn" href="https://w3c.github.io/webappsec-secure-contexts/#potentially-trustworthy-url" id="ref-for-potentially-trustworthy-url①">potentially trustworthy URL</a>s, on the other hand, will contain no
   referrer information. A <code><a data-link-type="dfn" href="https://tools.ietf.org/html/rfc7231#section-5.5.2" id="ref-for-section-5.5.2④">Referer</a></code> HTTP header will not be
   sent.</p>
-    <div class="example" id="example-e13d3d6c">
-     <a class="self-link" href="#example-e13d3d6c"></a> If a document at <code>https://example.com/page.html</code> sets a policy of <a data-link-type="dfn" href="#referrer-policy-no-referrer-when-downgrade" id="ref-for-referrer-policy-no-referrer-when-downgrade①">"<code>no-referrer-when-downgrade</code>"</a>, then navigations to <code>https://not.example.com/</code> would send a <code><a data-link-type="dfn" href="https://tools.ietf.org/html/rfc7231#section-5.5.2" id="ref-for-section-5.5.2⑤">Referer</a></code> HTTP header with a value of <code>https://example.com/page.html</code>, as neither resource’s origin is a
+    <div class="example" id="example-8ec274c6">
+     <a class="self-link" href="#example-8ec274c6"></a> If a document at <code>https://example.com/page.html</code> sets a policy of <a data-link-type="dfn" href="#referrer-policy-no-referrer-when-downgrade" id="ref-for-referrer-policy-no-referrer-when-downgrade①">"<code>no-referrer-when-downgrade</code>"</a>, then navigations to <code>https://not.example.com/</code> would send a <code><a data-link-type="dfn" href="https://tools.ietf.org/html/rfc7231#section-5.5.2" id="ref-for-section-5.5.2⑤">Referer</a></code> HTTP header with a value of <code>https://example.com/page.html</code>, as neither resource’s origin is a
     non-<a data-link-type="dfn" href="https://w3c.github.io/webappsec-secure-contexts/#potentially-trustworthy-url" id="ref-for-potentially-trustworthy-url②">potentially trustworthy URL</a>. 
      <p>Navigations from that same page to <code><strong>http</strong>://not.example.com/</code> would send no <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc7231#section-5.5.2" id="ref-for-section-5.5.2⑥"><code>Referer</code></a> header.</p>
     </div>
     <p>This is a user agent’s default behavior, if no policy is otherwise specified.</p>
-    <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-export="" data-level="3.3" data-lt="&quot;same-origin&quot;" id="referrer-policy-same-origin"><span class="secno">3.3. </span><span class="content">"<code>same-origin</code>"</span></h3>
+    <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-export data-level="3.3" data-lt="&quot;same-origin&quot;" id="referrer-policy-same-origin"><span class="secno">3.3. </span><span class="content">"<code>same-origin</code>"</span></h3>
     <p>The <a data-link-type="dfn" href="#referrer-policy-same-origin" id="ref-for-referrer-policy-same-origin">"<code>same-origin</code>"</a> policy specifies that a
   full URL, <a href="#strip-url">stripped for use as a referrer</a>, is sent as
   referrer information when making <a data-link-type="dfn" href="#same-origin-request" id="ref-for-same-origin-request①">same-origin requests</a> from a particular <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client" id="ref-for-concept-request-client⑤">client</a>.</p>
     <p><a data-link-type="dfn" href="#cross-origin-request" id="ref-for-cross-origin-request">Cross-origin requests</a>, on the other hand, will contain no
   referrer information. A <code><a data-link-type="dfn" href="https://tools.ietf.org/html/rfc7231#section-5.5.2" id="ref-for-section-5.5.2⑦">Referer</a></code> HTTP header will not be
   sent.</p>
-    <div class="example" id="example-af6c3f8c">
-     <a class="self-link" href="#example-af6c3f8c"></a> If a document at <code>https://example.com/page.html</code> sets a policy of <a data-link-type="dfn" href="#referrer-policy-same-origin" id="ref-for-referrer-policy-same-origin①">"<code>same-origin</code>"</a>, then navigations to <code>https://example.com/not-page.html</code> would send a <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc7231#section-5.5.2" id="ref-for-section-5.5.2⑧"><code>Referer</code></a> header with a value of <code>https://example.com/page.html</code>. 
+    <div class="example" id="example-44f75544">
+     <a class="self-link" href="#example-44f75544"></a> If a document at <code>https://example.com/page.html</code> sets a policy of <a data-link-type="dfn" href="#referrer-policy-same-origin" id="ref-for-referrer-policy-same-origin①">"<code>same-origin</code>"</a>, then navigations to <code>https://example.com/not-page.html</code> would send a <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc7231#section-5.5.2" id="ref-for-section-5.5.2⑧"><code>Referer</code></a> header with a value of <code>https://example.com/page.html</code>. 
      <p>Navigations from that same page to <code>https://<strong>not</strong>.example.com/</code> would send no <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc7231#section-5.5.2" id="ref-for-section-5.5.2⑨"><code>Referer</code></a> header.</p>
     </div>
-    <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-export="" data-level="3.4" data-lt="&quot;origin&quot;" id="referrer-policy-origin"><span class="secno">3.4. </span><span class="content">"<code>origin</code>"</span><span id="referrer-policy-state-origin"></span></h3>
+    <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-export data-level="3.4" data-lt="&quot;origin&quot;" id="referrer-policy-origin"><span class="secno">3.4. </span><span class="content">"<code>origin</code>"</span><span id="referrer-policy-state-origin"></span></h3>
     <p>The <a data-link-type="dfn" href="#referrer-policy-origin" id="ref-for-referrer-policy-origin">"<code>origin</code>"</a> policy specifies that only the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#ascii-serialisation-of-an-origin" id="ref-for-ascii-serialisation-of-an-origin">ASCII serialization</a> of the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin" id="ref-for-concept-settings-object-origin">origin</a> of the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client" id="ref-for-concept-request-client⑥">request client</a> is sent as referrer information
   when making both <a data-link-type="dfn" href="#same-origin-request" id="ref-for-same-origin-request②">same-origin requests</a> and <a data-link-type="dfn" href="#cross-origin-request" id="ref-for-cross-origin-request①">cross-origin requests</a> from a particular <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client" id="ref-for-concept-request-client⑦">client</a>.</p>
     <p class="note" role="note"><span>Note:</span> The serialization of an origin looks like <code>https://example.com</code>. To ensure that a valid URL is sent in the
@@ -1675,24 +1712,25 @@ pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em
     <p class="note" role="note"><span>Note:</span> The <a data-link-type="dfn" href="#referrer-policy-origin" id="ref-for-referrer-policy-origin①">"<code>origin</code>"</a> policy causes the origin of HTTPS
   referrers to be sent over the network as part of unencrypted HTTP requests.
   The <a data-link-type="dfn" href="#referrer-policy-strict-origin" id="ref-for-referrer-policy-strict-origin">"<code>strict-origin</code>"</a> policy addresses this concern.</p>
-    <div class="example" id="example-fa6ba067"><a class="self-link" href="#example-fa6ba067"></a> If a document at <code>https://example.com/page.html</code> sets a policy of <a data-link-type="dfn" href="#referrer-policy-origin" id="ref-for-referrer-policy-origin②">"<code>origin</code>"</a>, then navigations to any <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin" id="ref-for-concept-origin②">origin</a> would send a <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc7231#section-5.5.2" id="ref-for-section-5.5.2①⓪"><code>Referer</code></a> header with a value
+    <div class="example" id="example-5d156f10"><a class="self-link" href="#example-5d156f10"></a> If a document at <code>https://example.com/page.html</code> sets a policy of <a data-link-type="dfn" href="#referrer-policy-origin" id="ref-for-referrer-policy-origin②">"<code>origin</code>"</a>, then navigations to any <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin" id="ref-for-concept-origin②">origin</a> would send a <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc7231#section-5.5.2" id="ref-for-section-5.5.2①⓪"><code>Referer</code></a> header with a value
     of <code>https://example.com/</code>, even to URLs that are not <a data-link-type="dfn" href="https://w3c.github.io/webappsec-secure-contexts/#potentially-trustworthy-url" id="ref-for-potentially-trustworthy-url③">potentially trustworthy URL</a>. </div>
-    <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-export="" data-level="3.5" data-lt="&quot;strict-origin&quot;" id="referrer-policy-strict-origin"><span class="secno">3.5. </span><span class="content">"<code>strict-origin</code>"</span></h3>
+    <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-export data-level="3.5" data-lt="&quot;strict-origin&quot;" id="referrer-policy-strict-origin"><span class="secno">3.5. </span><span class="content">"<code>strict-origin</code>"</span></h3>
     <p>The <a data-link-type="dfn" href="#referrer-policy-strict-origin" id="ref-for-referrer-policy-strict-origin①">"<code>strict-origin</code>"</a> policy sends the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#ascii-serialisation-of-an-origin" id="ref-for-ascii-serialisation-of-an-origin①">ASCII serialization</a> of the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin" id="ref-for-concept-settings-object-origin①">origin</a> of the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client" id="ref-for-concept-request-client⑧">request client</a> when making requests:</p>
     <ul>
-     <li>from a <a data-link-type="dfn" href="http://www.w3.org/TR/2010/REC-wsc-ui-20100812/#typesoftls" id="ref-for-typesoftls③">TLS-protected</a> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object" id="ref-for-environment-settings-object⑤">environment settings object</a> to a <a data-link-type="dfn" href="https://w3c.github.io/webappsec-secure-contexts/#potentially-trustworthy-url" id="ref-for-potentially-trustworthy-url④">potentially trustworthy URL</a>, and
-     <li>from <em>non-</em><a data-link-type="dfn" href="http://www.w3.org/TR/2010/REC-wsc-ui-20100812/#typesoftls" id="ref-for-typesoftls④">TLS-protected</a> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object" id="ref-for-environment-settings-object⑥">environment settings objects</a> to
+     <li>from an <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object" id="ref-for-environment-settings-object⑤">environment settings object</a> whose <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#https-state" id="ref-for-https-state③">HTTPS state</a> is "`modern`" to a <a data-link-type="dfn" href="https://w3c.github.io/webappsec-secure-contexts/#potentially-trustworthy-url" id="ref-for-potentially-trustworthy-url④">potentially trustworthy URL</a>, and
+     <li>from <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object" id="ref-for-environment-settings-object⑥">environment settings objects</a> whose <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#https-state" id="ref-for-https-state④">HTTPS state</a> is not "`modern`" to
           any <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin" id="ref-for-concept-origin③">origin</a>.
     </ul>
-    <p>Requests from <a data-link-type="dfn" href="http://www.w3.org/TR/2010/REC-wsc-ui-20100812/#typesoftls" id="ref-for-typesoftls⑤">TLS-protected</a> <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client" id="ref-for-concept-request-client⑨">request clients</a> to non- <a data-link-type="dfn" href="https://w3c.github.io/webappsec-secure-contexts/#potentially-trustworthy-url" id="ref-for-potentially-trustworthy-url⑤">potentially trustworthy URL</a>s, on the other hand, will contain no
+    <p>Requests from <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client" id="ref-for-concept-request-client⑨">request clients</a> whose <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#https-state" id="ref-for-https-state⑤">HTTPS state</a> is "`modern`"
+  to non-<a data-link-type="dfn" href="https://w3c.github.io/webappsec-secure-contexts/#potentially-trustworthy-url" id="ref-for-potentially-trustworthy-url⑤">potentially trustworthy URL</a>s, on the other hand, will contain no
   referrer information. A <code><a data-link-type="dfn" href="https://tools.ietf.org/html/rfc7231#section-5.5.2" id="ref-for-section-5.5.2①①">Referer</a></code> HTTP header will not be
   sent.</p>
-    <div class="example" id="example-e6df45e4">
-     <a class="self-link" href="#example-e6df45e4"></a> If a document at <code>https://example.com/page.html</code> sets a policy of <a data-link-type="dfn" href="#referrer-policy-strict-origin" id="ref-for-referrer-policy-strict-origin②">"<code>strict-origin</code>"</a>, then navigations to <code>https://<strong>not</strong>.example.com</code> would send a <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc7231#section-5.5.2" id="ref-for-section-5.5.2①②"><code>Referer</code></a> header with a value of <code>https://example.com/</code>. 
+    <div class="example" id="example-108b15a6">
+     <a class="self-link" href="#example-108b15a6"></a> If a document at <code>https://example.com/page.html</code> sets a policy of <a data-link-type="dfn" href="#referrer-policy-strict-origin" id="ref-for-referrer-policy-strict-origin②">"<code>strict-origin</code>"</a>, then navigations to <code>https://<strong>not</strong>.example.com</code> would send a <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc7231#section-5.5.2" id="ref-for-section-5.5.2①②"><code>Referer</code></a> header with a value of <code>https://example.com/</code>. 
      <p>Navigations from that same page to <code><strong>http://</strong>not.example.com</code> would send no <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc7231#section-5.5.2" id="ref-for-section-5.5.2①③"><code>Referer</code></a> header.</p>
     </div>
-    <div class="example" id="example-e2f29a9f"><a class="self-link" href="#example-e2f29a9f"></a> If a document at <code>http://example.com/page.html</code> sets a policy of <a data-link-type="dfn" href="#referrer-policy-strict-origin" id="ref-for-referrer-policy-strict-origin③">"<code>strict-origin</code>"</a>, then navigations to <code>http://<strong>not</strong>.example.com</code> or <code><strong>https</strong>://example.com</code> would send a <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc7231#section-5.5.2" id="ref-for-section-5.5.2①④"><code>Referer</code></a> header with a value of <code>http://example.com/</code>. </div>
-    <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-export="" data-level="3.6" data-lt="&quot;origin-when-cross-origin&quot;" id="referrer-policy-origin-when-cross-origin"><span class="secno">3.6. </span><span class="content">"<code>origin-when-cross-origin</code>"</span><span id="referrer-policy-state-origin-when-cross-origin"></span></h3>
+    <div class="example" id="example-d8f9ca3f"><a class="self-link" href="#example-d8f9ca3f"></a> If a document at <code>http://example.com/page.html</code> sets a policy of <a data-link-type="dfn" href="#referrer-policy-strict-origin" id="ref-for-referrer-policy-strict-origin③">"<code>strict-origin</code>"</a>, then navigations to <code>http://<strong>not</strong>.example.com</code> or <code><strong>https</strong>://example.com</code> would send a <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc7231#section-5.5.2" id="ref-for-section-5.5.2①④"><code>Referer</code></a> header with a value of <code>http://example.com/</code>. </div>
+    <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-export data-level="3.6" data-lt="&quot;origin-when-cross-origin&quot;" id="referrer-policy-origin-when-cross-origin"><span class="secno">3.6. </span><span class="content">"<code>origin-when-cross-origin</code>"</span><span id="referrer-policy-state-origin-when-cross-origin"></span></h3>
     <p>The <a data-link-type="dfn" href="#referrer-policy-origin-when-cross-origin" id="ref-for-referrer-policy-origin-when-cross-origin">"<code>origin-when-cross-origin</code>"</a> policy specifies that a
   full URL, <a href="#strip-url">stripped for use as a referrer</a>, is sent as
   referrer information when making <a data-link-type="dfn" href="#same-origin-request" id="ref-for-same-origin-request③">same-origin requests</a> from a particular <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client" id="ref-for-concept-request-client①⓪">request client</a>, and only the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#ascii-serialisation-of-an-origin" id="ref-for-ascii-serialisation-of-an-origin②">ASCII serialization</a> of the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin" id="ref-for-concept-settings-object-origin②">origin</a> of the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client" id="ref-for-concept-request-client①①">request client</a> is sent as referrer information
@@ -1703,43 +1741,43 @@ pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em
   origin of HTTPS referrers to be sent over the network as part of unencrypted
   HTTP requests. The <a data-link-type="dfn" href="#referrer-policy-strict-origin-when-cross-origin" id="ref-for-referrer-policy-strict-origin-when-cross-origin">"<code>strict-origin-when-cross-origin</code>"</a> policy
   addresses this concern.</p>
-    <div class="example" id="example-747c716f">
-     <a class="self-link" href="#example-747c716f"></a> If a document at <code>https://example.com/page.html</code> sets a policy of <a data-link-type="dfn" href="#referrer-policy-origin-when-cross-origin" id="ref-for-referrer-policy-origin-when-cross-origin③">"<code>origin-when-cross-origin</code>"</a>, then navigations to <code>https://example.com/not-page.html</code> would send a <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc7231#section-5.5.2" id="ref-for-section-5.5.2①⑤"><code>Referer</code></a> header with a value of <code>https://example.com/page.html</code>. 
+    <div class="example" id="example-f8a49432">
+     <a class="self-link" href="#example-f8a49432"></a> If a document at <code>https://example.com/page.html</code> sets a policy of <a data-link-type="dfn" href="#referrer-policy-origin-when-cross-origin" id="ref-for-referrer-policy-origin-when-cross-origin③">"<code>origin-when-cross-origin</code>"</a>, then navigations to <code>https://example.com/not-page.html</code> would send a <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc7231#section-5.5.2" id="ref-for-section-5.5.2①⑤"><code>Referer</code></a> header with a value of <code>https://example.com/page.html</code>. 
      <p>Navigations from that same page to <code>https://not.example.com/</code> would send a <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc7231#section-5.5.2" id="ref-for-section-5.5.2①⑥"><code>Referer</code></a> header with a value of <code>https://example.com/</code>, even to URLs that are not <a data-link-type="dfn" href="https://w3c.github.io/webappsec-secure-contexts/#potentially-trustworthy-url" id="ref-for-potentially-trustworthy-url⑥">potentially trustworthy URL</a>s.</p>
     </div>
-    <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-export="" data-level="3.7" data-lt="&quot;strict-origin-when-cross-origin&quot;" id="referrer-policy-strict-origin-when-cross-origin"><span class="secno">3.7. </span><span class="content">"<code>strict-origin-when-cross-origin</code>"</span></h3>
+    <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-export data-level="3.7" data-lt="&quot;strict-origin-when-cross-origin&quot;" id="referrer-policy-strict-origin-when-cross-origin"><span class="secno">3.7. </span><span class="content">"<code>strict-origin-when-cross-origin</code>"</span></h3>
     <p>The <a data-link-type="dfn" href="#referrer-policy-strict-origin-when-cross-origin" id="ref-for-referrer-policy-strict-origin-when-cross-origin①">"<code>strict-origin-when-cross-origin</code>"</a> policy specifies that a
   full URL, <a href="#strip-url">stripped for use as a referrer</a>, is sent as
   referrer information when making <a data-link-type="dfn" href="#same-origin-request" id="ref-for-same-origin-request④">same-origin requests</a> from a particular <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client" id="ref-for-concept-request-client①③">request client</a>, and only the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#ascii-serialisation-of-an-origin" id="ref-for-ascii-serialisation-of-an-origin③">ASCII serialization</a> of the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin" id="ref-for-concept-settings-object-origin③">origin</a> of the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client" id="ref-for-concept-request-client①④">request client</a> when making <a data-link-type="dfn" href="#cross-origin-request" id="ref-for-cross-origin-request④">cross-origin requests</a>:</p>
     <ul>
-     <li>from a <a data-link-type="dfn" href="http://www.w3.org/TR/2010/REC-wsc-ui-20100812/#typesoftls" id="ref-for-typesoftls⑥">TLS-protected</a> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object" id="ref-for-environment-settings-object⑦">environment settings object</a> to a <a data-link-type="dfn" href="https://w3c.github.io/webappsec-secure-contexts/#potentially-trustworthy-url" id="ref-for-potentially-trustworthy-url⑦">potentially trustworthy URL</a>, and
-     <li>from <em>non-</em><a data-link-type="dfn" href="http://www.w3.org/TR/2010/REC-wsc-ui-20100812/#typesoftls" id="ref-for-typesoftls⑦">TLS-protected</a> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object" id="ref-for-environment-settings-object⑧">environment settings objects</a> to
+     <li>from a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object" id="ref-for-environment-settings-object⑦">environment settings object</a> whose <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#https-state" id="ref-for-https-state⑥">HTTPS state</a> is "`modern`" to a <a data-link-type="dfn" href="https://w3c.github.io/webappsec-secure-contexts/#potentially-trustworthy-url" id="ref-for-potentially-trustworthy-url⑦">potentially trustworthy URL</a>, and
+     <li>from <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object" id="ref-for-environment-settings-object⑧">environment settings objects</a> whose <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#https-state" id="ref-for-https-state⑦">HTTPS state</a> is not "`modern`" to
           any <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin" id="ref-for-concept-origin④">origin</a>.
     </ul>
-    <p>Requests from <a data-link-type="dfn" href="http://www.w3.org/TR/2010/REC-wsc-ui-20100812/#typesoftls" id="ref-for-typesoftls⑧">TLS-protected</a> <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client" id="ref-for-concept-request-client①⑤">clients</a> to non- <a data-link-type="dfn" href="https://w3c.github.io/webappsec-secure-contexts/#potentially-trustworthy-url" id="ref-for-potentially-trustworthy-url⑧">potentially trustworthy URL</a>s, on the other hand, will contain no
+    <p>Requests from <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client" id="ref-for-concept-request-client①⑤">clients</a> whose <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#https-state" id="ref-for-https-state⑧">HTTPS state</a> is "`modern`" to non- <a data-link-type="dfn" href="https://w3c.github.io/webappsec-secure-contexts/#potentially-trustworthy-url" id="ref-for-potentially-trustworthy-url⑧">potentially trustworthy URL</a>s, on the other hand, will contain no
   referrer information. A <code><a data-link-type="dfn" href="https://tools.ietf.org/html/rfc7231#section-5.5.2" id="ref-for-section-5.5.2①⑦">Referer</a></code> HTTP header will not be
   sent.</p>
-    <div class="example" id="example-2269af87">
-     <a class="self-link" href="#example-2269af87"></a> If a document at <code>https://example.com/page.html</code> sets a policy of <a data-link-type="dfn" href="#referrer-policy-strict-origin-when-cross-origin" id="ref-for-referrer-policy-strict-origin-when-cross-origin②">"<code>strict-origin-when-cross-origin</code>"</a>, then navigations to <code>https://example.com/not-page.html</code> would send a <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc7231#section-5.5.2" id="ref-for-section-5.5.2①⑧"><code>Referer</code></a> header with a value of <code>https://example.com/page.html</code>. 
+    <div class="example" id="example-2e47c322">
+     <a class="self-link" href="#example-2e47c322"></a> If a document at <code>https://example.com/page.html</code> sets a policy of <a data-link-type="dfn" href="#referrer-policy-strict-origin-when-cross-origin" id="ref-for-referrer-policy-strict-origin-when-cross-origin②">"<code>strict-origin-when-cross-origin</code>"</a>, then navigations to <code>https://example.com/not-page.html</code> would send a <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc7231#section-5.5.2" id="ref-for-section-5.5.2①⑧"><code>Referer</code></a> header with a value of <code>https://example.com/page.html</code>. 
      <p>Navigations from that same page to <code>https://not.example.com/</code> would send a <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc7231#section-5.5.2" id="ref-for-section-5.5.2①⑨"><code>Referer</code></a> header with a value of <code>https://example.com/</code>.</p>
      <p>Navigations from that same page to <code><strong>http://</strong>not.example.com/</code> would send no <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc7231#section-5.5.2" id="ref-for-section-5.5.2②⓪"><code>Referer</code></a> header.</p>
     </div>
-    <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-export="" data-level="3.8" data-lt="&quot;unsafe-url&quot;" id="referrer-policy-unsafe-url"><span class="secno">3.8. </span><span class="content">"<code>unsafe-url</code>"</span><span id="referrer-policy-state-unsafe-url"></span></h3>
+    <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-export data-level="3.8" data-lt="&quot;unsafe-url&quot;" id="referrer-policy-unsafe-url"><span class="secno">3.8. </span><span class="content">"<code>unsafe-url</code>"</span><span id="referrer-policy-state-unsafe-url"></span></h3>
     <p>The <a data-link-type="dfn" href="#referrer-policy-unsafe-url" id="ref-for-referrer-policy-unsafe-url">"<code>unsafe-url</code>"</a> policy specifies that a full URL, <a href="#strip-url">stripped for use as a referrer</a>, is sent along with
   both <a data-link-type="dfn" href="#cross-origin-request" id="ref-for-cross-origin-request⑤">cross-origin requests</a> and <a data-link-type="dfn" href="#same-origin-request" id="ref-for-same-origin-request⑤">same-origin requests</a> made from
   a particular <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client" id="ref-for-concept-request-client①⑥">client</a>.</p>
-    <div class="example" id="example-32de6eb8"><a class="self-link" href="#example-32de6eb8"></a> If a document at <code>https://example.com/sekrit.html</code> sets a policy
+    <div class="example" id="example-56375f3a"><a class="self-link" href="#example-56375f3a"></a> If a document at <code>https://example.com/sekrit.html</code> sets a policy
     of <a data-link-type="dfn" href="#referrer-policy-unsafe-url" id="ref-for-referrer-policy-unsafe-url①">"<code>unsafe-url</code>"</a>, then navigations to <code>http://not.example.com/</code> (and every other origin) would send a <code><a data-link-type="dfn" href="https://tools.ietf.org/html/rfc7231#section-5.5.2" id="ref-for-section-5.5.2②①">Referer</a></code> HTTP header with a value of <code>https://example.com/sekrit.html</code>. </div>
     <p class="note" role="note"><span>Note:</span> The policy’s name doesn’t lie; it is unsafe. This policy will leak
-  origins and paths from <a data-link-type="dfn" href="http://www.w3.org/TR/2010/REC-wsc-ui-20100812/#typesoftls" id="ref-for-typesoftls⑨">TLS-protected</a> resources to insecure origins.
+  origins and paths from secure resources to insecure origins.
   Carefully consider the impact of setting such a policy for potentially
   sensitive documents.</p>
-    <h3 class="heading settled" data-dfn-type="dfn" data-export="" data-level="3.9" data-lt="The empty string" id="referrer-policy-empty-string"><span class="secno">3.9. </span><span class="content">The empty string</span><a class="self-link" href="#referrer-policy-empty-string"></a></h3>
+    <h3 class="heading settled" data-dfn-type="dfn" data-export data-level="3.9" data-lt="The empty string" id="referrer-policy-empty-string"><span class="secno">3.9. </span><span class="content">The empty string</span><a class="self-link" href="#referrer-policy-empty-string"></a></h3>
     <p>The empty string "" corresponds to no <a data-link-type="dfn" href="#referrer-policy" id="ref-for-referrer-policy⑤">referrer policy</a>, causing a
   fallback to a <a data-link-type="dfn" href="#referrer-policy" id="ref-for-referrer-policy⑥">referrer policy</a> defined elsewhere, or in the case where
   no such higher-level policy is available, defaulting to <a data-link-type="dfn" href="#referrer-policy-no-referrer-when-downgrade" id="ref-for-referrer-policy-no-referrer-when-downgrade②">"<code>no-referrer-when-downgrade</code>"</a>. This defaulting happens in
   the <a href="#determine-requests-referrer" id="ref-for-determine-requests-referrer">§8.3 Determine request’s Referrer</a> algorithm.</p>
-    <div class="example" id="example-76174780"><a class="self-link" href="#example-76174780"></a> Given a HTML <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-a-element" id="ref-for-the-a-element">a</a></code> element without any declared <code><a data-link-type="element-sub" href="https://html.spec.whatwg.org/multipage/semantics.html#attr-a-referrerpolicy" id="ref-for-attr-a-referrerpolicy">referrerpolicy</a></code> attribute, its referrer policy is the empty string. Thus, navigation
+    <div class="example" id="example-16facf41"><a class="self-link" href="#example-16facf41"></a> Given a HTML <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-a-element" id="ref-for-the-a-element">a</a></code> element without any declared <code><a data-link-type="element-sub" href="https://html.spec.whatwg.org/multipage/semantics.html#attr-a-referrerpolicy" id="ref-for-attr-a-referrerpolicy">referrerpolicy</a></code> attribute, its referrer policy is the empty string. Thus, navigation
     requests initiated by clicking on that <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-a-element" id="ref-for-the-a-element①">a</a></code> element will be sent
     with the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#concept-document-referrer-policy" id="ref-for-concept-document-referrer-policy">referrer
     policy</a> of the <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-a-element" id="ref-for-the-a-element②">a</a></code> element’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-node-document" id="ref-for-concept-node-document">node document</a>. If that <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/dom.html#document" id="ref-for-document">Document</a></code> has the empty string as its referrer policy, the <a href="#determine-requests-referrer" id="ref-for-determine-requests-referrer①">§8.3 Determine request’s Referrer</a> algorithm will treat the empty
@@ -1753,11 +1791,11 @@ pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em
       in <a href="#referrer-policy-header">§4.1 Delivery via Referrer-Policy header</a>). 
      <li> Via a <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#meta" id="ref-for-meta">meta</a></code> element with a <code><a data-link-type="element-sub" href="https://html.spec.whatwg.org/multipage/semantics.html#attr-meta-name" id="ref-for-attr-meta-name">name</a></code> of <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/semantics.html#meta-referrer" id="ref-for-meta-referrer"><code>referrer</code></a>. 
      <li> Via a <code>referrerpolicy</code> content attribute on an <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-a-element" id="ref-for-the-a-element③">a</a></code>, <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/image-maps.html#the-area-element" id="ref-for-the-area-element">area</a></code>, <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element" id="ref-for-the-img-element">img</a></code>, <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element" id="ref-for-the-iframe-element">iframe</a></code>, or <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-link-element" id="ref-for-the-link-element">link</a></code> element. 
-     <li> Via the <code><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/semantics.html#link-type-noreferrer" id="ref-for-link-type-noreferrer②">noreferrer</a></code> link relation on an <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-a-element" id="ref-for-the-a-element④">a</a></code>, <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/image-maps.html#the-area-element" id="ref-for-the-area-element①">area</a></code>, or <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-link-element" id="ref-for-the-link-element①">link</a></code> element. 
+     <li> Via the <code><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/semantics.html#link-type-noreferrer" id="ref-for-link-type-noreferrer②">noreferrer</a></code> link relation on an <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-a-element" id="ref-for-the-a-element④">a</a></code>, or <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/image-maps.html#the-area-element" id="ref-for-the-area-element①">area</a></code> element. 
      <li> Implicitly, via inheritance. 
     </ul>
     <h3 class="heading settled" data-level="4.1" id="referrer-policy-header"><span class="secno">4.1. </span><span class="content">Delivery via Referrer-Policy header</span><a class="self-link" href="#referrer-policy-header"></a></h3>
-    <p>The <code><dfn class="dfn-paneled" data-dfn-type="dfn" data-local-lt="referrer-policy header" data-noexport="" id="referrer-policy-header-dfn">Referrer-Policy</dfn></code> HTTP header
+    <p>The <code><dfn class="dfn-paneled" data-dfn-type="dfn" data-local-lt="referrer-policy header" data-noexport id="referrer-policy-header-dfn">Referrer-Policy</dfn></code> HTTP header
   specifies the referrer policy that the user agent applies when determining
   what referrer information should be included with requests made, and with <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context">browsing contexts</a> created from the context of the protected
   resource.</p>
@@ -1766,8 +1804,8 @@ pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em
   extension used below is defined in <a href="https://tools.ietf.org/html/rfc7230#section-7">Section 7</a> of <a data-link-type="biblio" href="#biblio-rfc7230">[RFC7230]</a>.</p>
 <pre>"Referrer-Policy:" 1#(<a data-link-type="grammar" href="#grammardef-policy-token" id="ref-for-grammardef-policy-token">policy-token</a> / <a data-link-type="grammar" href="#grammardef-extension-token" id="ref-for-grammardef-extension-token">extension-token</a>)
 </pre>
-<pre><dfn class="dfn-paneled" data-dfn-type="grammar" data-export="" id="grammardef-policy-token">policy-token</dfn> = "no-referrer" / "no-referrer-when-downgrade" / "strict-origin" / "strict-origin-when-cross-origin" / "same-origin" / "origin" / "origin-when-cross-origin" / "unsafe-url"
-<dfn class="dfn-paneled" data-dfn-type="grammar" data-export="" id="grammardef-extension-token">extension-token</dfn> = 1*( <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc5234#appendix-B.1" id="ref-for-appendix-B.1">ALPHA</a> / "-" )
+<pre><dfn class="dfn-paneled" data-dfn-type="grammar" data-export id="grammardef-policy-token">policy-token</dfn> = "no-referrer" / "no-referrer-when-downgrade" / "strict-origin" / "strict-origin-when-cross-origin" / "same-origin" / "origin" / "origin-when-cross-origin" / "unsafe-url"
+<dfn class="dfn-paneled" data-dfn-type="grammar" data-export id="grammardef-extension-token">extension-token</dfn> = 1*( <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc5234#appendix-B.1" id="ref-for-appendix-B.1">ALPHA</a> / "-" )
 </pre>
     <p class="note" role="note"><span>Note:</span> The header name does not share the HTTP Referer header’s misspelling.</p>
     <p class="note" role="note"><span>Note:</span> The purpose of <a data-link-type="grammar" href="#grammardef-extension-token" id="ref-for-grammardef-extension-token①">extension-token</a> is so that
@@ -1799,7 +1837,7 @@ pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em
      <p><em>This section is not normative.</em></p>
      <p>The HTML Standard defines the concept of <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#referrer-policy-attribute" id="ref-for-referrer-policy-attribute">referrer policy
     attributes</a> which applies to several of its elements, for example:</p>
-<pre class="example" id="example-4214a796"><a class="self-link" href="#example-4214a796"></a><code class="lang-html highlight"><span class="p">&lt;</span><span class="nt">a</span> <span class="na">href</span><span class="o">=</span><span class="s">"http://example.com"</span> <span class="na">referrerpolicy</span><span class="o">=</span><span class="s">"origin"</span><span class="p">></span>
+<pre class="example" id="example-d7516db8"><a class="self-link" href="#example-d7516db8"></a><code class="lang-html highlight"><c- p>&lt;</c-><c- f>a</c-> <c- e>href</c-><c- o>=</c-><c- s>"http://example.com"</c-> <c- e>referrerpolicy</c-><c- o>=</c-><c- s>"origin"</c-><c- p>></c->
 </code></pre>
     </section>
     <section class="informative">
@@ -1846,8 +1884,8 @@ pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em
        and its <a data-link-type="dfn" href="https://drafts.csswg.org/cssom-1/#concept-css-style-sheet-location" id="ref-for-concept-css-style-sheet-location">location</a> is non-null,
        set the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-referrer" id="ref-for-concept-request-referrer">referrer</a> to its <a data-link-type="dfn" href="https://drafts.csswg.org/cssom-1/#concept-css-style-sheet-location" id="ref-for-concept-css-style-sheet-location①">location</a>, and the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-referrer-policy" id="ref-for-concept-request-referrer-policy①">referrer
        policy</a> to its <a data-link-type="dfn" href="#cssstylesheet-referrer-policy" id="ref-for-cssstylesheet-referrer-policy">referrer policy</a>. 
-      <p class="issue" id="issue-8299c74c"><a class="self-link" href="#issue-8299c74c"></a> This requires that CSS style sheets process `Referrer-Policy`
-       headers, and store a <dfn class="dfn-paneled" data-dfn-for="CSSStyleSheet" data-dfn-type="dfn" data-noexport="" id="cssstylesheet-referrer-policy">referrer policy</dfn> in the same way that <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#concept-document-referrer-policy" id="ref-for-concept-document-referrer-policy①">Documents
+      <p class="issue" id="issue-a01fbbf2"><a class="self-link" href="#issue-a01fbbf2"></a> This requires that CSS style sheets process `Referrer-Policy`
+       headers, and store a <dfn class="dfn-paneled" data-dfn-for="CSSStyleSheet" data-dfn-type="dfn" data-noexport id="cssstylesheet-referrer-policy">referrer policy</dfn> in the same way that <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#concept-document-referrer-policy" id="ref-for-concept-document-referrer-policy①">Documents
        do</a>.</p>
      <li> If a <a data-link-type="dfn" href="https://drafts.csswg.org/cssom-1/#css-style-sheet" id="ref-for-css-style-sheet①">CSS style sheet</a> with a null <a data-link-type="dfn" href="https://drafts.csswg.org/cssom-1/#concept-css-style-sheet-location" id="ref-for-concept-css-style-sheet-location②">location</a> is responsible
       for the request, set the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-referrer" id="ref-for-concept-request-referrer①">referrer</a> to its <a data-link-type="dfn" href="https://drafts.csswg.org/cssom-1/#concept-css-style-sheet-owner-node" id="ref-for-concept-css-style-sheet-owner-node">owner node</a>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-node-document" id="ref-for-concept-node-document①">node document</a>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document-url" id="ref-for-concept-document-url">URL</a>, and the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-referrer-policy" id="ref-for-concept-request-referrer-policy②">referrer policy</a> to its <a data-link-type="dfn" href="https://drafts.csswg.org/cssom-1/#concept-css-style-sheet-owner-node" id="ref-for-concept-css-style-sheet-owner-node①">owner node</a>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-node-document" id="ref-for-concept-node-document②">node document</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#concept-document-referrer-policy" id="ref-for-concept-document-referrer-policy②">referrer policy</a>. 
@@ -1881,7 +1919,7 @@ pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em
 	  agents, as described in <a href="#unknown-policy-values">§11.1 Unknown Policy Values</a>.</p>
      <li> Return <var>policy</var>. 
     </ol>
-    <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-export="" data-level="8.2" data-lt="Set request’s referrer policy on redirect" id="set-requests-referrer-policy-on-redirect"><span class="secno">8.2. </span><span class="content"> Set <var>request</var>’s referrer policy on redirect </span></h3>
+    <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-export data-level="8.2" data-lt="Set request’s referrer policy on redirect" id="set-requests-referrer-policy-on-redirect"><span class="secno">8.2. </span><span class="content"> Set <var>request</var>’s referrer policy on redirect </span></h3>
     <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤">request</a> <var>request</var> and a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②">response</a> <var>actualResponse</var>,
   this algorithm updates <var>request</var>’s associated <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-referrer-policy" id="ref-for-concept-request-referrer-policy⑤">referrer policy</a> according to the Referrer-Policy header (if any) in <var>actualResponse</var>.</p>
     <ol>
@@ -1889,7 +1927,7 @@ pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em
      <li>If <var>policy</var> is not the empty string, then set <var>request</var>’s
     associated referrer policy to <var>policy</var>.
     </ol>
-    <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-export="" data-level="8.3" data-lt="Determine request’s Referrer" id="determine-requests-referrer"><span class="secno">8.3. </span><span class="content"> Determine <var>request</var>’s Referrer </span></h3>
+    <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-export data-level="8.3" data-lt="Determine request’s Referrer" id="determine-requests-referrer"><span class="secno">8.3. </span><span class="content"> Determine <var>request</var>’s Referrer </span></h3>
     <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑥">request</a> <var>request</var>, we can determine the correct
   referrer information to send by examining the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-referrer-policy" id="ref-for-concept-request-referrer-policy⑥">referrer policy</a> associated with it, as detailed in the following steps, which return
   either <code>no referrer</code> or a URL:</p>
@@ -1940,7 +1978,7 @@ pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em
          <li>
            If <var>environment</var> is not null: 
           <ol>
-           <li> If <var>environment</var> is <a data-link-type="dfn" href="http://www.w3.org/TR/2010/REC-wsc-ui-20100812/#typesoftls" id="ref-for-typesoftls①⓪">TLS-protected</a> <em>and</em> <var>request</var>’s <a href="https://fetch.spec.whatwg.org/#concept-request-current-url">current
+           <li> If <var>environment</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#https-state" id="ref-for-https-state⑨">HTTPS state</a> is "`modern`" <em>and</em> <var>request</var>’s <a href="https://fetch.spec.whatwg.org/#concept-request-current-url" id="termref-for-">current
                   URL</a> is not a <a data-link-type="dfn" href="https://w3c.github.io/webappsec-secure-contexts/#potentially-trustworthy-url" id="ref-for-potentially-trustworthy-url⑨">potentially trustworthy
                   URL</a>, then return <code>no referrer</code>. 
           </ol>
@@ -1955,7 +1993,7 @@ pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em
            If <var>environment</var> is not null: 
           <ol>
            <li>
-             If <var>environment</var> is <a data-link-type="dfn" href="http://www.w3.org/TR/2010/REC-wsc-ui-20100812/#typesoftls" id="ref-for-typesoftls①①">TLS-protected</a> <em>and</em> <var>request</var>’s <a href="https://fetch.spec.whatwg.org/#concept-request-current-url">current
+             If <var>environment</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#https-state" id="ref-for-https-state①⓪">HTTPS state</a> is "`modern`" <em>and</em> <var>request</var>’s <a href="https://fetch.spec.whatwg.org/#concept-request-current-url" id="termref-for-①">current
                   URL</a> is not a <a data-link-type="dfn" href="https://w3c.github.io/webappsec-secure-contexts/#potentially-trustworthy-url" id="ref-for-potentially-trustworthy-url①⓪">potentially trustworthy URL</a> 
             <ol>
              <li>Return <code>no referrer</code>. 
@@ -1983,7 +2021,7 @@ pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em
          <li>
            If <var>environment</var> is not null: 
           <ol>
-           <li> If <var>environment</var> is <a data-link-type="dfn" href="http://www.w3.org/TR/2010/REC-wsc-ui-20100812/#typesoftls" id="ref-for-typesoftls①②">TLS-protected</a> <em>and</em> <var>request</var>’s <a href="https://fetch.spec.whatwg.org/#concept-request-current-url">current
+           <li> If <var>environment</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#https-state" id="ref-for-https-state①①">HTTPS state</a> is "`modern`" <em>and</em> <var>request</var>’s <a href="https://fetch.spec.whatwg.org/#concept-request-current-url" id="termref-for-②">current
                   URL</a> is not a <a data-link-type="dfn" href="https://w3c.github.io/webappsec-secure-contexts/#potentially-trustworthy-url" id="ref-for-potentially-trustworthy-url①①">potentially trustworthy
                   URL</a>, then return <code>no referrer</code>. 
           </ol>
@@ -1997,7 +2035,7 @@ pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em
     <p>Certain portions of URLs must not be included when sending a URL as the value
   of a `<code>Referer</code>` header: a URLs fragment, username, and password
   components must be stripped from the URL before it’s sent out. This
-  algorithm accepts a <code><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="origin-only-flag">origin-only flag</dfn></code>, which defaults
+  algorithm accepts a <code><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="origin-only-flag">origin-only flag</dfn></code>, which defaults
   to <code>false</code>. If set to <code>true</code>, the algorithm will
   additionally remove the URL’s path and query components, leaving only the
   scheme, host, and port.</p>
@@ -2052,12 +2090,12 @@ pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em
   policy values will be ignored, and when multiple sources specify a
   referrer policy, the value of the latest one will be used. This makes
   it possible to deploy new policy values.</p>
-    <div class="example" id="example-e42fe91b"><a class="self-link" href="#example-e42fe91b"></a> Suppose older user agents don’t understand
+    <div class="example" id="example-1ba8d4a5"><a class="self-link" href="#example-1ba8d4a5"></a> Suppose older user agents don’t understand
     the <a data-link-type="dfn" href="#referrer-policy-unsafe-url" id="ref-for-referrer-policy-unsafe-url⑤">"<code>unsafe-url</code>"</a> policy. A site can specify
     an <a data-link-type="dfn" href="#referrer-policy-origin" id="ref-for-referrer-policy-origin⑥">"<code>origin</code>"</a> policy followed by an <a data-link-type="dfn" href="#referrer-policy-unsafe-url" id="ref-for-referrer-policy-unsafe-url⑥">"<code>unsafe-url</code>"</a> policy: older user agents will ignore the
     unknown <a data-link-type="dfn" href="#referrer-policy-unsafe-url" id="ref-for-referrer-policy-unsafe-url⑦">"<code>unsafe-url</code>"</a> value and use <a data-link-type="dfn" href="#referrer-policy-origin" id="ref-for-referrer-policy-origin⑦">"<code>origin</code>"</a>, while newer user agents will use <a data-link-type="dfn" href="#referrer-policy-unsafe-url" id="ref-for-referrer-policy-unsafe-url⑧">"<code>unsafe-url</code>"</a> because it is the last to be processed. </div>
-    <div class="example" id="example-af01a355">
-     <a class="self-link" href="#example-af01a355"></a> To specify multiple policy values in the Referrer-Policy header, a site can
+    <div class="example" id="example-3966e12b">
+     <a class="self-link" href="#example-3966e12b"></a> To specify multiple policy values in the Referrer-Policy header, a site can
     send multiple Referrer-Policy headers: 
 <pre>Referrer-Policy: no-referrer
 Referrer-Policy: unsafe-url
@@ -2090,8 +2128,8 @@ Referrer-Policy: unsafe-url
   <p>Examples in this specification are introduced with the words “for example”
     or are set apart from the normative text with <code>class="example"</code>,
     like this: </p>
-  <div class="example" id="example-f839f6c8">
-   <a class="self-link" href="#example-f839f6c8"></a> 
+  <div class="example" id="example-ae2b6bc0">
+   <a class="self-link" href="#example-ae2b6bc0"></a> 
    <p>This is an example of an informative example.</p>
   </div>
   <p>Informative notes begin with the word “Note” and are set apart from the
@@ -2118,177 +2156,640 @@ Referrer-Policy: unsafe-url
    <li>
     "no-referrer"
     <ul>
-     <li><a href="#dom-referrerpolicy-no-referrer">enum-value for ReferrerPolicy</a><span>, in §3</span>
      <li><a href="#referrer-policy-no-referrer">definition of</a><span>, in §3</span>
+     <li><a href="#dom-referrerpolicy-no-referrer">enum-value for ReferrerPolicy</a><span>, in §3</span>
     </ul>
-   <li><a href="#dom-referrerpolicy-no-referrer">no-referrer</a><span>, in §3</span>
-   <li><a href="#dom-referrerpolicy-no-referrer-when-downgrade">no-referrer-when-downgrade</a><span>, in §3</span>
    <li>
     "no-referrer-when-downgrade"
     <ul>
-     <li><a href="#dom-referrerpolicy-no-referrer-when-downgrade">enum-value for ReferrerPolicy</a><span>, in §3</span>
      <li><a href="#referrer-policy-no-referrer-when-downgrade">definition of</a><span>, in §3.1</span>
+     <li><a href="#dom-referrerpolicy-no-referrer-when-downgrade">enum-value for ReferrerPolicy</a><span>, in §3</span>
     </ul>
-   <li><a href="#dom-referrerpolicy-origin">origin</a><span>, in §3</span>
    <li>
     "origin"
     <ul>
-     <li><a href="#dom-referrerpolicy-origin">enum-value for ReferrerPolicy</a><span>, in §3</span>
      <li><a href="#referrer-policy-origin">definition of</a><span>, in §3.3</span>
+     <li><a href="#dom-referrerpolicy-origin">enum-value for ReferrerPolicy</a><span>, in §3</span>
     </ul>
    <li><a href="#origin-only-flag">origin-only flag</a><span>, in §8.4</span>
-   <li><a href="#dom-referrerpolicy-origin-when-cross-origin">origin-when-cross-origin</a><span>, in §3</span>
    <li>
     "origin-when-cross-origin"
     <ul>
-     <li><a href="#dom-referrerpolicy-origin-when-cross-origin">enum-value for ReferrerPolicy</a><span>, in §3</span>
      <li><a href="#referrer-policy-origin-when-cross-origin">definition of</a><span>, in §3.5</span>
+     <li><a href="#dom-referrerpolicy-origin-when-cross-origin">enum-value for ReferrerPolicy</a><span>, in §3</span>
     </ul>
    <li><a href="#grammardef-policy-token">policy-token</a><span>, in §4.1</span>
    <li><a href="#enumdef-referrerpolicy">ReferrerPolicy</a><span>, in §3</span>
+   <li><a href="#referrer-policy-header-dfn">Referrer-Policy</a><span>, in §4.1</span>
    <li>
     referrer policy
     <ul>
      <li><a href="#referrer-policy">definition of</a><span>, in §3</span>
      <li><a href="#cssstylesheet-referrer-policy">dfn for CSSStyleSheet</a><span>, in §7</span>
     </ul>
-   <li><a href="#referrer-policy-header-dfn">Referrer-Policy</a><span>, in §4.1</span>
    <li><a href="#referrer-policy-header-dfn">referrer-policy header</a><span>, in §4.1</span>
    <li>
     "same-origin"
     <ul>
-     <li><a href="#dom-referrerpolicy-same-origin">enum-value for ReferrerPolicy</a><span>, in §3</span>
      <li><a href="#referrer-policy-same-origin">definition of</a><span>, in §3.2</span>
+     <li><a href="#dom-referrerpolicy-same-origin">enum-value for ReferrerPolicy</a><span>, in §3</span>
     </ul>
-   <li><a href="#dom-referrerpolicy-same-origin">same-origin</a><span>, in §3</span>
    <li><a href="#same-origin-request">same-origin request</a><span>, in §2</span>
    <li><a href="#set-requests-referrer-policy-on-redirect">Set request’s referrer policy on redirect</a><span>, in §8.1</span>
-   <li><a href="#dom-referrerpolicy-strict-origin">strict-origin</a><span>, in §3</span>
    <li>
     "strict-origin"
     <ul>
-     <li><a href="#dom-referrerpolicy-strict-origin">enum-value for ReferrerPolicy</a><span>, in §3</span>
      <li><a href="#referrer-policy-strict-origin">definition of</a><span>, in §3.4</span>
+     <li><a href="#dom-referrerpolicy-strict-origin">enum-value for ReferrerPolicy</a><span>, in §3</span>
     </ul>
    <li>
     "strict-origin-when-cross-origin"
     <ul>
-     <li><a href="#dom-referrerpolicy-strict-origin-when-cross-origin">enum-value for ReferrerPolicy</a><span>, in §3</span>
      <li><a href="#referrer-policy-strict-origin-when-cross-origin">definition of</a><span>, in §3.6</span>
+     <li><a href="#dom-referrerpolicy-strict-origin-when-cross-origin">enum-value for ReferrerPolicy</a><span>, in §3</span>
     </ul>
-   <li><a href="#dom-referrerpolicy-strict-origin-when-cross-origin">strict-origin-when-cross-origin</a><span>, in §3</span>
    <li><a href="#referrer-policy-empty-string">The empty string</a><span>, in §3.8</span>
-   <li><a href="#dom-referrerpolicy-unsafe-url">unsafe-url</a><span>, in §3</span>
    <li>
     "unsafe-url"
     <ul>
-     <li><a href="#dom-referrerpolicy-unsafe-url">enum-value for ReferrerPolicy</a><span>, in §3</span>
      <li><a href="#referrer-policy-unsafe-url">definition of</a><span>, in §3.7</span>
+     <li><a href="#dom-referrerpolicy-unsafe-url">enum-value for ReferrerPolicy</a><span>, in §3</span>
     </ul>
   </ul>
+  <aside class="dfn-panel" data-for="term-for-css-declaration-block">
+   <a href="https://drafts.csswg.org/cssom-1/#css-declaration-block">https://drafts.csswg.org/cssom-1/#css-declaration-block</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-css-declaration-block">7. Integration with CSS</a> <a href="#ref-for-css-declaration-block①">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-css-style-sheet">
+   <a href="https://drafts.csswg.org/cssom-1/#css-style-sheet">https://drafts.csswg.org/cssom-1/#css-style-sheet</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-css-style-sheet">7. Integration with CSS</a> <a href="#ref-for-css-style-sheet①">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-concept-css-style-sheet-location">
+   <a href="https://drafts.csswg.org/cssom-1/#concept-css-style-sheet-location">https://drafts.csswg.org/cssom-1/#concept-css-style-sheet-location</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-concept-css-style-sheet-location">7. Integration with CSS</a> <a href="#ref-for-concept-css-style-sheet-location①">(2)</a> <a href="#ref-for-concept-css-style-sheet-location②">(3)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-concept-css-style-sheet-owner-node">
+   <a href="https://drafts.csswg.org/cssom-1/#concept-css-style-sheet-owner-node">https://drafts.csswg.org/cssom-1/#concept-css-style-sheet-owner-node</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-concept-css-style-sheet-owner-node">7. Integration with CSS</a> <a href="#ref-for-concept-css-style-sheet-owner-node①">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-concept-node-document">
+   <a href="https://dom.spec.whatwg.org/#concept-node-document">https://dom.spec.whatwg.org/#concept-node-document</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-concept-node-document">3.9. The empty string</a>
+    <li><a href="#ref-for-concept-node-document①">7. Integration with CSS</a> <a href="#ref-for-concept-node-document②">(2)</a> <a href="#ref-for-concept-node-document③">(3)</a> <a href="#ref-for-concept-node-document④">(4)</a>
+    <li><a href="#ref-for-concept-node-document⑤">8.3. 
+    Determine request’s Referrer </a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-concept-document-origin">
+   <a href="https://dom.spec.whatwg.org/#concept-document-origin">https://dom.spec.whatwg.org/#concept-document-origin</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-concept-document-origin">8.3. 
+    Determine request’s Referrer </a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-concept-document-url">
+   <a href="https://dom.spec.whatwg.org/#concept-document-url">https://dom.spec.whatwg.org/#concept-document-url</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-concept-document-url">7. Integration with CSS</a> <a href="#ref-for-concept-document-url①">(2)</a>
+    <li><a href="#ref-for-concept-document-url②">8.3. 
+    Determine request’s Referrer </a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-request">
+   <a href="https://fetch.spec.whatwg.org/#request">https://fetch.spec.whatwg.org/#request</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-request">2. Key Concepts and Terminology</a> <a href="#ref-for-request①">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-concept-request-client">
+   <a href="https://fetch.spec.whatwg.org/#concept-request-client">https://fetch.spec.whatwg.org/#concept-request-client</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-concept-request-client">2. Key Concepts and Terminology</a>
+    <li><a href="#ref-for-concept-request-client①">3. Referrer Policies</a>
+    <li><a href="#ref-for-concept-request-client②">3.1. "no-referrer"</a>
+    <li><a href="#ref-for-concept-request-client③">3.2. "no-referrer-when-downgrade"</a> <a href="#ref-for-concept-request-client④">(2)</a>
+    <li><a href="#ref-for-concept-request-client⑤">3.3. "same-origin"</a>
+    <li><a href="#ref-for-concept-request-client⑥">3.4. "origin"</a> <a href="#ref-for-concept-request-client⑦">(2)</a>
+    <li><a href="#ref-for-concept-request-client⑧">3.5. "strict-origin"</a> <a href="#ref-for-concept-request-client⑨">(2)</a>
+    <li><a href="#ref-for-concept-request-client①⓪">3.6. "origin-when-cross-origin"</a> <a href="#ref-for-concept-request-client①①">(2)</a> <a href="#ref-for-concept-request-client①②">(3)</a>
+    <li><a href="#ref-for-concept-request-client①③">3.7. "strict-origin-when-cross-origin"</a> <a href="#ref-for-concept-request-client①④">(2)</a> <a href="#ref-for-concept-request-client①⑤">(3)</a>
+    <li><a href="#ref-for-concept-request-client①⑥">3.8. "unsafe-url"</a>
+    <li><a href="#ref-for-concept-request-client①⑦">6. Integration with HTML</a>
+    <li><a href="#ref-for-concept-request-client①⑧">8.3. 
+    Determine request’s Referrer </a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-concept-request-current-url">
+   <a href="https://fetch.spec.whatwg.org/#concept-request-current-url">https://fetch.spec.whatwg.org/#concept-request-current-url</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-concept-request-current-url">2. Key Concepts and Terminology</a>
+    <li><a href="#termref-for-">8.3. 
+    Determine request’s Referrer </a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-extract-header-list-values">
+   <a href="https://fetch.spec.whatwg.org/#extract-header-list-values">https://fetch.spec.whatwg.org/#extract-header-list-values</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-extract-header-list-values">8.1. 
+    Parse a referrer policy from a Referrer-Policy header </a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-concept-fetch">
+   <a href="https://fetch.spec.whatwg.org/#concept-fetch">https://fetch.spec.whatwg.org/#concept-fetch</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-concept-fetch">2. Key Concepts and Terminology</a>
+    <li><a href="#ref-for-concept-fetch①">6. Integration with HTML</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-concept-response-header-list">
+   <a href="https://fetch.spec.whatwg.org/#concept-response-header-list">https://fetch.spec.whatwg.org/#concept-response-header-list</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-concept-response-header-list">8.1. 
+    Parse a referrer policy from a Referrer-Policy header </a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-local-scheme">
+   <a href="https://fetch.spec.whatwg.org/#local-scheme">https://fetch.spec.whatwg.org/#local-scheme</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-local-scheme">8.4. 
+    Strip url for use as a referrer </a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-concept-request-origin">
+   <a href="https://fetch.spec.whatwg.org/#concept-request-origin">https://fetch.spec.whatwg.org/#concept-request-origin</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-concept-request-origin">2. Key Concepts and Terminology</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-concept-request-referrer">
+   <a href="https://fetch.spec.whatwg.org/#concept-request-referrer">https://fetch.spec.whatwg.org/#concept-request-referrer</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-concept-request-referrer">7. Integration with CSS</a> <a href="#ref-for-concept-request-referrer①">(2)</a> <a href="#ref-for-concept-request-referrer②">(3)</a> <a href="#ref-for-concept-request-referrer③">(4)</a>
+    <li><a href="#ref-for-concept-request-referrer④">8.3. 
+    Determine request’s Referrer </a> <a href="#ref-for-concept-request-referrer⑤">(2)</a> <a href="#ref-for-concept-request-referrer⑥">(3)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-concept-request-referrer-policy">
+   <a href="https://fetch.spec.whatwg.org/#concept-request-referrer-policy">https://fetch.spec.whatwg.org/#concept-request-referrer-policy</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-concept-request-referrer-policy">4. Referrer Policy Delivery</a>
+    <li><a href="#ref-for-concept-request-referrer-policy①">7. Integration with CSS</a> <a href="#ref-for-concept-request-referrer-policy②">(2)</a> <a href="#ref-for-concept-request-referrer-policy③">(3)</a> <a href="#ref-for-concept-request-referrer-policy④">(4)</a>
+    <li><a href="#ref-for-concept-request-referrer-policy⑤">8.2. 
+    Set request’s referrer policy on redirect </a>
+    <li><a href="#ref-for-concept-request-referrer-policy⑥">8.3. 
+    Determine request’s Referrer </a> <a href="#ref-for-concept-request-referrer-policy⑦">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-concept-request">
+   <a href="https://fetch.spec.whatwg.org/#concept-request">https://fetch.spec.whatwg.org/#concept-request</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-concept-request">2. Key Concepts and Terminology</a>
+    <li><a href="#ref-for-concept-request①">4. Referrer Policy Delivery</a>
+    <li><a href="#ref-for-concept-request②">7. Integration with CSS</a> <a href="#ref-for-concept-request③">(2)</a> <a href="#ref-for-concept-request④">(3)</a>
+    <li><a href="#ref-for-concept-request⑤">8.2. 
+    Set request’s referrer policy on redirect </a>
+    <li><a href="#ref-for-concept-request⑥">8.3. 
+    Determine request’s Referrer </a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-concept-response">
+   <a href="https://fetch.spec.whatwg.org/#concept-response">https://fetch.spec.whatwg.org/#concept-response</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-concept-response">4.4. Nested browsing contexts</a>
+    <li><a href="#ref-for-concept-response①">8.1. 
+    Parse a referrer policy from a Referrer-Policy header </a>
+    <li><a href="#ref-for-concept-response②">8.2. 
+    Set request’s referrer policy on redirect </a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-document">
+   <a href="https://html.spec.whatwg.org/multipage/dom.html#document">https://html.spec.whatwg.org/multipage/dom.html#document</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-document">3.9. The empty string</a>
+    <li><a href="#ref-for-document①">6. Integration with HTML</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-window">
+   <a href="https://html.spec.whatwg.org/multipage/window-object.html#window">https://html.spec.whatwg.org/multipage/window-object.html#window</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-window">8.3. 
+    Determine request’s Referrer </a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-workerglobalscope">
+   <a href="https://html.spec.whatwg.org/multipage/workers.html#workerglobalscope">https://html.spec.whatwg.org/multipage/workers.html#workerglobalscope</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-workerglobalscope">6. Integration with HTML</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-the-a-element">
+   <a href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-a-element">https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-a-element</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-the-a-element">3.9. The empty string</a> <a href="#ref-for-the-a-element①">(2)</a> <a href="#ref-for-the-a-element②">(3)</a>
+    <li><a href="#ref-for-the-a-element③">4. Referrer Policy Delivery</a> <a href="#ref-for-the-a-element④">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-an-iframe-srcdoc-document">
+   <a href="https://html.spec.whatwg.org/multipage/embedded-content.html#an-iframe-srcdoc-document">https://html.spec.whatwg.org/multipage/embedded-content.html#an-iframe-srcdoc-document</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-an-iframe-srcdoc-document">8.3. 
+    Determine request’s Referrer </a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-the-area-element">
+   <a href="https://html.spec.whatwg.org/multipage/image-maps.html#the-area-element">https://html.spec.whatwg.org/multipage/image-maps.html#the-area-element</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-the-area-element">4. Referrer Policy Delivery</a> <a href="#ref-for-the-area-element①">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-ascii-serialisation-of-an-origin">
+   <a href="https://html.spec.whatwg.org/multipage/origin.html#ascii-serialisation-of-an-origin">https://html.spec.whatwg.org/multipage/origin.html#ascii-serialisation-of-an-origin</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-ascii-serialisation-of-an-origin">3.4. "origin"</a>
+    <li><a href="#ref-for-ascii-serialisation-of-an-origin①">3.5. "strict-origin"</a>
+    <li><a href="#ref-for-ascii-serialisation-of-an-origin②">3.6. "origin-when-cross-origin"</a>
+    <li><a href="#ref-for-ascii-serialisation-of-an-origin③">3.7. "strict-origin-when-cross-origin"</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-concept-document-window">
+   <a href="https://html.spec.whatwg.org/multipage/browsers.html#concept-document-window">https://html.spec.whatwg.org/multipage/browsers.html#concept-document-window</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-concept-document-window">8.3. 
+    Determine request’s Referrer </a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-concept-document-bc">
+   <a href="https://html.spec.whatwg.org/multipage/browsers.html#concept-document-bc">https://html.spec.whatwg.org/multipage/browsers.html#concept-document-bc</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-concept-document-bc">8.3. 
+    Determine request’s Referrer </a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-browsing-context-container">
+   <a href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context-container">https://html.spec.whatwg.org/multipage/browsers.html#browsing-context-container</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-browsing-context-container">8.3. 
+    Determine request’s Referrer </a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-concept-environment-creation-url">
+   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-creation-url">https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-creation-url</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-concept-environment-creation-url">8.3. 
+    Determine request’s Referrer </a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-concept-document-referrer-policy">
+   <a href="https://html.spec.whatwg.org/multipage/dom.html#concept-document-referrer-policy">https://html.spec.whatwg.org/multipage/dom.html#concept-document-referrer-policy</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-concept-document-referrer-policy">3.9. The empty string</a>
+    <li><a href="#ref-for-concept-document-referrer-policy①">7. Integration with CSS</a> <a href="#ref-for-concept-document-referrer-policy②">(2)</a> <a href="#ref-for-concept-document-referrer-policy③">(3)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-environment-settings-object">
+   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-environment-settings-object">2. Key Concepts and Terminology</a> <a href="#ref-for-environment-settings-object①">(2)</a>
+    <li><a href="#ref-for-environment-settings-object②">3. Referrer Policies</a> <a href="#ref-for-environment-settings-object③">(2)</a>
+    <li><a href="#ref-for-environment-settings-object④">3.2. "no-referrer-when-downgrade"</a>
+    <li><a href="#ref-for-environment-settings-object⑤">3.5. "strict-origin"</a> <a href="#ref-for-environment-settings-object⑥">(2)</a>
+    <li><a href="#ref-for-environment-settings-object⑦">3.7. "strict-origin-when-cross-origin"</a> <a href="#ref-for-environment-settings-object⑧">(2)</a>
+    <li><a href="#ref-for-environment-settings-object⑨">6. Integration with HTML</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-concept-url-fragment">
+   <a href="https://html.spec.whatwg.org/multipage/infrastructure.html#concept-url-fragment">https://html.spec.whatwg.org/multipage/infrastructure.html#concept-url-fragment</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-concept-url-fragment">8.4. 
+    Strip url for use as a referrer </a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-concept-settings-object-global">
+   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global">https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-concept-settings-object-global">8.3. 
+    Determine request’s Referrer </a> <a href="#ref-for-concept-settings-object-global①">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-https-state">
+   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#https-state">https://html.spec.whatwg.org/multipage/webappapis.html#https-state</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-https-state">3.2. "no-referrer-when-downgrade"</a> <a href="#ref-for-https-state①">(2)</a> <a href="#ref-for-https-state②">(3)</a>
+    <li><a href="#ref-for-https-state③">3.5. "strict-origin"</a> <a href="#ref-for-https-state④">(2)</a> <a href="#ref-for-https-state⑤">(3)</a>
+    <li><a href="#ref-for-https-state⑥">3.7. "strict-origin-when-cross-origin"</a> <a href="#ref-for-https-state⑦">(2)</a> <a href="#ref-for-https-state⑧">(3)</a>
+    <li><a href="#ref-for-https-state⑨">8.3. 
+    Determine request’s Referrer </a> <a href="#ref-for-https-state①⓪">(2)</a> <a href="#ref-for-https-state①①">(3)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-the-iframe-element">
+   <a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-the-iframe-element">4. Referrer Policy Delivery</a>
+    <li><a href="#ref-for-the-iframe-element①">4.4. Nested browsing contexts</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-the-img-element">
+   <a href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element">https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-the-img-element">4. Referrer Policy Delivery</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-the-link-element">
+   <a href="https://html.spec.whatwg.org/multipage/semantics.html#the-link-element">https://html.spec.whatwg.org/multipage/semantics.html#the-link-element</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-the-link-element">4. Referrer Policy Delivery</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-meta">
+   <a href="https://html.spec.whatwg.org/multipage/semantics.html#meta">https://html.spec.whatwg.org/multipage/semantics.html#meta</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-meta">4. Referrer Policy Delivery</a>
+    <li><a href="#ref-for-meta①">4.2. Delivery via meta</a> <a href="#ref-for-meta②">(2)</a>
+    <li><a href="#ref-for-meta③">6. Integration with HTML</a>
+    <li><a href="#ref-for-meta④">11.1. Unknown Policy Values</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-attr-meta-name">
+   <a href="https://html.spec.whatwg.org/multipage/semantics.html#attr-meta-name">https://html.spec.whatwg.org/multipage/semantics.html#attr-meta-name</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-attr-meta-name">4. Referrer Policy Delivery</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-navigate">
+   <a href="https://html.spec.whatwg.org/multipage/browsers.html#navigate">https://html.spec.whatwg.org/multipage/browsers.html#navigate</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-navigate">6. Integration with HTML</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-link-type-noreferrer">
+   <a href="https://html.spec.whatwg.org/multipage/semantics.html#link-type-noreferrer">https://html.spec.whatwg.org/multipage/semantics.html#link-type-noreferrer</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-link-type-noreferrer">1. Introduction</a>
+    <li><a href="#ref-for-link-type-noreferrer①">3. Referrer Policies</a>
+    <li><a href="#ref-for-link-type-noreferrer②">4. Referrer Policy Delivery</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-concept-origin-opaque">
+   <a href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin-opaque">https://html.spec.whatwg.org/multipage/browsers.html#concept-origin-opaque</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-concept-origin-opaque">8.3. 
+    Determine request’s Referrer </a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-concept-settings-object-origin">
+   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-concept-settings-object-origin">3.4. "origin"</a>
+    <li><a href="#ref-for-concept-settings-object-origin①">3.5. "strict-origin"</a>
+    <li><a href="#ref-for-concept-settings-object-origin②">3.6. "origin-when-cross-origin"</a>
+    <li><a href="#ref-for-concept-settings-object-origin③">3.7. "strict-origin-when-cross-origin"</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-presentational-hints">
+   <a href="https://html.spec.whatwg.org/multipage/rendering.html#presentational-hints">https://html.spec.whatwg.org/multipage/rendering.html#presentational-hints</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-presentational-hints">7. Integration with CSS</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-meta-referrer">
+   <a href="https://html.spec.whatwg.org/multipage/semantics.html#meta-referrer">https://html.spec.whatwg.org/multipage/semantics.html#meta-referrer</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-meta-referrer">4. Referrer Policy Delivery</a>
+    <li><a href="#ref-for-meta-referrer①">4.2. Delivery via meta</a>
+    <li><a href="#ref-for-meta-referrer②">6. Integration with HTML</a>
+    <li><a href="#ref-for-meta-referrer③">11.1. Unknown Policy Values</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-concept-document-referrer-policy">
+   <a href="https://html.spec.whatwg.org/multipage/dom.html#concept-document-referrer-policy">https://html.spec.whatwg.org/multipage/dom.html#concept-document-referrer-policy</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-concept-document-referrer-policy">3.9. The empty string</a>
+    <li><a href="#ref-for-concept-document-referrer-policy①">7. Integration with CSS</a> <a href="#ref-for-concept-document-referrer-policy②">(2)</a> <a href="#ref-for-concept-document-referrer-policy③">(3)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-referrer-policy-attribute">
+   <a href="https://html.spec.whatwg.org/multipage/infrastructure.html#referrer-policy-attribute">https://html.spec.whatwg.org/multipage/infrastructure.html#referrer-policy-attribute</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-referrer-policy-attribute">4.3. Delivery
+    via a referrerpolicy content attribute</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-attr-a-referrerpolicy">
+   <a href="https://html.spec.whatwg.org/multipage/semantics.html#attr-a-referrerpolicy">https://html.spec.whatwg.org/multipage/semantics.html#attr-a-referrerpolicy</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-attr-a-referrerpolicy">3.9. The empty string</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-run-a-worker">
+   <a href="https://html.spec.whatwg.org/multipage/workers.html#run-a-worker">https://html.spec.whatwg.org/multipage/workers.html#run-a-worker</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-run-a-worker">6. Integration with HTML</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-same-origin">
+   <a href="https://html.spec.whatwg.org/multipage/origin.html#same-origin">https://html.spec.whatwg.org/multipage/origin.html#same-origin</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-same-origin">2. Key Concepts and Terminology</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-attr-iframe-srcdoc">
+   <a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-iframe-srcdoc">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-iframe-srcdoc</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-attr-iframe-srcdoc">4.4. Nested browsing contexts</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-the-style-attribute">
+   <a href="https://html.spec.whatwg.org/multipage/dom.html#the-style-attribute">https://html.spec.whatwg.org/multipage/dom.html#the-style-attribute</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-the-style-attribute">7. Integration with CSS</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-appendix-B.1">
+   <a href="https://tools.ietf.org/html/rfc5234#appendix-B.1">https://tools.ietf.org/html/rfc5234#appendix-B.1</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-appendix-B.1">4.1. Delivery via Referrer-Policy header</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-section-5.5.2">
+   <a href="https://tools.ietf.org/html/rfc7231#section-5.5.2">https://tools.ietf.org/html/rfc7231#section-5.5.2</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-section-5.5.2">1. Introduction</a> <a href="#ref-for-section-5.5.2①">(2)</a>
+    <li><a href="#ref-for-section-5.5.2②">2. Key Concepts and Terminology</a>
+    <li><a href="#ref-for-section-5.5.2③">3.1. "no-referrer"</a>
+    <li><a href="#ref-for-section-5.5.2④">3.2. "no-referrer-when-downgrade"</a> <a href="#ref-for-section-5.5.2⑤">(2)</a> <a href="#ref-for-section-5.5.2⑥">(3)</a>
+    <li><a href="#ref-for-section-5.5.2⑦">3.3. "same-origin"</a> <a href="#ref-for-section-5.5.2⑧">(2)</a> <a href="#ref-for-section-5.5.2⑨">(3)</a>
+    <li><a href="#ref-for-section-5.5.2①⓪">3.4. "origin"</a>
+    <li><a href="#ref-for-section-5.5.2①①">3.5. "strict-origin"</a> <a href="#ref-for-section-5.5.2①②">(2)</a> <a href="#ref-for-section-5.5.2①③">(3)</a> <a href="#ref-for-section-5.5.2①④">(4)</a>
+    <li><a href="#ref-for-section-5.5.2①⑤">3.6. "origin-when-cross-origin"</a> <a href="#ref-for-section-5.5.2①⑥">(2)</a>
+    <li><a href="#ref-for-section-5.5.2①⑦">3.7. "strict-origin-when-cross-origin"</a> <a href="#ref-for-section-5.5.2①⑧">(2)</a> <a href="#ref-for-section-5.5.2①⑨">(3)</a> <a href="#ref-for-section-5.5.2②⓪">(4)</a>
+    <li><a href="#ref-for-section-5.5.2②①">3.8. "unsafe-url"</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-potentially-trustworthy-url">
+   <a href="https://w3c.github.io/webappsec-secure-contexts/#potentially-trustworthy-url">https://w3c.github.io/webappsec-secure-contexts/#potentially-trustworthy-url</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-potentially-trustworthy-url">3.2. "no-referrer-when-downgrade"</a> <a href="#ref-for-potentially-trustworthy-url①">(2)</a> <a href="#ref-for-potentially-trustworthy-url②">(3)</a>
+    <li><a href="#ref-for-potentially-trustworthy-url③">3.4. "origin"</a>
+    <li><a href="#ref-for-potentially-trustworthy-url④">3.5. "strict-origin"</a> <a href="#ref-for-potentially-trustworthy-url⑤">(2)</a>
+    <li><a href="#ref-for-potentially-trustworthy-url⑥">3.6. "origin-when-cross-origin"</a>
+    <li><a href="#ref-for-potentially-trustworthy-url⑦">3.7. "strict-origin-when-cross-origin"</a> <a href="#ref-for-potentially-trustworthy-url⑧">(2)</a>
+    <li><a href="#ref-for-potentially-trustworthy-url⑨">8.3. 
+    Determine request’s Referrer </a> <a href="#ref-for-potentially-trustworthy-url①⓪">(2)</a> <a href="#ref-for-potentially-trustworthy-url①①">(3)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-concept-url-origin">
+   <a href="https://url.spec.whatwg.org/#concept-url-origin">https://url.spec.whatwg.org/#concept-url-origin</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-concept-url-origin">2. Key Concepts and Terminology</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-concept-url-password">
+   <a href="https://url.spec.whatwg.org/#concept-url-password">https://url.spec.whatwg.org/#concept-url-password</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-concept-url-password">8.4. 
+    Strip url for use as a referrer </a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-concept-url-path">
+   <a href="https://url.spec.whatwg.org/#concept-url-path">https://url.spec.whatwg.org/#concept-url-path</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-concept-url-path">8.4. 
+    Strip url for use as a referrer </a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-concept-url-query">
+   <a href="https://url.spec.whatwg.org/#concept-url-query">https://url.spec.whatwg.org/#concept-url-query</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-concept-url-query">8.4. 
+    Strip url for use as a referrer </a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-concept-url-scheme">
+   <a href="https://url.spec.whatwg.org/#concept-url-scheme">https://url.spec.whatwg.org/#concept-url-scheme</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-concept-url-scheme">8.4. 
+    Strip url for use as a referrer </a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-concept-url">
+   <a href="https://url.spec.whatwg.org/#concept-url">https://url.spec.whatwg.org/#concept-url</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-concept-url">8.3. 
+    Determine request’s Referrer </a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-concept-url-username">
+   <a href="https://url.spec.whatwg.org/#concept-url-username">https://url.spec.whatwg.org/#concept-url-username</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-concept-url-username">8.4. 
+    Strip url for use as a referrer </a>
+   </ul>
+  </aside>
   <h3 class="no-num no-ref heading settled" id="index-defined-elsewhere"><span class="content">Terms defined by reference</span><a class="self-link" href="#index-defined-elsewhere"></a></h3>
   <ul class="index">
    <li>
     <a data-link-type="biblio">[cssom-1]</a> defines the following terms:
     <ul>
-     <li><a href="https://drafts.csswg.org/cssom-1/#css-declaration-block">css declaration block</a>
-     <li><a href="https://drafts.csswg.org/cssom-1/#css-style-sheet">css style sheet</a>
-     <li><a href="https://drafts.csswg.org/cssom-1/#concept-css-style-sheet-location">location</a>
-     <li><a href="https://drafts.csswg.org/cssom-1/#cssstyledeclaration-owner-node">owner node <small>(for CSSStyleDeclaration)</small></a>
-     <li><a href="https://drafts.csswg.org/cssom-1/#concept-css-style-sheet-owner-node">owner node <small>(for CSSStyleSheet)</small></a>
+     <li><span class="dfn-paneled" id="term-for-css-declaration-block" style="color:initial">css declaration block</span>
+     <li><span class="dfn-paneled" id="term-for-css-style-sheet" style="color:initial">css style sheet</span>
+     <li><span class="dfn-paneled" id="term-for-concept-css-style-sheet-location" style="color:initial">location</span>
+     <li><span class="dfn-paneled" id="term-for-concept-css-style-sheet-owner-node" style="color:initial">owner node <small>(for CSSStyleSheet)</small></span>
     </ul>
    <li>
     <a data-link-type="biblio">[DOM]</a> defines the following terms:
     <ul>
-     <li><a href="https://dom.spec.whatwg.org/#concept-node-document">node document</a>
-     <li><a href="https://dom.spec.whatwg.org/#concept-document-origin">origin</a>
-     <li><a href="https://dom.spec.whatwg.org/#concept-document-url">url</a>
+     <li><span class="dfn-paneled" id="term-for-concept-node-document" style="color:initial">node document</span>
+     <li><span class="dfn-paneled" id="term-for-concept-document-origin" style="color:initial">origin</span>
+     <li><span class="dfn-paneled" id="term-for-concept-document-url" style="color:initial">url</span>
     </ul>
    <li>
     <a data-link-type="biblio">[FETCH]</a> defines the following terms:
     <ul>
-     <li><a href="https://fetch.spec.whatwg.org/#request">Request</a>
-     <li><a href="https://fetch.spec.whatwg.org/#concept-request-client">client</a>
-     <li><a href="https://fetch.spec.whatwg.org/#concept-request-current-url">current url</a>
-     <li><a href="https://fetch.spec.whatwg.org/#extract-header-list-values">extracting header list values</a>
-     <li><a href="https://fetch.spec.whatwg.org/#concept-fetch">fetch</a>
-     <li><a href="https://fetch.spec.whatwg.org/#concept-response-header-list">header list</a>
-     <li><a href="https://fetch.spec.whatwg.org/#local-scheme">local scheme</a>
-     <li><a href="https://fetch.spec.whatwg.org/#concept-request-origin">origin</a>
-     <li><a href="https://fetch.spec.whatwg.org/#concept-request-referrer">referrer</a>
-     <li><a href="https://fetch.spec.whatwg.org/#concept-request-referrer-policy">referrer policy</a>
-     <li><a href="https://fetch.spec.whatwg.org/#concept-request">request</a>
-     <li><a href="https://fetch.spec.whatwg.org/#concept-response">response</a>
+     <li><span class="dfn-paneled" id="term-for-request" style="color:initial">Request</span>
+     <li><span class="dfn-paneled" id="term-for-concept-request-client" style="color:initial">client</span>
+     <li><span class="dfn-paneled" id="term-for-concept-request-current-url" style="color:initial">current url</span>
+     <li><span class="dfn-paneled" id="term-for-extract-header-list-values" style="color:initial">extracting header list values</span>
+     <li><span class="dfn-paneled" id="term-for-concept-fetch" style="color:initial">fetch</span>
+     <li><span class="dfn-paneled" id="term-for-concept-response-header-list" style="color:initial">header list</span>
+     <li><span class="dfn-paneled" id="term-for-local-scheme" style="color:initial">local scheme</span>
+     <li><span class="dfn-paneled" id="term-for-concept-request-origin" style="color:initial">origin</span>
+     <li><span class="dfn-paneled" id="term-for-concept-request-referrer" style="color:initial">referrer</span>
+     <li><span class="dfn-paneled" id="term-for-concept-request-referrer-policy" style="color:initial">referrer policy</span>
+     <li><span class="dfn-paneled" id="term-for-concept-request" style="color:initial">request</span>
+     <li><span class="dfn-paneled" id="term-for-concept-response" style="color:initial">response</span>
     </ul>
    <li>
     <a data-link-type="biblio">[HTML]</a> defines the following terms:
     <ul>
-     <li><a href="https://html.spec.whatwg.org/multipage/dom.html#document">Document</a>
-     <li><a href="https://html.spec.whatwg.org/multipage/window-object.html#window">Window</a>
-     <li><a href="https://html.spec.whatwg.org/multipage/workers.html#workerglobalscope">WorkerGlobalScope</a>
-     <li><a href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-a-element">a</a>
-     <li><a href="https://html.spec.whatwg.org/multipage/embedded-content.html#an-iframe-srcdoc-document">an iframe srcdoc document</a>
-     <li><a href="https://html.spec.whatwg.org/multipage/image-maps.html#the-area-element">area</a>
-     <li><a href="https://html.spec.whatwg.org/multipage/origin.html#ascii-serialisation-of-an-origin">ascii serialization of an origin</a>
-     <li><a href="https://html.spec.whatwg.org/multipage/browsers.html#concept-document-window">associated document</a>
-     <li><a href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context">browsing context</a>
-     <li><a href="https://html.spec.whatwg.org/multipage/browsers.html#concept-document-bc">browsing context <small>(for Document)</small></a>
-     <li><a href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context-container">browsing context container</a>
-     <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-creation-url">creation url</a>
-     <li><a href="https://html.spec.whatwg.org/multipage/dom.html#concept-document-referrer-policy">document referrer policy</a>
-     <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">environment settings object</a>
-     <li><a href="https://html.spec.whatwg.org/multipage/infrastructure.html#concept-url-fragment">fragment</a>
-     <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global">global object</a>
-     <li><a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element">iframe</a>
-     <li><a href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element">img</a>
-     <li><a href="https://html.spec.whatwg.org/multipage/semantics.html#the-link-element">link</a>
-     <li><a href="https://html.spec.whatwg.org/multipage/semantics.html#meta">meta</a>
-     <li><a href="https://html.spec.whatwg.org/multipage/semantics.html#attr-meta-name">name</a>
-     <li><a href="https://html.spec.whatwg.org/multipage/browsers.html#navigate">navigation</a>
-     <li><a href="https://html.spec.whatwg.org/multipage/semantics.html#link-type-noreferrer">noreferrer</a>
-     <li><a href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin-opaque">opaque origin</a>
-     <li><a href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin">origin</a>
-     <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">origin <small>(for environment settings object)</small></a>
-     <li><a href="https://html.spec.whatwg.org/multipage/rendering.html#presentational-hints">presentational hints</a>
-     <li><a href="https://html.spec.whatwg.org/multipage/semantics.html#meta-referrer">referrer</a>
-     <li><a href="https://html.spec.whatwg.org/multipage/dom.html#concept-document-referrer-policy">referrer policy</a>
-     <li><a href="https://html.spec.whatwg.org/multipage/infrastructure.html#referrer-policy-attribute">referrer policy attribute</a>
-     <li><a href="https://html.spec.whatwg.org/multipage/semantics.html#attr-a-referrerpolicy">referrerpolicy</a>
-     <li><a href="https://html.spec.whatwg.org/multipage/workers.html#run-a-worker">running a worker</a>
-     <li><a href="https://html.spec.whatwg.org/multipage/origin.html#same-origin">same origin</a>
-     <li><a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-iframe-srcdoc">srcdoc</a>
-     <li><a href="https://html.spec.whatwg.org/multipage/dom.html#the-style-attribute">style attribute</a>
+     <li><span class="dfn-paneled" id="term-for-document" style="color:initial">Document</span>
+     <li><span class="dfn-paneled" id="term-for-window" style="color:initial">Window</span>
+     <li><span class="dfn-paneled" id="term-for-workerglobalscope" style="color:initial">WorkerGlobalScope</span>
+     <li><span class="dfn-paneled" id="term-for-the-a-element" style="color:initial">a</span>
+     <li><span class="dfn-paneled" id="term-for-an-iframe-srcdoc-document" style="color:initial">an iframe srcdoc document</span>
+     <li><span class="dfn-paneled" id="term-for-the-area-element" style="color:initial">area</span>
+     <li><span class="dfn-paneled" id="term-for-ascii-serialisation-of-an-origin" style="color:initial">ascii serialization of an origin</span>
+     <li><span class="dfn-paneled" id="term-for-concept-document-window" style="color:initial">associated document</span>
+     <li><span class="dfn-paneled" id="term-for-concept-document-bc" style="color:initial">browsing context <small>(for Document)</small></span>
+     <li><span class="dfn-paneled" id="term-for-browsing-context-container" style="color:initial">browsing context container</span>
+     <li><span class="dfn-paneled" id="term-for-concept-environment-creation-url" style="color:initial">creation url</span>
+     <li><span class="dfn-paneled" id="term-for-concept-document-referrer-policy" style="color:initial">document referrer policy</span>
+     <li><span class="dfn-paneled" id="term-for-environment-settings-object" style="color:initial">environment settings object</span>
+     <li><span class="dfn-paneled" id="term-for-concept-url-fragment" style="color:initial">fragment</span>
+     <li><span class="dfn-paneled" id="term-for-concept-settings-object-global" style="color:initial">global object</span>
+     <li><span class="dfn-paneled" id="term-for-https-state" style="color:initial">https state</span>
+     <li><span class="dfn-paneled" id="term-for-the-iframe-element" style="color:initial">iframe</span>
+     <li><span class="dfn-paneled" id="term-for-the-img-element" style="color:initial">img</span>
+     <li><span class="dfn-paneled" id="term-for-the-link-element" style="color:initial">link</span>
+     <li><span class="dfn-paneled" id="term-for-meta" style="color:initial">meta</span>
+     <li><span class="dfn-paneled" id="term-for-attr-meta-name" style="color:initial">name</span>
+     <li><span class="dfn-paneled" id="term-for-navigate" style="color:initial">navigation</span>
+     <li><span class="dfn-paneled" id="term-for-link-type-noreferrer" style="color:initial">noreferrer</span>
+     <li><span class="dfn-paneled" id="term-for-concept-origin-opaque" style="color:initial">opaque origin</span>
+     <li><span class="dfn-paneled" id="term-for-concept-settings-object-origin" style="color:initial">origin <small>(for environment settings object)</small></span>
+     <li><span class="dfn-paneled" id="term-for-presentational-hints" style="color:initial">presentational hints</span>
+     <li><span class="dfn-paneled" id="term-for-meta-referrer" style="color:initial">referrer</span>
+     <li><span class="dfn-paneled" id="term-for-concept-document-referrer-policy①" style="color:initial">referrer policy</span>
+     <li><span class="dfn-paneled" id="term-for-referrer-policy-attribute" style="color:initial">referrer policy attribute</span>
+     <li><span class="dfn-paneled" id="term-for-attr-a-referrerpolicy" style="color:initial">referrerpolicy</span>
+     <li><span class="dfn-paneled" id="term-for-run-a-worker" style="color:initial">running a worker</span>
+     <li><span class="dfn-paneled" id="term-for-same-origin" style="color:initial">same origin</span>
+     <li><span class="dfn-paneled" id="term-for-attr-iframe-srcdoc" style="color:initial">srcdoc</span>
+     <li><span class="dfn-paneled" id="term-for-the-style-attribute" style="color:initial">style attribute</span>
     </ul>
    <li>
     <a data-link-type="biblio">[RFC5234]</a> defines the following terms:
     <ul>
-     <li><a href="https://tools.ietf.org/html/rfc5234#appendix-B.1">alpha</a>
+     <li><span class="dfn-paneled" id="term-for-appendix-B.1" style="color:initial">alpha</span>
     </ul>
    <li>
     <a data-link-type="biblio">[RFC7231]</a> defines the following terms:
     <ul>
-     <li><a href="https://tools.ietf.org/html/rfc7231#section-5.5.2">referer</a>
+     <li><span class="dfn-paneled" id="term-for-section-5.5.2" style="color:initial">referer</span>
     </ul>
    <li>
     <a data-link-type="biblio">[secure-contexts]</a> defines the following terms:
     <ul>
-     <li><a href="https://w3c.github.io/webappsec-secure-contexts/#potentially-trustworthy-url">potentially trustworthy url</a>
+     <li><span class="dfn-paneled" id="term-for-potentially-trustworthy-url" style="color:initial">potentially trustworthy url</span>
     </ul>
    <li>
     <a data-link-type="biblio">[URL]</a> defines the following terms:
     <ul>
-     <li><a href="https://url.spec.whatwg.org/#concept-url-origin">origin</a>
-     <li><a href="https://url.spec.whatwg.org/#concept-url-password">password</a>
-     <li><a href="https://url.spec.whatwg.org/#concept-url-path">path</a>
-     <li><a href="https://url.spec.whatwg.org/#concept-url-query">query</a>
-     <li><a href="https://url.spec.whatwg.org/#concept-url-scheme">scheme</a>
-     <li><a href="https://url.spec.whatwg.org/#concept-url">url</a>
-     <li><a href="https://url.spec.whatwg.org/#concept-url-username">username</a>
-    </ul>
-   <li>
-    <a data-link-type="biblio">[wsc-ui]</a> defines the following terms:
-    <ul>
-     <li><a href="http://www.w3.org/TR/2010/REC-wsc-ui-20100812/#typesoftls">tls-protected</a>
+     <li><span class="dfn-paneled" id="term-for-concept-url-origin" style="color:initial">origin</span>
+     <li><span class="dfn-paneled" id="term-for-concept-url-password" style="color:initial">password</span>
+     <li><span class="dfn-paneled" id="term-for-concept-url-path" style="color:initial">path</span>
+     <li><span class="dfn-paneled" id="term-for-concept-url-query" style="color:initial">query</span>
+     <li><span class="dfn-paneled" id="term-for-concept-url-scheme" style="color:initial">scheme</span>
+     <li><span class="dfn-paneled" id="term-for-concept-url" style="color:initial">url</span>
+     <li><span class="dfn-paneled" id="term-for-concept-url-username" style="color:initial">username</span>
     </ul>
   </ul>
   <h2 class="no-num no-ref heading settled" id="references"><span class="content">References</span><a class="self-link" href="#references"></a></h2>
@@ -2314,8 +2815,6 @@ Referrer-Policy: unsafe-url
    <dd>Mike West. <a href="https://www.w3.org/TR/secure-contexts/">Secure Contexts</a>. 15 September 2016. CR. URL: <a href="https://www.w3.org/TR/secure-contexts/">https://www.w3.org/TR/secure-contexts/</a>
    <dt id="biblio-url">[URL]
    <dd>Anne van Kesteren. <a href="https://url.spec.whatwg.org/">URL Standard</a>. Living Standard. URL: <a href="https://url.spec.whatwg.org/">https://url.spec.whatwg.org/</a>
-   <dt id="biblio-wsc-ui">[WSC-UI]
-   <dd>Thomas Roessler; Anil Saldhana. <a href="https://www.w3.org/TR/wsc-ui/">Web Security Context: User Interface Guidelines</a>. 12 August 2010. REC. URL: <a href="https://www.w3.org/TR/wsc-ui/">https://www.w3.org/TR/wsc-ui/</a>
   </dl>
   <h3 class="no-num no-ref heading settled" id="informative"><span class="content">Informative References</span><a class="self-link" href="#informative"></a></h3>
   <dl>
@@ -2323,16 +2822,16 @@ Referrer-Policy: unsafe-url
    <dd>Jenni Tennison. <a href="http://www.w3.org/TR/capability-urls/">Capability URLs</a>. WD. URL: <a href="http://www.w3.org/TR/capability-urls/">http://www.w3.org/TR/capability-urls/</a>
   </dl>
   <h2 class="no-num no-ref heading settled" id="idl-index"><span class="content">IDL Index</span><a class="self-link" href="#idl-index"></a></h2>
-<pre class="idl highlight def"><span class="kt">enum</span> <a class="nv" href="#enumdef-referrerpolicy"><code>ReferrerPolicy</code></a> {
-  <a class="s" href="#dom-referrerpolicy"><code>""</code></a>,
-  <a class="s" href="#dom-referrerpolicy-no-referrer"><code>"no-referrer"</code></a>,
-  <a class="s" href="#dom-referrerpolicy-no-referrer-when-downgrade"><code>"no-referrer-when-downgrade"</code></a>,
-  <a class="s" href="#dom-referrerpolicy-same-origin"><code>"same-origin"</code></a>,
-  <a class="s" href="#dom-referrerpolicy-origin"><code>"origin"</code></a>,
-  <a class="s" href="#dom-referrerpolicy-strict-origin"><code>"strict-origin"</code></a>,
-  <a class="s" href="#dom-referrerpolicy-origin-when-cross-origin"><code>"origin-when-cross-origin"</code></a>,
-  <a class="s" href="#dom-referrerpolicy-strict-origin-when-cross-origin"><code>"strict-origin-when-cross-origin"</code></a>,
-  <a class="s" href="#dom-referrerpolicy-unsafe-url"><code>"unsafe-url"</code></a>
+<pre class="idl highlight def"><c- b>enum</c-> <a href="#enumdef-referrerpolicy"><code><c- g>ReferrerPolicy</c-></code></a> {
+  <a href="#dom-referrerpolicy"><code><c- s>""</c-></code></a>,
+  <a href="#dom-referrerpolicy-no-referrer"><code><c- s>"no-referrer"</c-></code></a>,
+  <a href="#dom-referrerpolicy-no-referrer-when-downgrade"><code><c- s>"no-referrer-when-downgrade"</c-></code></a>,
+  <a href="#dom-referrerpolicy-same-origin"><code><c- s>"same-origin"</c-></code></a>,
+  <a href="#dom-referrerpolicy-origin"><code><c- s>"origin"</c-></code></a>,
+  <a href="#dom-referrerpolicy-strict-origin"><code><c- s>"strict-origin"</c-></code></a>,
+  <a href="#dom-referrerpolicy-origin-when-cross-origin"><code><c- s>"origin-when-cross-origin"</c-></code></a>,
+  <a href="#dom-referrerpolicy-strict-origin-when-cross-origin"><code><c- s>"strict-origin-when-cross-origin"</c-></code></a>,
+  <a href="#dom-referrerpolicy-unsafe-url"><code><c- s>"unsafe-url"</c-></code></a>
 };
 
 </pre>
@@ -2340,7 +2839,7 @@ Referrer-Policy: unsafe-url
   <div style="counter-reset:issue">
    <div class="issue"> This requires that CSS style sheets process `Referrer-Policy`
        headers, and store a <span>referrer policy</span> in the same way that <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#concept-document-referrer-policy">Documents
-       do</a>.<a href="#issue-8299c74c"> ↵ </a></div>
+       do</a>.<a href="#issue-a01fbbf2"> ↵ </a></div>
   </div>
   <aside class="dfn-panel" data-for="same-origin-request">
    <b><a href="#same-origin-request">#same-origin-request</a></b><b>Referenced in:</b>
@@ -2513,58 +3012,57 @@ Referrer-Policy: unsafe-url
   </aside>
 <script>/* script-dfn-panel */
 
-        document.body.addEventListener("click", function(e) {
-            var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-            // Find the dfn element or panel, if any, that was clicked on.
-            var el = e.target;
-            var target;
-            var hitALink = false;
-            while(el.parentElement) {
-                if(el.tagName == "A") {
-                    // Clicking on a link in a <dfn> shouldn't summon the panel
-                    hitALink = true;
-                }
-                if(el.classList.contains("dfn-paneled")) {
-                    target = "dfn";
-                    break;
-                }
-                if(el.classList.contains("dfn-panel")) {
-                    target = "dfn-panel";
-                    break;
-                }
-                el = el.parentElement;
-            }
-            if(target != "dfn-panel") {
-                // Turn off any currently "on" or "activated" panels.
-                queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-                    el.classList.remove("on");
-                    el.classList.remove("activated");
-                });
-            }
-            if(target == "dfn" && !hitALink) {
-                // open the panel
-                var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-                if(dfnPanel) {
-                    console.log(dfnPanel);
-                    dfnPanel.classList.add("on");
-                    var rect = el.getBoundingClientRect();
-                    dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-                    dfnPanel.style.top = window.scrollY + rect.top + "px";
-                    var panelRect = dfnPanel.getBoundingClientRect();
-                    var panelWidth = panelRect.right - panelRect.left;
-                    if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                        // Reposition, because the panel is overflowing
-                        dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-                    }
-                } else {
-                    console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-                }
-            } else if(target == "dfn-panel") {
-                // Switch it to "activated" state, which pins it.
-                el.classList.add("activated");
-                el.style.left = null;
-                el.style.top = null;
-            }
-
+document.body.addEventListener("click", function(e) {
+    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
+    // Find the dfn element or panel, if any, that was clicked on.
+    var el = e.target;
+    var target;
+    var hitALink = false;
+    while(el.parentElement) {
+        if(el.tagName == "A") {
+            // Clicking on a link in a <dfn> shouldn't summon the panel
+            hitALink = true;
+        }
+        if(el.classList.contains("dfn-paneled")) {
+            target = "dfn";
+            break;
+        }
+        if(el.classList.contains("dfn-panel")) {
+            target = "dfn-panel";
+            break;
+        }
+        el = el.parentElement;
+    }
+    if(target != "dfn-panel") {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
+            el.classList.remove("on");
+            el.classList.remove("activated");
         });
-        </script>
+    }
+    if(target == "dfn" && !hitALink) {
+        // open the panel
+        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
+        if(dfnPanel) {
+            dfnPanel.classList.add("on");
+            var rect = el.getBoundingClientRect();
+            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
+            dfnPanel.style.top = window.scrollY + rect.top + "px";
+            var panelRect = dfnPanel.getBoundingClientRect();
+            var panelWidth = panelRect.right - panelRect.left;
+            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
+                // Reposition, because the panel is overflowing
+                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
+            }
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
+        }
+    } else if(target == "dfn-panel") {
+        // Switch it to "activated" state, which pins it.
+        el.classList.add("activated");
+        el.style.left = null;
+        el.style.top = null;
+    }
+
+});
+</script>

--- a/index.src.html
+++ b/index.src.html
@@ -507,8 +507,8 @@ spec: html; type: element; text: a;
       <{area}>, <{img}>, <{iframe}>, or <{link}> element.
     </li>
     <li>
-      Via the <code><a>noreferrer</a></code> link relation on an <{a}>,
-      <{area}>, or <{link}> element.
+      Via the <code><a>noreferrer</a></code> link relation on an <{a}>, or
+      <{area}> element.
     </li>
     <li>
       Implicitly, via inheritance.


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jeisinger/webappsec-referrer-policy/pull/117.html" title="Last updated on Oct 25, 2018, 8:59 AM GMT (58679ac)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-referrer-policy/117/cd3894a...jeisinger:58679ac.html" title="Last updated on Oct 25, 2018, 8:59 AM GMT (58679ac)">Diff</a>