### PR TITLE
Make 'unsafe-url' an alias for 'no-referrer-when-downgrade'

### DIFF
--- a/index.html
+++ b/index.html
@@ -1029,7 +1029,7 @@ Possible extra rowspan handling
 		}
 	/* } */
 
-	@supports (display:grid) {
+	@supports (display:grid) and (display:contents) {
 		/* Use #toc over .toc to override non-@supports rules. */
 		#toc {
 			display: grid;
@@ -1212,9 +1212,9 @@ Possible extra rowspan handling
 		}
 	}
 </style>
-  <meta content="Bikeshed version 018be3f805d3272ce699a232398d6e3902d1ea8d" name="generator">
+  <meta content="Bikeshed version 08c4b0e94d147852f66673459784d3429bb3bda1" name="generator">
   <link href="http://www.w3.org/TR/referrer-policy/" rel="canonical">
-  <meta content="cd3894ac6bdc097abed1b8584d8e96bb0fca00ec" name="document-revision">
+  <meta content="20aad3a785a5ba2ab67c0780c9cded9c45e37735" name="document-revision">
 <style>/* style-md-lists */
 
 /* This is a weird hack for me not yet following the commonmark spec
@@ -1461,7 +1461,7 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1>Referrer Policy</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2018-10-25">25 October 2018</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2019-10-15">15 October 2019</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1483,7 +1483,7 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
     </dl>
    </div>
    <div data-fill-with="warning"></div>
-   <p class="copyright" data-fill-with="copyright"><a href="https://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 2018 <a href="https://www.w3.org/"><abbr title="World Wide Web Consortium">W3C</abbr></a><sup>®</sup> (<a href="https://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>, <a href="https://www.ercim.eu/"><abbr title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>, <a href="https://www.keio.ac.jp/">Keio</a>, <a href="http://ev.buaa.edu.cn/">Beihang</a>). W3C <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>, <a href="https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and <a href="https://www.w3.org/Consortium/Legal/copyright-documents">document use</a> rules apply. </p>
+   <p class="copyright" data-fill-with="copyright"><a href="https://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 2019 <a href="https://www.w3.org/"><abbr title="World Wide Web Consortium">W3C</abbr></a><sup>®</sup> (<a href="https://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>, <a href="https://www.ercim.eu/"><abbr title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>, <a href="https://www.keio.ac.jp/">Keio</a>, <a href="https://ev.buaa.edu.cn/">Beihang</a>). W3C <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>, <a href="https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and <a href="https://www.w3.org/Consortium/Legal/copyright-documents">document use</a> rules apply. </p>
    <hr title="Separator for header">
   </div>
   <div class="p-summary" data-fill-with="abstract">
@@ -1509,7 +1509,7 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
 	W3C maintains a <a href="https://www.w3.org/2004/01/pp-impl/49309/status" rel="disclosure">public list of any patent disclosures</a> made in connection with the deliverables of the group;
 	that page also includes instructions for disclosing a patent.
 	An individual who has actual knowledge of a patent which the individual believes contains <a href="https://www.w3.org/Consortium/Patent-Policy/#def-essential">Essential Claim(s)</a> must disclose the information in accordance with <a href="https://www.w3.org/Consortium/Patent-Policy/#sec-Disclosure">section 6 of the W3C Patent Policy</a>. </p>
-   <p> This document is governed by the <a href="https://www.w3.org/2018/Process-20180201/" id="w3c_process_revision">1 February 2018 W3C Process Document</a>. </p>
+   <p> This document is governed by the <a href="https://www.w3.org/2019/Process-20190301/" id="w3c_process_revision">1 March 2019 W3C Process Document</a>. </p>
    <p></p>
   </div>
   <div data-fill-with="at-risk"></div>
@@ -1667,7 +1667,7 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
 };
 </pre>
     <p>Each possible <a data-link-type="dfn" href="#referrer-policy" id="ref-for-referrer-policy④">referrer policy</a> is explained below. A detailed
-  algorithm for evaluating their effect is given in the <a href="#integration-with-fetch">§5 Integration with Fetch</a> and <a href="#algorithms">§8 Algorithms</a> sections.</p>
+  algorithm for evaluating their effect is given in the <a href="#integration-with-fetch">§ 5 Integration with Fetch</a> and <a href="#algorithms">§ 8 Algorithms</a> sections.</p>
     <p class="note" role="note"><span>Note:</span> The referrer policy for an <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object" id="ref-for-environment-settings-object②">environment settings object</a> provides a
   default baseline policy for requests when that <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object" id="ref-for-environment-settings-object③">environment settings
   object</a> is used as a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client" id="ref-for-concept-request-client①">request client</a>. This policy may be tightened
@@ -1763,32 +1763,30 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
      <p>Navigations from that same page to <code><strong>http://</strong>not.example.com/</code> would send no <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc7231#section-5.5.2" id="ref-for-section-5.5.2②⓪"><code>Referer</code></a> header.</p>
     </div>
     <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-export data-level="3.8" data-lt="&quot;unsafe-url&quot;" id="referrer-policy-unsafe-url"><span class="secno">3.8. </span><span class="content">"<code>unsafe-url</code>"</span><span id="referrer-policy-state-unsafe-url"></span></h3>
-    <p>The <a data-link-type="dfn" href="#referrer-policy-unsafe-url" id="ref-for-referrer-policy-unsafe-url">"<code>unsafe-url</code>"</a> policy specifies that a full URL, <a href="#strip-url">stripped for use as a referrer</a>, is sent along with
-  both <a data-link-type="dfn" href="#cross-origin-request" id="ref-for-cross-origin-request⑤">cross-origin requests</a> and <a data-link-type="dfn" href="#same-origin-request" id="ref-for-same-origin-request⑤">same-origin requests</a> made from
-  a particular <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client" id="ref-for-concept-request-client①⑥">client</a>.</p>
-    <div class="example" id="example-56375f3a"><a class="self-link" href="#example-56375f3a"></a> If a document at <code>https://example.com/sekrit.html</code> sets a policy
-    of <a data-link-type="dfn" href="#referrer-policy-unsafe-url" id="ref-for-referrer-policy-unsafe-url①">"<code>unsafe-url</code>"</a>, then navigations to <code>http://not.example.com/</code> (and every other origin) would send a <code><a data-link-type="dfn" href="https://tools.ietf.org/html/rfc7231#section-5.5.2" id="ref-for-section-5.5.2②①">Referer</a></code> HTTP header with a value of <code>https://example.com/sekrit.html</code>. </div>
-    <p class="note" role="note"><span>Note:</span> The policy’s name doesn’t lie; it is unsafe. This policy will leak
-  origins and paths from secure resources to insecure origins.
-  Carefully consider the impact of setting such a policy for potentially
-  sensitive documents.</p>
+    <p>The <a data-link-type="dfn" href="#referrer-policy-unsafe-url" id="ref-for-referrer-policy-unsafe-url">"<code>unsafe-url</code>"</a> policy is an alias for the <a data-link-type="dfn" href="#referrer-policy-no-referrer-when-downgrade" id="ref-for-referrer-policy-no-referrer-when-downgrade②">"<code>no-referrer-when-downgrade</code>"</a> policy.</p>
+    <p class="note" role="note"><span>Note:</span> In previous versions of this specification, this policy was, in fact,
+  unsafe, as it intentionally leaked origins and paths from secure resources to
+  non-secure origins. The original intent was to allow pages to migrate to HTTPS
+  without losing referrer-based attribution vis a vis non-secure sites. Given
+  our collective progress at that migration, this safety valve is no longer
+  necessary.</p>
     <h3 class="heading settled" data-dfn-type="dfn" data-export data-level="3.9" data-lt="The empty string" id="referrer-policy-empty-string"><span class="secno">3.9. </span><span class="content">The empty string</span><a class="self-link" href="#referrer-policy-empty-string"></a></h3>
     <p>The empty string "" corresponds to no <a data-link-type="dfn" href="#referrer-policy" id="ref-for-referrer-policy⑤">referrer policy</a>, causing a
   fallback to a <a data-link-type="dfn" href="#referrer-policy" id="ref-for-referrer-policy⑥">referrer policy</a> defined elsewhere, or in the case where
-  no such higher-level policy is available, defaulting to <a data-link-type="dfn" href="#referrer-policy-no-referrer-when-downgrade" id="ref-for-referrer-policy-no-referrer-when-downgrade②">"<code>no-referrer-when-downgrade</code>"</a>. This defaulting happens in
-  the <a href="#determine-requests-referrer" id="ref-for-determine-requests-referrer">§8.3 Determine request’s Referrer</a> algorithm.</p>
+  no such higher-level policy is available, defaulting to <a data-link-type="dfn" href="#referrer-policy-no-referrer-when-downgrade" id="ref-for-referrer-policy-no-referrer-when-downgrade③">"<code>no-referrer-when-downgrade</code>"</a>. This defaulting happens in
+  the <a href="#determine-requests-referrer" id="ref-for-determine-requests-referrer">§ 8.3 Determine request’s Referrer</a> algorithm.</p>
     <div class="example" id="example-16facf41"><a class="self-link" href="#example-16facf41"></a> Given a HTML <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-a-element" id="ref-for-the-a-element">a</a></code> element without any declared <code><a data-link-type="element-sub" href="https://html.spec.whatwg.org/multipage/semantics.html#attr-a-referrerpolicy" id="ref-for-attr-a-referrerpolicy">referrerpolicy</a></code> attribute, its referrer policy is the empty string. Thus, navigation
     requests initiated by clicking on that <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-a-element" id="ref-for-the-a-element①">a</a></code> element will be sent
     with the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#concept-document-referrer-policy" id="ref-for-concept-document-referrer-policy">referrer
-    policy</a> of the <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-a-element" id="ref-for-the-a-element②">a</a></code> element’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-node-document" id="ref-for-concept-node-document">node document</a>. If that <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/dom.html#document" id="ref-for-document">Document</a></code> has the empty string as its referrer policy, the <a href="#determine-requests-referrer" id="ref-for-determine-requests-referrer①">§8.3 Determine request’s Referrer</a> algorithm will treat the empty
-    string the same as <a data-link-type="dfn" href="#referrer-policy-no-referrer-when-downgrade" id="ref-for-referrer-policy-no-referrer-when-downgrade③">"<code>no-referrer-when-downgrade</code>"</a>. </div>
+    policy</a> of the <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-a-element" id="ref-for-the-a-element②">a</a></code> element’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-node-document" id="ref-for-concept-node-document">node document</a>. If that <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/dom.html#document" id="ref-for-document">Document</a></code> has the empty string as its referrer policy, the <a href="#determine-requests-referrer" id="ref-for-determine-requests-referrer①">§ 8.3 Determine request’s Referrer</a> algorithm will treat the empty
+    string the same as <a data-link-type="dfn" href="#referrer-policy-no-referrer-when-downgrade" id="ref-for-referrer-policy-no-referrer-when-downgrade④">"<code>no-referrer-when-downgrade</code>"</a>. </div>
    </section>
    <section>
     <h2 class="heading settled" data-level="4" id="referrer-policy-delivery"><span class="secno">4. </span><span class="content">Referrer Policy Delivery</span><a class="self-link" href="#referrer-policy-delivery"></a></h2>
     <p>A <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request①">request</a>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-referrer-policy" id="ref-for-concept-request-referrer-policy">referrer policy</a> is delivered in one of five ways:</p>
     <ul>
      <li> Via the <code>Referrer-Policy</code> HTTP header (defined
-      in <a href="#referrer-policy-header">§4.1 Delivery via Referrer-Policy header</a>). 
+      in <a href="#referrer-policy-header">§ 4.1 Delivery via Referrer-Policy header</a>). 
      <li> Via a <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#meta" id="ref-for-meta">meta</a></code> element with a <code><a data-link-type="element-sub" href="https://html.spec.whatwg.org/multipage/semantics.html#attr-meta-name" id="ref-for-attr-meta-name">name</a></code> of <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/semantics.html#meta-referrer" id="ref-for-meta-referrer"><code>referrer</code></a>. 
      <li> Via a <code>referrerpolicy</code> content attribute on an <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-a-element" id="ref-for-the-a-element③">a</a></code>, <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/image-maps.html#the-area-element" id="ref-for-the-area-element">area</a></code>, <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element" id="ref-for-the-img-element">img</a></code>, <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element" id="ref-for-the-iframe-element">iframe</a></code>, or <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-link-element" id="ref-for-the-link-element">link</a></code> element. 
      <li> Via the <code><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/semantics.html#link-type-noreferrer" id="ref-for-link-type-noreferrer②">noreferrer</a></code> link relation on an <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-a-element" id="ref-for-the-a-element④">a</a></code>, or <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/image-maps.html#the-area-element" id="ref-for-the-area-element①">area</a></code> element. 
@@ -1810,11 +1808,11 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
     <p class="note" role="note"><span>Note:</span> The header name does not share the HTTP Referer header’s misspelling.</p>
     <p class="note" role="note"><span>Note:</span> The purpose of <a data-link-type="grammar" href="#grammardef-extension-token" id="ref-for-grammardef-extension-token①">extension-token</a> is so that
   browsers do not fail to parse the entire header field if it includes an
-  unknown policy value. <a href="#unknown-policy-values">§11.1 Unknown Policy Values</a> describes in greater detail
+  unknown policy value. <a href="#unknown-policy-values">§ 11.1 Unknown Policy Values</a> describes in greater detail
   how new policy values can be deployed.</p>
     <p class="note" role="note"><span>Note:</span> The quotes in the ABNF above are used to indicate literal strings.
   Referrer-Policy header values should not be quoted.</p>
-    <p><a href="#integration-with-fetch">§5 Integration with Fetch</a> and <a href="#integration-with-html">§6 Integration with HTML</a> describe
+    <p><a href="#integration-with-fetch">§ 5 Integration with Fetch</a> and <a href="#integration-with-html">§ 6 Integration with HTML</a> describe
   how the <code>Referrer-Policy</code> header is processed.</p>
     <section class="informative">
      <h4 class="heading settled" data-level="4.1.1" id="referrer-usage"><span class="secno">4.1.1. </span><span class="content">Usage</span><a class="self-link" href="#referrer-usage"></a></h4>
@@ -1852,10 +1850,10 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
    <section class="informative">
     <h2 class="heading settled" data-level="5" id="integration-with-fetch"><span class="secno">5. </span><span class="content">Integration with Fetch</span><a class="self-link" href="#integration-with-fetch"></a></h2>
     <p><em>This section is not normative.</em></p>
-    <p>The Fetch specification calls out to <a href="#set-requests-referrer-policy-on-redirect" id="ref-for-set-requests-referrer-policy-on-redirect">§8.2 Set request’s referrer policy on redirect</a> before <a href="https://fetch.spec.whatwg.org/#http-redirect-fetch">Step
+    <p>The Fetch specification calls out to <a href="#set-requests-referrer-policy-on-redirect" id="ref-for-set-requests-referrer-policy-on-redirect">§ 8.2 Set request’s referrer policy on redirect</a> before <a href="https://fetch.spec.whatwg.org/#http-redirect-fetch">Step
   13 of the HTTP-redirect fetch</a>, so that a request’s referrer policy
   can be updated before following a redirect.</p>
-    <p>The Fetch specification calls out to <a href="#determine-requests-referrer" id="ref-for-determine-requests-referrer②">§8.3 Determine request’s Referrer</a> as <a href="https://fetch.spec.whatwg.org/#main-fetch">Step 8 of the
+    <p>The Fetch specification calls out to <a href="#determine-requests-referrer" id="ref-for-determine-requests-referrer②">§ 8.3 Determine request’s Referrer</a> as <a href="https://fetch.spec.whatwg.org/#main-fetch">Step 8 of the
   Main fetch algorithm</a>, and uses the result to set the <var>request</var>’s <code>referrer</code> property. Fetch is responsible for serializing the
   URL provided, and setting the `<code>Referer</code>` header on <var>request</var>.</p>
    </section>
@@ -1866,7 +1864,7 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
   received during <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#navigate" id="ref-for-navigate">navigation</a> or while <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/workers.html#run-a-worker" id="ref-for-run-a-worker">running a worker</a>, and uses
   the result to set the resulting <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/dom.html#document" id="ref-for-document①">Document</a></code> or <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#workerglobalscope" id="ref-for-workerglobalscope">WorkerGlobalScope</a></code>'s
   referrer policy. This is later used by the corresponding <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object" id="ref-for-environment-settings-object⑨">environment
-  settings object</a>, which serves as a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client" id="ref-for-concept-request-client①⑦">request client</a> for <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-fetch" id="ref-for-concept-fetch①">fetches</a> it initiates.</p>
+  settings object</a>, which serves as a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client" id="ref-for-concept-request-client①⑥">request client</a> for <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-fetch" id="ref-for-concept-fetch①">fetches</a> it initiates.</p>
     <p class="note" role="note"><span>Note:</span> W3C HTML5 does not define the <code>referrerpolicy</code> content
   attributes, or <code>referrerPolicy</code> IDL attributes, or the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/semantics.html#meta-referrer" id="ref-for-meta-referrer②"><code>referrer</code></a> keyword for <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#meta" id="ref-for-meta③">meta</a></code>, or the
   integration with navigation or running a worker. For this spec to make sense
@@ -1916,14 +1914,14 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
       policy</a> and <var>token</var> is not the empty string, then set <var>policy</var> to <var>token</var>. 
       <p class="note" role="note"><span>Note:</span> This algorithm loops over multiple policy values to allow
 	  deployment of new policy values with fallbacks for older user
-	  agents, as described in <a href="#unknown-policy-values">§11.1 Unknown Policy Values</a>.</p>
+	  agents, as described in <a href="#unknown-policy-values">§ 11.1 Unknown Policy Values</a>.</p>
      <li> Return <var>policy</var>. 
     </ol>
     <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-export data-level="8.2" data-lt="Set request’s referrer policy on redirect" id="set-requests-referrer-policy-on-redirect"><span class="secno">8.2. </span><span class="content"> Set <var>request</var>’s referrer policy on redirect </span></h3>
     <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤">request</a> <var>request</var> and a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②">response</a> <var>actualResponse</var>,
   this algorithm updates <var>request</var>’s associated <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-referrer-policy" id="ref-for-concept-request-referrer-policy⑤">referrer policy</a> according to the Referrer-Policy header (if any) in <var>actualResponse</var>.</p>
     <ol>
-     <li> Let <var>policy</var> be the result of executing <a href="#parse-referrer-policy-from-header">§8.1 Parse a referrer policy from a Referrer-Policy header</a> on <var>actualResponse</var>. 
+     <li> Let <var>policy</var> be the result of executing <a href="#parse-referrer-policy-from-header">§ 8.1 Parse a referrer policy from a Referrer-Policy header</a> on <var>actualResponse</var>. 
      <li>If <var>policy</var> is not the empty string, then set <var>request</var>’s
     associated referrer policy to <var>policy</var>.
     </ol>
@@ -1933,7 +1931,7 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
   either <code>no referrer</code> or a URL:</p>
     <ol>
      <li> Let <var>policy</var> be <var>request</var>’s associated <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-referrer-policy" id="ref-for-concept-request-referrer-policy⑦">referrer policy</a>. 
-     <li> Let <var>environment</var> be <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client" id="ref-for-concept-request-client①⑧">client</a>. 
+     <li> Let <var>environment</var> be <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client" id="ref-for-concept-request-client①⑦">client</a>. 
      <li>
        Switch on <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-referrer" id="ref-for-concept-request-referrer④">referrer</a>: 
       <dl class="switch">
@@ -1970,8 +1968,6 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
        <dd>Return <code>no referrer</code>
        <dt><a data-link-type="dfn" href="#referrer-policy-origin" id="ref-for-referrer-policy-origin③">"<code>origin</code>"</a>
        <dd>Return <var>referrerOrigin</var>
-       <dt><a data-link-type="dfn" href="#referrer-policy-unsafe-url" id="ref-for-referrer-policy-unsafe-url②">"<code>unsafe-url</code>"</a>
-       <dd>Return <var>referrerURL</var>.
        <dt><a data-link-type="dfn" href="#referrer-policy-strict-origin" id="ref-for-referrer-policy-strict-origin④">"<code>strict-origin</code>"</a>
        <dd>
         <ol>
@@ -1987,7 +1983,7 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
        <dt><a data-link-type="dfn" href="#referrer-policy-strict-origin-when-cross-origin" id="ref-for-referrer-policy-strict-origin-when-cross-origin③">"<code>strict-origin-when-cross-origin</code>"</a>
        <dd>
         <ol>
-         <li> If <var>request</var> is a <a data-link-type="dfn" href="#same-origin-request" id="ref-for-same-origin-request⑥">same-origin request</a>, then
+         <li> If <var>request</var> is a <a data-link-type="dfn" href="#same-origin-request" id="ref-for-same-origin-request⑤">same-origin request</a>, then
               return <var>referrerURL</var>. 
          <li>
            If <var>environment</var> is not null: 
@@ -2004,18 +2000,19 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
        <dt><a data-link-type="dfn" href="#referrer-policy-same-origin" id="ref-for-referrer-policy-same-origin②">"<code>same-origin</code>"</a>
        <dd>
         <ol>
-         <li> If <var>request</var> is a <a data-link-type="dfn" href="#same-origin-request" id="ref-for-same-origin-request⑦">same-origin request</a>, then
+         <li> If <var>request</var> is a <a data-link-type="dfn" href="#same-origin-request" id="ref-for-same-origin-request⑥">same-origin request</a>, then
               return <var>referrerURL</var>. 
          <li> Otherwise, return <code>no referrer</code>. 
         </ol>
        <dt><a data-link-type="dfn" href="#referrer-policy-origin-when-cross-origin" id="ref-for-referrer-policy-origin-when-cross-origin④">"<code>origin-when-cross-origin</code>"</a>
        <dd>
         <ol>
-         <li> If <var>request</var> is a <a data-link-type="dfn" href="#cross-origin-request" id="ref-for-cross-origin-request⑥">cross-origin request</a>, then
+         <li> If <var>request</var> is a <a data-link-type="dfn" href="#cross-origin-request" id="ref-for-cross-origin-request⑤">cross-origin request</a>, then
               return <var>referrerOrigin</var>. 
          <li> Otherwise, return <var>referrerURL</var>. 
         </ol>
-       <dt><a data-link-type="dfn" href="#referrer-policy-no-referrer-when-downgrade" id="ref-for-referrer-policy-no-referrer-when-downgrade④">"<code>no-referrer-when-downgrade</code>"</a>
+       <dt><a data-link-type="dfn" href="#referrer-policy-unsafe-url" id="ref-for-referrer-policy-unsafe-url①">"<code>unsafe-url</code>"</a>
+       <dt><a data-link-type="dfn" href="#referrer-policy-no-referrer-when-downgrade" id="ref-for-referrer-policy-no-referrer-when-downgrade⑤">"<code>no-referrer-when-downgrade</code>"</a>
        <dd>
         <ol>
          <li>
@@ -2068,40 +2065,42 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
    <section>
     <h2 class="heading settled" data-level="10" id="security"><span class="secno">10. </span><span class="content">Security Considerations</span><a class="self-link" href="#security"></a></h2>
     <h3 class="heading settled" data-level="10.1" id="information-leakage"><span class="secno">10.1. </span><span class="content">Information Leakage</span><a class="self-link" href="#information-leakage"></a></h3>
-    <p>The <a data-link-type="dfn" href="#referrer-policy" id="ref-for-referrer-policy①④">referrer policies</a> <a data-link-type="dfn" href="#referrer-policy-origin" id="ref-for-referrer-policy-origin④">"<code>origin</code>"</a>, <a data-link-type="dfn" href="#referrer-policy-origin-when-cross-origin" id="ref-for-referrer-policy-origin-when-cross-origin⑤">"<code>origin-when-cross-origin</code>"</a> and <a data-link-type="dfn" href="#referrer-policy-unsafe-url" id="ref-for-referrer-policy-unsafe-url③">"<code>unsafe-url</code>"</a> might leak the origin and the URL of
-  a secure site respectively via insecure transport.</p>
-    <p>Those three policies are included in the spec nevertheless to lower the friction
+    <p>The <a data-link-type="dfn" href="#referrer-policy" id="ref-for-referrer-policy①④">referrer policies</a> <a data-link-type="dfn" href="#referrer-policy-origin" id="ref-for-referrer-policy-origin④">"<code>origin</code>"</a> and <a data-link-type="dfn" href="#referrer-policy-origin-when-cross-origin" id="ref-for-referrer-policy-origin-when-cross-origin⑤">"<code>origin-when-cross-origin</code>"</a> might leak the origin of
+  a secure site via insecure transport.</p>
+    <p>Those policies are included in the spec nevertheless to lower the friction
   of sites adopting secure transport.</p>
     <p>Authors wanting to ensure that they do not leak any more information than
   the default policy should instead use the policy states <a data-link-type="dfn" href="#referrer-policy-same-origin" id="ref-for-referrer-policy-same-origin③">"<code>same-origin</code>"</a>, <a data-link-type="dfn" href="#referrer-policy-strict-origin" id="ref-for-referrer-policy-strict-origin⑤">"<code>strict-origin</code>"</a>, <a data-link-type="dfn" href="#referrer-policy-strict-origin-when-cross-origin" id="ref-for-referrer-policy-strict-origin-when-cross-origin④">"<code>strict-origin-when-cross-origin</code>"</a> or <a data-link-type="dfn" href="#referrer-policy-no-referrer" id="ref-for-referrer-policy-no-referrer③">"<code>no-referrer</code>"</a>.</p>
     <h3 class="heading settled" data-level="10.2" id="downgrade"><span class="secno">10.2. </span><span class="content">Downgrade to less strict policies</span><a class="self-link" href="#downgrade"></a></h3>
-    <p>The spec does not forbid downgrading to less strict policies, e.g., from <a data-link-type="dfn" href="#referrer-policy-no-referrer" id="ref-for-referrer-policy-no-referrer④">"<code>no-referrer</code>"</a> to <a data-link-type="dfn" href="#referrer-policy-unsafe-url" id="ref-for-referrer-policy-unsafe-url④">"<code>unsafe-url</code>"</a>.</p>
+    <p>The spec does not forbid downgrading to less strict policies, e.g., from <a data-link-type="dfn" href="#referrer-policy-no-referrer" id="ref-for-referrer-policy-no-referrer④">"<code>no-referrer</code>"</a> to <a data-link-type="dfn" href="#referrer-policy-origin" id="ref-for-referrer-policy-origin⑤">"<code>origin</code>"</a>.</p>
     <p>On the one hand, it is not clear which policy is more strict for all possible
-  pairs of policies: While <a data-link-type="dfn" href="#referrer-policy-no-referrer-when-downgrade" id="ref-for-referrer-policy-no-referrer-when-downgrade⑤">"<code>no-referrer-when-downgrade</code>"</a> will
-  not leak any information over insecure transport, and <a data-link-type="dfn" href="#referrer-policy-origin" id="ref-for-referrer-policy-origin⑤">"<code>origin</code>"</a> will, the latter reveals less information
+  pairs of policies: While <a data-link-type="dfn" href="#referrer-policy-no-referrer-when-downgrade" id="ref-for-referrer-policy-no-referrer-when-downgrade⑥">"<code>no-referrer-when-downgrade</code>"</a> will
+  not leak any information over insecure transport, and <a data-link-type="dfn" href="#referrer-policy-origin" id="ref-for-referrer-policy-origin⑥">"<code>origin</code>"</a> will, the latter reveals less information
   across cross-origin navigations.</p>
     <p>On the other hand, allowing for setting less strict policies enables authors
-  to define safe fallbacks as described in <a href="#unknown-policy-values">§11.1 Unknown Policy Values</a>.</p>
+  to define safe fallbacks as described in <a href="#unknown-policy-values">§ 11.1 Unknown Policy Values</a>.</p>
    </section>
    <section>
     <h2 class="heading settled" data-level="11" id="authoring"><span class="secno">11. </span><span class="content">Authoring Considerations</span><a class="self-link" href="#authoring"></a></h2>
     <h3 class="heading settled" data-level="11.1" id="unknown-policy-values"><span class="secno">11.1. </span><span class="content">Unknown Policy Values</span><a class="self-link" href="#unknown-policy-values"></a></h3>
-    <p>As described in <a href="#parse-referrer-policy-from-header">§8.1 Parse a referrer policy from a Referrer-Policy header</a> and in the <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#meta" id="ref-for-meta④">meta</a></code> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/semantics.html#meta-referrer" id="ref-for-meta-referrer③"><code>referrer</code></a> algorithm, unknown
+    <p>As described in <a href="#parse-referrer-policy-from-header">§ 8.1 Parse a referrer policy from a Referrer-Policy header</a> and in the <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#meta" id="ref-for-meta④">meta</a></code> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/semantics.html#meta-referrer" id="ref-for-meta-referrer③"><code>referrer</code></a> algorithm, unknown
   policy values will be ignored, and when multiple sources specify a
   referrer policy, the value of the latest one will be used. This makes
   it possible to deploy new policy values.</p>
-    <div class="example" id="example-1ba8d4a5"><a class="self-link" href="#example-1ba8d4a5"></a> Suppose older user agents don’t understand
-    the <a data-link-type="dfn" href="#referrer-policy-unsafe-url" id="ref-for-referrer-policy-unsafe-url⑤">"<code>unsafe-url</code>"</a> policy. A site can specify
-    an <a data-link-type="dfn" href="#referrer-policy-origin" id="ref-for-referrer-policy-origin⑥">"<code>origin</code>"</a> policy followed by an <a data-link-type="dfn" href="#referrer-policy-unsafe-url" id="ref-for-referrer-policy-unsafe-url⑥">"<code>unsafe-url</code>"</a> policy: older user agents will ignore the
-    unknown <a data-link-type="dfn" href="#referrer-policy-unsafe-url" id="ref-for-referrer-policy-unsafe-url⑦">"<code>unsafe-url</code>"</a> value and use <a data-link-type="dfn" href="#referrer-policy-origin" id="ref-for-referrer-policy-origin⑦">"<code>origin</code>"</a>, while newer user agents will use <a data-link-type="dfn" href="#referrer-policy-unsafe-url" id="ref-for-referrer-policy-unsafe-url⑧">"<code>unsafe-url</code>"</a> because it is the last to be processed. </div>
-    <div class="example" id="example-3966e12b">
-     <a class="self-link" href="#example-3966e12b"></a> To specify multiple policy values in the Referrer-Policy header, a site can
+    <div class="example" id="example-640c70af"><a class="self-link" href="#example-640c70af"></a> Suppose older user agents don’t understand
+    the "<code>not-yet-defined</code>" policy. A site can specify
+    an <a data-link-type="dfn" href="#referrer-policy-origin" id="ref-for-referrer-policy-origin⑦">"<code>origin</code>"</a> policy followed by an
+    "<code>not-yet-defined</code>" policy: older user agents will ignore the
+    unknown "<code>not-yet-defined</code>" value and use <a data-link-type="dfn" href="#referrer-policy-origin" id="ref-for-referrer-policy-origin⑧">"<code>origin</code>"</a>, while newer user agents will use
+    "<code>not-yet-defined</code>" because it is the last to be processed. </div>
+    <div class="example" id="example-0cd1e2f4">
+     <a class="self-link" href="#example-0cd1e2f4"></a> To specify multiple policy values in the Referrer-Policy header, a site can
     send multiple Referrer-Policy headers: 
 <pre>Referrer-Policy: no-referrer
-Referrer-Policy: unsafe-url
+Referrer-Policy: not-yet-defined
 </pre>
      <p>or, equivalently, multiple comma-separated header values:</p>
-<pre>Referrer-Policy: no-referrer,unsafe-url
+<pre>Referrer-Policy: no-referrer,not-yet-defined
 </pre>
     </div>
     <p>This behavior does not, however, apply to
@@ -2282,9 +2281,8 @@ Referrer-Policy: unsafe-url
     <li><a href="#ref-for-concept-request-client⑧">3.5. "strict-origin"</a> <a href="#ref-for-concept-request-client⑨">(2)</a>
     <li><a href="#ref-for-concept-request-client①⓪">3.6. "origin-when-cross-origin"</a> <a href="#ref-for-concept-request-client①①">(2)</a> <a href="#ref-for-concept-request-client①②">(3)</a>
     <li><a href="#ref-for-concept-request-client①③">3.7. "strict-origin-when-cross-origin"</a> <a href="#ref-for-concept-request-client①④">(2)</a> <a href="#ref-for-concept-request-client①⑤">(3)</a>
-    <li><a href="#ref-for-concept-request-client①⑥">3.8. "unsafe-url"</a>
-    <li><a href="#ref-for-concept-request-client①⑦">6. Integration with HTML</a>
-    <li><a href="#ref-for-concept-request-client①⑧">8.3. 
+    <li><a href="#ref-for-concept-request-client①⑥">6. Integration with HTML</a>
+    <li><a href="#ref-for-concept-request-client①⑦">8.3. 
     Determine request’s Referrer </a>
    </ul>
   </aside>
@@ -2631,7 +2629,6 @@ Referrer-Policy: unsafe-url
     <li><a href="#ref-for-section-5.5.2①①">3.5. "strict-origin"</a> <a href="#ref-for-section-5.5.2①②">(2)</a> <a href="#ref-for-section-5.5.2①③">(3)</a> <a href="#ref-for-section-5.5.2①④">(4)</a>
     <li><a href="#ref-for-section-5.5.2①⑤">3.6. "origin-when-cross-origin"</a> <a href="#ref-for-section-5.5.2①⑥">(2)</a>
     <li><a href="#ref-for-section-5.5.2①⑦">3.7. "strict-origin-when-cross-origin"</a> <a href="#ref-for-section-5.5.2①⑧">(2)</a> <a href="#ref-for-section-5.5.2①⑨">(3)</a> <a href="#ref-for-section-5.5.2②⓪">(4)</a>
-    <li><a href="#ref-for-section-5.5.2②①">3.8. "unsafe-url"</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-potentially-trustworthy-url">
@@ -2808,7 +2805,7 @@ Referrer-Policy: unsafe-url
    <dt id="biblio-rfc5234">[RFC5234]
    <dd>D. Crocker, Ed.; P. Overell. <a href="https://tools.ietf.org/html/rfc5234">Augmented BNF for Syntax Specifications: ABNF</a>. January 2008. Internet Standard. URL: <a href="https://tools.ietf.org/html/rfc5234">https://tools.ietf.org/html/rfc5234</a>
    <dt id="biblio-rfc7230">[RFC7230]
-   <dd>R. Fielding, Ed.; J. Reschke, Ed.. <a href="https://tools.ietf.org/html/rfc7230">Hypertext Transfer Protocol (HTTP/1.1): Message Syntax and Routing</a>. June 2014. Proposed Standard. URL: <a href="https://tools.ietf.org/html/rfc7230">https://tools.ietf.org/html/rfc7230</a>
+   <dd>R. Fielding, Ed.; J. Reschke, Ed.. <a href="https://httpwg.org/specs/rfc7230.html">Hypertext Transfer Protocol (HTTP/1.1): Message Syntax and Routing</a>. June 2014. Proposed Standard. URL: <a href="https://httpwg.org/specs/rfc7230.html">https://httpwg.org/specs/rfc7230.html</a>
    <dt id="biblio-rfc7231">[RFC7231]
    <dd>Roy T. Fielding; Julian F. Reschke. <a href="http://www.ietf.org/rfc/rfc7231.txt">HTTP/1.1 Semantics and Content</a>. RFC. URL: <a href="http://www.ietf.org/rfc/rfc7231.txt">http://www.ietf.org/rfc/rfc7231.txt</a>
    <dt id="biblio-secure-contexts">[SECURE-CONTEXTS]
@@ -2849,9 +2846,8 @@ Referrer-Policy: unsafe-url
     <li><a href="#ref-for-same-origin-request②">3.4. "origin"</a>
     <li><a href="#ref-for-same-origin-request③">3.6. "origin-when-cross-origin"</a>
     <li><a href="#ref-for-same-origin-request④">3.7. "strict-origin-when-cross-origin"</a>
-    <li><a href="#ref-for-same-origin-request⑤">3.8. "unsafe-url"</a>
-    <li><a href="#ref-for-same-origin-request⑥">8.3. 
-    Determine request’s Referrer </a> <a href="#ref-for-same-origin-request⑦">(2)</a>
+    <li><a href="#ref-for-same-origin-request⑤">8.3. 
+    Determine request’s Referrer </a> <a href="#ref-for-same-origin-request⑥">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="cross-origin-request">
@@ -2861,8 +2857,7 @@ Referrer-Policy: unsafe-url
     <li><a href="#ref-for-cross-origin-request①">3.4. "origin"</a>
     <li><a href="#ref-for-cross-origin-request②">3.6. "origin-when-cross-origin"</a> <a href="#ref-for-cross-origin-request③">(2)</a>
     <li><a href="#ref-for-cross-origin-request④">3.7. "strict-origin-when-cross-origin"</a>
-    <li><a href="#ref-for-cross-origin-request⑤">3.8. "unsafe-url"</a>
-    <li><a href="#ref-for-cross-origin-request⑥">8.3. 
+    <li><a href="#ref-for-cross-origin-request⑤">8.3. 
     Determine request’s Referrer </a>
    </ul>
   </aside>
@@ -2897,10 +2892,11 @@ Referrer-Policy: unsafe-url
    <b><a href="#referrer-policy-no-referrer-when-downgrade">#referrer-policy-no-referrer-when-downgrade</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-referrer-policy-no-referrer-when-downgrade">3.2. "no-referrer-when-downgrade"</a> <a href="#ref-for-referrer-policy-no-referrer-when-downgrade①">(2)</a>
-    <li><a href="#ref-for-referrer-policy-no-referrer-when-downgrade②">3.9. The empty string</a> <a href="#ref-for-referrer-policy-no-referrer-when-downgrade③">(2)</a>
-    <li><a href="#ref-for-referrer-policy-no-referrer-when-downgrade④">8.3. 
+    <li><a href="#ref-for-referrer-policy-no-referrer-when-downgrade②">3.8. "unsafe-url"</a>
+    <li><a href="#ref-for-referrer-policy-no-referrer-when-downgrade③">3.9. The empty string</a> <a href="#ref-for-referrer-policy-no-referrer-when-downgrade④">(2)</a>
+    <li><a href="#ref-for-referrer-policy-no-referrer-when-downgrade⑤">8.3. 
     Determine request’s Referrer </a>
-    <li><a href="#ref-for-referrer-policy-no-referrer-when-downgrade⑤">10.2. Downgrade to less strict policies</a>
+    <li><a href="#ref-for-referrer-policy-no-referrer-when-downgrade⑥">10.2. Downgrade to less strict policies</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="referrer-policy-same-origin">
@@ -2919,8 +2915,8 @@ Referrer-Policy: unsafe-url
     <li><a href="#ref-for-referrer-policy-origin③">8.3. 
     Determine request’s Referrer </a>
     <li><a href="#ref-for-referrer-policy-origin④">10.1. Information Leakage</a>
-    <li><a href="#ref-for-referrer-policy-origin⑤">10.2. Downgrade to less strict policies</a>
-    <li><a href="#ref-for-referrer-policy-origin⑥">11.1. Unknown Policy Values</a> <a href="#ref-for-referrer-policy-origin⑦">(2)</a>
+    <li><a href="#ref-for-referrer-policy-origin⑤">10.2. Downgrade to less strict policies</a> <a href="#ref-for-referrer-policy-origin⑥">(2)</a>
+    <li><a href="#ref-for-referrer-policy-origin⑦">11.1. Unknown Policy Values</a> <a href="#ref-for-referrer-policy-origin⑧">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="referrer-policy-strict-origin">
@@ -2955,12 +2951,9 @@ Referrer-Policy: unsafe-url
   <aside class="dfn-panel" data-for="referrer-policy-unsafe-url">
    <b><a href="#referrer-policy-unsafe-url">#referrer-policy-unsafe-url</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-referrer-policy-unsafe-url">3.8. "unsafe-url"</a> <a href="#ref-for-referrer-policy-unsafe-url①">(2)</a>
-    <li><a href="#ref-for-referrer-policy-unsafe-url②">8.3. 
+    <li><a href="#ref-for-referrer-policy-unsafe-url">3.8. "unsafe-url"</a>
+    <li><a href="#ref-for-referrer-policy-unsafe-url①">8.3. 
     Determine request’s Referrer </a>
-    <li><a href="#ref-for-referrer-policy-unsafe-url③">10.1. Information Leakage</a>
-    <li><a href="#ref-for-referrer-policy-unsafe-url④">10.2. Downgrade to less strict policies</a>
-    <li><a href="#ref-for-referrer-policy-unsafe-url⑤">11.1. Unknown Policy Values</a> <a href="#ref-for-referrer-policy-unsafe-url⑥">(2)</a> <a href="#ref-for-referrer-policy-unsafe-url⑦">(3)</a> <a href="#ref-for-referrer-policy-unsafe-url⑧">(4)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="referrer-policy-header-dfn">

--- a/index.src.html
+++ b/index.src.html
@@ -445,23 +445,15 @@ spec: html; type: element; text: a;
 
   <h3 dfn export id="referrer-policy-unsafe-url" oldids="referrer-policy-state-unsafe-url">"<code>unsafe-url</code>"</h3>
 
-  The <a>"<code>unsafe-url</code>"</a> policy specifies that a full URL,
-  <a href="#strip-url">stripped for use as a referrer</a>, is sent along with
-  both <a>cross-origin requests</a> and <a>same-origin requests</a> made from
-  a particular <a for=request>client</a>.
-
-  <div class="example">
-    If a document at <code>https://example.com/sekrit.html</code> sets a policy
-    of <a>"<code>unsafe-url</code>"</a>, then navigations to
-    <code>http://not.example.com/</code> (and every other origin) would send a
-    <code><a>Referer</a></code> HTTP header with a value of
-    <code>https://example.com/sekrit.html</code>.
-  </div>
-
-  Note: The policy's name doesn't lie; it is unsafe. This policy will leak
-  origins and paths from secure resources to insecure origins.
-  Carefully consider the impact of setting such a policy for potentially
-  sensitive documents.
+  The <a>"<code>unsafe-url</code>"</a> policy is an alias for the
+  <a>"<code>no-referrer-when-downgrade</code>"</a> policy.
+  
+  Note: In previous versions of this specification, this policy was, in fact,
+  unsafe, as it intentionally leaked origins and paths from secure resources to
+  non-secure origins. The original intent was to allow pages to migrate to HTTPS
+  without losing referrer-based attribution vis a vis non-secure sites. Given
+  our collective progress at that migration, this safety valve is no longer
+  necessary.
 
   <h3 dfn export id="referrer-policy-empty-string">The empty string</h3>
 
@@ -828,9 +820,6 @@ spec: html; type: element; text: a;
         <dt><a>"<code>origin</code>"</a></dt>
         <dd>Return <var>referrerOrigin</var></dd>
 
-        <dt><a>"<code>unsafe-url</code>"</a></dt>
-        <dd>Return <var>referrerURL</var>.</dd>
-
         <dt><a>"<code>strict-origin</code>"</a></dt>
         <dd>
           <ol>
@@ -901,6 +890,7 @@ spec: html; type: element; text: a;
           </ol>
         </dd>
 
+        <dt><a>"<code>unsafe-url</code>"</a></dt>
         <dt><a>"<code>no-referrer-when-downgrade</code>"</a></dt>
         <dd>
           <ol>
@@ -992,12 +982,11 @@ spec: html; type: element; text: a;
 
   <h3 id="information-leakage">Information Leakage</h3>
 
-  The <a for="/">referrer policies</a> <a>"<code>origin</code>"</a>,
-  <a>"<code>origin-when-cross-origin</code>"</a> and
-  <a>"<code>unsafe-url</code>"</a> might leak the origin and the URL of
-  a secure site respectively via insecure transport.
+  The <a for="/">referrer policies</a> <a>"<code>origin</code>"</a> and
+  <a>"<code>origin-when-cross-origin</code>"</a> might leak the origin of
+  a secure site via insecure transport.
 
-  Those three policies are included in the spec nevertheless to lower the friction
+  Those policies are included in the spec nevertheless to lower the friction
   of sites adopting secure transport.
 
   Authors wanting to ensure that they do not leak any more information than
@@ -1009,7 +998,7 @@ spec: html; type: element; text: a;
   <h3 id="downgrade">Downgrade to less strict policies</h3>
 
   The spec does not forbid downgrading to less strict policies, e.g., from
-  <a>"<code>no-referrer</code>"</a> to <a>"<code>unsafe-url</code>"</a>.
+  <a>"<code>no-referrer</code>"</a> to <a>"<code>origin</code>"</a>.
 
   On the one hand, it is not clear which policy is more strict for all possible
   pairs of policies: While <a>"<code>no-referrer-when-downgrade</code>"</a> will
@@ -1034,12 +1023,12 @@ spec: html; type: element; text: a;
 
   <div class="example">
   	Suppose older user agents don't understand
-    the <a>"<code>unsafe-url</code>"</a> policy. A site can specify
+    the "<code>not-yet-defined</code>" policy. A site can specify
     an <a>"<code>origin</code>"</a> policy followed by an
-    <a>"<code>unsafe-url</code>"</a> policy: older user agents will ignore the
-    unknown <a>"<code>unsafe-url</code>"</a> value and use
+    "<code>not-yet-defined</code>" policy: older user agents will ignore the
+    unknown "<code>not-yet-defined</code>" value and use
     <a>"<code>origin</code>"</a>, while newer user agents will use
-    <a>"<code>unsafe-url</code>"</a> because it is the last to be processed.
+    "<code>not-yet-defined</code>" because it is the last to be processed.
   </div>
 
   <div class="example">
@@ -1047,11 +1036,13 @@ spec: html; type: element; text: a;
     send multiple Referrer-Policy headers:
     <pre>
       Referrer-Policy: no-referrer
-      Referrer-Policy: unsafe-url
+      Referrer-Policy: not-yet-defined
     </pre>
+
     or, equivalently, multiple comma-separated header values:
+
     <pre>
-      Referrer-Policy: no-referrer,unsafe-url
+      Referrer-Policy: no-referrer,not-yet-defined
     </pre>
   </div>
 


### PR DESCRIPTION
This patch converts 'unsafe-url' to be an alias for 'no-referrer-when-downgrade'.
I think we're past the point at which 'unsafe-url' is a useful safety valve for
folks migrating to HTTPS, and it seems reasonable to remove this footgun.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-referrer-policy/pull/124.html" title="Last updated on Feb 16, 2021, 11:23 PM UTC (607ea88)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-referrer-policy/124/20aad3a...607ea88.html" title="Last updated on Feb 16, 2021, 11:23 PM UTC (607ea88)">Diff</a>


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-referrer-policy/pull/124.html" title="Last updated on May 24, 2022, 6:31 PM UTC (607ea88)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-referrer-policy/124/20aad3a...607ea88.html" title="Last updated on May 24, 2022, 6:31 PM UTC (607ea88)">Diff</a>