### PR TITLE
Limit `referer` header's value to 4k.

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -812,6 +812,10 @@ spec: html; type: element; text: a;
       <var>referrerSource</var> for use as a referrer.</a>
     </li>
     <li>
+      If <var>referrerURL</var>'s length is greater than 4096, set <var>referrerURL</var>
+      to <var>referrerOrigin</var>.
+    </li>
+    <li>
       Let <var>referrerOrigin</var> be the result of
       <a href="#strip-url">stripping <var>referrerSource</var> for use as a
       referrer</a>, with the <code><a>origin-only flag</a></code> set to

--- a/index.src.html
+++ b/index.src.html
@@ -812,16 +812,16 @@ spec: html; type: element; text: a;
       <var>referrerSource</var> for use as a referrer.</a>
     </li>
     <li>
-      If the result of <a lt="url serializer">serializing</a> <var>referrerURL</var> is a string
-      whose length is greater than 4096, set <var>referrerURL</var> to <var>referrerOrigin</var>.
-    </li>
-    <li>
       Let <var>referrerOrigin</var> be the result of
       <a href="#strip-url">stripping <var>referrerSource</var> for use as a
       referrer</a>, with the <code><a>origin-only flag</a></code> set to
       <code>true</code>.
     </li>
-
+    <li>
+      If the result of <a lt="url serializer">serializing</a> <var>referrerURL</var> is a string
+      whose <a for="string">length</a> is greater than 4096, set <var>referrerURL</var> to
+      <var>referrerOrigin</var>.
+    </li>
     <li>
       Execute the statements corresponding to the value of <var>policy</var>:
 

--- a/index.src.html
+++ b/index.src.html
@@ -812,8 +812,8 @@ spec: html; type: element; text: a;
       <var>referrerSource</var> for use as a referrer.</a>
     </li>
     <li>
-      If <var>referrerURL</var>'s length is greater than 4096, set <var>referrerURL</var>
-      to <var>referrerOrigin</var>.
+      If the result of <a lt="url serializer">serializing</a> <var>referrerURL</var> is a string
+      whose length is greater than 4096, set <var>referrerURL</var> to <var>referrerOrigin</var>.
     </li>
     <li>
       Let <var>referrerOrigin</var> be the result of


### PR DESCRIPTION
If the `referer` header's value is a URL with a length of more than 4k, strip it down to an origin.

Fixes https://github.com/whatwg/fetch/issues/903.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-referrer-policy/pull/122.html" title="Last updated on Oct 21, 2019, 10:21 AM UTC (039ee88)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-referrer-policy/122/1a1f47b...039ee88.html" title="Last updated on Oct 21, 2019, 10:21 AM UTC (039ee88)">Diff</a>