### PR TITLE
Strip referrer information from non-secure requests.

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -760,6 +760,11 @@ spec: html; type: element; text: a;
 
   <ol>
     <li>
+      If <var>request</var>'s
+      <a href="https://fetch.spec.whatwg.org/#concept-request-current-url">current
+      URL</a> is not a <a>potentially trustworthy URL</a>, then return <code>no referrer</code>.
+    </li>
+    <li>
       Let <var>policy</var> be |request|'s associated <a for=request>referrer policy</a>.
     </li>
     <li>


### PR DESCRIPTION
It's good to have dreams.