### PR TITLE
No need to use the word "associated" when referring to referrer policy

### DIFF
--- a/index.html
+++ b/index.html
@@ -1486,7 +1486,7 @@ Possible extra rowspan handling
 </style>
   <meta content="Bikeshed version c5172e83, updated Fri Nov 20 15:35:20 2020 -0800" name="generator">
   <link href="http://www.w3.org/TR/referrer-policy/" rel="canonical">
-  <meta content="fcb42d5c42ef363ed4f2e462b201fd6291bd157c" name="document-revision">
+  <meta content="6e207776af06a04e42105a84ac4ab71f11a41a10" name="document-revision">
 <style>/* style-autolinks */
 
 .css.css, .property.property, .descriptor.descriptor {
@@ -2103,7 +2103,7 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1>Referrer Policy</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2021-01-12">12 January 2021</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2021-01-14">14 January 2021</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -2737,18 +2737,17 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
     </ol>
     <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-export data-level="8.2" data-lt="Set request’s referrer policy on redirect" id="set-requests-referrer-policy-on-redirect"><span class="secno">8.2. </span><span class="content"> Set <var>request</var>’s referrer policy on redirect </span><a class="self-link" href="#set-requests-referrer-policy-on-redirect" id="ref-for-set-requests-referrer-policy-on-redirect①"></a></h3>
     <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤">request</a> <var>request</var> and a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②">response</a> <var>actualResponse</var>,
-  this algorithm updates <var>request</var>’s associated <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-referrer-policy" id="ref-for-concept-request-referrer-policy⑤">referrer policy</a> according to the Referrer-Policy header (if any) in <var>actualResponse</var>.</p>
+  this algorithm updates <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-referrer-policy" id="ref-for-concept-request-referrer-policy⑤">referrer policy</a> according to the Referrer-Policy header (if any) in <var>actualResponse</var>.</p>
     <ol>
      <li> Let <var>policy</var> be the result of executing <a href="#parse-referrer-policy-from-header">§ 8.1 Parse a referrer policy from a Referrer-Policy header</a> on <var>actualResponse</var>. 
-     <li>If <var>policy</var> is not the empty string, then set <var>request</var>’s
-    associated referrer policy to <var>policy</var>.
+     <li>If <var>policy</var> is not the empty string, then set <var>request</var>’s referrer policy
+    to <var>policy</var>.
     </ol>
     <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-export data-level="8.3" data-lt="Determine request’s Referrer" id="determine-requests-referrer"><span class="secno">8.3. </span><span class="content"> Determine <var>request</var>’s Referrer </span><a class="self-link" href="#determine-requests-referrer" id="ref-for-determine-requests-referrer②"></a></h3>
     <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑥">request</a> <var>request</var>, we can determine the correct
-  referrer information to send by examining the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-referrer-policy" id="ref-for-concept-request-referrer-policy⑥">referrer policy</a> associated with it, as detailed in the following steps, which return
-  either <code>no referrer</code> or a URL:</p>
+  referrer information to send by examining its <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-referrer-policy" id="ref-for-concept-request-referrer-policy⑥">referrer policy</a> as detailed in the following steps, which return either <code>no referrer</code> or a URL:</p>
     <ol>
-     <li> Let <var>policy</var> be <var>request</var>’s associated <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-referrer-policy" id="ref-for-concept-request-referrer-policy⑦">referrer policy</a>. 
+     <li> Let <var>policy</var> be <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-referrer-policy" id="ref-for-concept-request-referrer-policy⑦">referrer policy</a>. 
      <li> Let <var>environment</var> be <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client" id="ref-for-concept-request-client③">client</a>. 
      <li>
        Switch on <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-referrer" id="ref-for-concept-request-referrer④">referrer</a>: 

--- a/index.html
+++ b/index.html
@@ -1486,7 +1486,7 @@ Possible extra rowspan handling
 </style>
   <meta content="Bikeshed version c5172e83, updated Fri Nov 20 15:35:20 2020 -0800" name="generator">
   <link href="http://www.w3.org/TR/referrer-policy/" rel="canonical">
-  <meta content="6e207776af06a04e42105a84ac4ab71f11a41a10" name="document-revision">
+  <meta content="3ee21371ac913830b572d67d2687e76a699f4c8d" name="document-revision">
 <style>/* style-autolinks */
 
 .css.css, .property.property, .descriptor.descriptor {
@@ -2740,14 +2740,13 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
   this algorithm updates <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-referrer-policy" id="ref-for-concept-request-referrer-policy⑤">referrer policy</a> according to the Referrer-Policy header (if any) in <var>actualResponse</var>.</p>
     <ol>
      <li> Let <var>policy</var> be the result of executing <a href="#parse-referrer-policy-from-header">§ 8.1 Parse a referrer policy from a Referrer-Policy header</a> on <var>actualResponse</var>. 
-     <li>If <var>policy</var> is not the empty string, then set <var>request</var>’s referrer policy
-    to <var>policy</var>.
+     <li>If <var>policy</var> is not the empty string, then set <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-referrer-policy" id="ref-for-concept-request-referrer-policy⑥">referrer policy</a> to <var>policy</var>.
     </ol>
     <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-export data-level="8.3" data-lt="Determine request’s Referrer" id="determine-requests-referrer"><span class="secno">8.3. </span><span class="content"> Determine <var>request</var>’s Referrer </span><a class="self-link" href="#determine-requests-referrer" id="ref-for-determine-requests-referrer②"></a></h3>
     <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑥">request</a> <var>request</var>, we can determine the correct
-  referrer information to send by examining its <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-referrer-policy" id="ref-for-concept-request-referrer-policy⑥">referrer policy</a> as detailed in the following steps, which return either <code>no referrer</code> or a URL:</p>
+  referrer information to send by examining its <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-referrer-policy" id="ref-for-concept-request-referrer-policy⑦">referrer policy</a> as detailed in the following steps, which return either <code>no referrer</code> or a URL:</p>
     <ol>
-     <li> Let <var>policy</var> be <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-referrer-policy" id="ref-for-concept-request-referrer-policy⑦">referrer policy</a>. 
+     <li> Let <var>policy</var> be <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-referrer-policy" id="ref-for-concept-request-referrer-policy⑧">referrer policy</a>. 
      <li> Let <var>environment</var> be <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client" id="ref-for-concept-request-client③">client</a>. 
      <li>
        Switch on <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-referrer" id="ref-for-concept-request-referrer④">referrer</a>: 
@@ -2785,7 +2784,7 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
      <li>
        Execute the statements corresponding to the value of <var>policy</var>: 
       <dl class="switch">
-        Note: If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-referrer-policy" id="ref-for-concept-request-referrer-policy⑧">referrer policy</a> is
+        Note: If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-referrer-policy" id="ref-for-concept-request-referrer-policy⑨">referrer policy</a> is
         the empty string, Fetch will not call into this algorithm. 
        <dt><a data-link-type="dfn" href="#referrer-policy-no-referrer" id="ref-for-referrer-policy-no-referrer②">"<code>no-referrer</code>"</a>
        <dd>Return <code>no referrer</code>
@@ -3142,9 +3141,9 @@ Referrer-Policy: unsafe-url
     <li><a href="#ref-for-concept-request-referrer-policy">4. Referrer Policy Delivery</a>
     <li><a href="#ref-for-concept-request-referrer-policy①">7. Integration with CSS</a> <a href="#ref-for-concept-request-referrer-policy②">(2)</a> <a href="#ref-for-concept-request-referrer-policy③">(3)</a> <a href="#ref-for-concept-request-referrer-policy④">(4)</a>
     <li><a href="#ref-for-concept-request-referrer-policy⑤">8.2. 
-    Set request’s referrer policy on redirect </a>
-    <li><a href="#ref-for-concept-request-referrer-policy⑥">8.3. 
-    Determine request’s Referrer </a> <a href="#ref-for-concept-request-referrer-policy⑦">(2)</a> <a href="#ref-for-concept-request-referrer-policy⑧">(3)</a>
+    Set request’s referrer policy on redirect </a> <a href="#ref-for-concept-request-referrer-policy⑥">(2)</a>
+    <li><a href="#ref-for-concept-request-referrer-policy⑦">8.3. 
+    Determine request’s Referrer </a> <a href="#ref-for-concept-request-referrer-policy⑧">(2)</a> <a href="#ref-for-concept-request-referrer-policy⑨">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-concept-request">

--- a/index.src.html
+++ b/index.src.html
@@ -777,8 +777,7 @@ spec: html; type: element; text:script
   </h3>
 
   Given a <a for=/>request</a> |request| and a <a for=/>response</a> |actualResponse|,
-  this algorithm updates |request|'s associated
-  <a for=request>referrer policy</a>
+  this algorithm updates |request|'s <a for=request>referrer policy</a>
   according to the Referrer-Policy header (if any) in |actualResponse|.
 
   <ol>
@@ -786,8 +785,8 @@ spec: html; type: element; text:script
       Let |policy| be the result of executing
       [[#parse-referrer-policy-from-header]] on |actualResponse|.
     </li>
-    <li>If |policy| is not the empty string, then set |request|'s
-    associated referrer policy to |policy|.</li>
+    <li>If |policy| is not the empty string, then set |request|'s referrer policy
+    to |policy|.</li>
   </ol>
 
   <h3 id="determine-requests-referrer" dfn export>
@@ -795,14 +794,12 @@ spec: html; type: element; text:script
   </h3>
 
   Given a <a for=/>request</a> |request|, we can determine the correct
-  referrer information to send by examining the
-  <a for=request>referrer policy</a>
-  associated with it, as detailed in the following steps, which return
-  either <code>no referrer</code> or a URL:
+  referrer information to send by examining its <a for=request>referrer policy</a>
+  as detailed in the following steps, which return either <code>no referrer</code> or a URL:
 
   <ol>
     <li>
-      Let <var>policy</var> be |request|'s associated <a for=request>referrer policy</a>.
+      Let <var>policy</var> be |request|'s <a for=request>referrer policy</a>.
     </li>
     <li>
       Let <var>environment</var> be <var>request</var>'s <a for=request>client</a>.

--- a/index.src.html
+++ b/index.src.html
@@ -785,8 +785,8 @@ spec: html; type: element; text:script
       Let |policy| be the result of executing
       [[#parse-referrer-policy-from-header]] on |actualResponse|.
     </li>
-    <li>If |policy| is not the empty string, then set |request|'s referrer policy
-    to |policy|.</li>
+    <li>If |policy| is not the empty string, then set |request|'s
+    <a for=request>referrer policy</a> to |policy|.</li>
   </ol>
 
   <h3 id="determine-requests-referrer" dfn export>


### PR DESCRIPTION
Referrer policy exists as an actual concept on requests, so in the interest of brevity we can just use it directly without using "associated" at the same time, which IMO makes it sound less concrete.

This PR also replaces one instance of "referrer policy" with "<a for=request>referrer policy</a>" in an algorithm.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-referrer-policy/pull/146.html" title="Last updated on Jan 14, 2021, 6:13 PM UTC (01cd937)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-referrer-policy/146/bf0e0fc...01cd937.html" title="Last updated on Jan 14, 2021, 6:13 PM UTC (01cd937)">Diff</a>