### PR TITLE
Clarify the rare inheritance of referrer policy

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -648,7 +648,7 @@ spec: html; type: element; text:script
     <em>This section is not normative.</em>
 
     {{Document}}s don't typically inherit their <a for="Document">referrer policy</a> from other
-    {{Document}}s. However, there are two exceptions:
+    {{Document}}s. However, there are currently three cases where this happens:
     - Requests that do not provide their own <a for="request">referrer policy</a> and are initiated
       from <a>an <code>iframe</code> <code>srcdoc</code> document</a> that does not set its own
       <a for="Document">referrer policy</a> (via a <{meta}> tag) will use the
@@ -671,6 +671,9 @@ spec: html; type: element; text:script
           the first point above in this section.
         - For all other <a>browsing contexts</a>, the new {{Document}}'s <a for="Document">referrer
           policy</a> is inherited from the {{Document}} preceding the "<code>javascript:</code>" navigation.
+    - Upon <a spec=html lt="create a new browsing context">creation</a> of a new <a>browsing context</a>,
+      the initial <code><a spec=html>about:blank</a></code> {{Document}} will inherit its
+      <a for="Document">referrer policy</a> from its creator {{Document}} if the creator is non-null.
 
     Note: When a Policy Container is fully defined, the inheritance of <a for="/">referrer policies</a> or
     lack thereof will be more consistent and clear, as opposed to relying on subtle edge cases described above.

--- a/index.src.html
+++ b/index.src.html
@@ -643,7 +643,7 @@ spec: html; type: element; text:script
 
   <section class="informative">
     <h3 id="referrer-policy-inheritance"
-    oldids="referrer-policy-delivery-nested, referrer-policy-delivery-implicit"><a for="/">Referrer policy</a> Inheritance</h3>
+    oldids="referrer-policy-delivery-nested, referrer-policy-delivery-implicit"><a for="/">Referrer Policy</a> Inheritance</h3>
 
     <em>This section is not normative.</em>
 

--- a/index.src.html
+++ b/index.src.html
@@ -660,8 +660,8 @@ spec: html; type: element; text:script
     - If when a "<code>javascript:</code>" URL is <a spec=html
       lt="execute a javascript: URL request">executed</a>, the result of its evaluation is a string,
       then we populate a locally-created <a for="/">response</a> whose <code><a>Referrer-Policy</a></code>
-      header is the navigating <a>browsing context</a>'s <span>active document</span>'s <span>relevant
-      settings object</span>'s <a for="environment settings object">referrer policy</a>. The {{Document}}
+      header is the navigating <a>browsing context</a>'s <a>active document</a>'s <a>relevant settings
+      object</a>'s <a for="environment settings object">referrer policy</a>. The {{Document}}
       that gets created later as a result of the "<code>javascript:</code>" navigation is <a spec=html
       lt="create and initialize a Document object">initialized</a> with this <a for="/">referrer policy</a>.
       This means:

--- a/index.src.html
+++ b/index.src.html
@@ -53,6 +53,7 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/multipage/
       text: sandboxed origin browsing context flag
       text: sandboxing flag set
       text: top-level browsing context
+      text: browsing context
     urlPrefix: infrastructure.html
       text: ascii case-insensitive match; url: ascii-case-insensitive
       text: fragment; url: concept-url-fragment
@@ -641,15 +642,35 @@ spec: html; type: element; text:script
   </section>
 
   <section class="informative">
-    <h3 id="referrer-policy-delivery-nested"
-    oldids="referrer-policy-delivery-implicit">Nested browsing contexts</h3>
+    <h3 id="referrer-policy-inheritance"
+    oldids="referrer-policy-delivery-nested, referrer-policy-delivery-implicit"><a for="/">Referrer policy</a> Inheritance</h3>
 
     <em>This section is not normative.</em>
 
-    The HTML Standard and Fetch Standard define how nested browsing contexts
-    that are not created from <a for="/">responses</a>, such as <{iframe}> elements with
-    their <{iframe/srcdoc}> attribute set, or created from a blob URL, inherit
-    their <a for="/">referrer policy</a> from the creator browsing context or blob URL.
+    {{Document}}s don't typically inherit their <a for="Document">referrer policy</a> from other
+    {{Document}}s, however there are two exceptions:
+    - Requests that do not provide their own <a for="request">referrer policy</a> and are initiated
+      from <a>an <code>iframe</code> <code>srcdoc</code> document</a> that does not set its own
+      <a for="Document">referrer policy</a> (via a <{meta}> tag) will use the
+      <a for="Document">referrer policy</a> of its first ancestor <a spec=html>container document</a>
+      that is not <a>an <code>iframe</code> <code>srcdoc</code> document</a>. This is specified per
+      the definition of an <a for="environment settings object" lt="referrer policy">environment
+      settings object referrer policy</a>, thus effectively creating a form of <a for="/">referrer
+      policy</a> inheritance.
+    - If when a "<code>javascript:</code>" URL is <a spec=html
+      lt="execute a javascript: URL request">executed</a>, the result of its evaluation is a string,
+      then we populate a locally-created <a for="/">response</a> whose <code><a>Referrer-Policy</a></code>
+      header is the navigating <a>browsing context</a>'s <span>active document</span>'s <span>relevant
+      settings object</span>'s <a for="environment settings object">referrer policy</a>. The {{Document}}
+      that gets created later as a result of the "<code>javascript:</code>" navigation is <a spec=html
+      lt="create and initialize a Document object">initialized</a> with this <a for="/">referrer policy</a>.
+      This means:
+        - For <a>nested browsing contexts</a> whose <a>active document</a> is a <a>an <code>iframe</code>
+          <code>srcdoc</code> document</a> that experiences a "<code>javascript:</code>" navigation, the
+          resulting {{Document}} inherits its <a for="Document">referrer policy</a> in the way described by
+          the first point above in this section.
+        - For all other <a>browsing contexts</a>, the new {{Document}}'s <a for="Document">referrer
+          policy</a> is inherited from the {{Document}} preceding the "<code>javascript:</code>" navigation.
   </section>
 </section>
 

--- a/index.src.html
+++ b/index.src.html
@@ -671,6 +671,11 @@ spec: html; type: element; text:script
           the first point above in this section.
         - For all other <a>browsing contexts</a>, the new {{Document}}'s <a for="Document">referrer
           policy</a> is inherited from the {{Document}} preceding the "<code>javascript:</code>" navigation.
+
+    Note: When a Policy Container is fully defined, the inheritance of <a for="/">referrer policies</a> or
+    lack thereof will be more consistent and clear, as opposed to relying on subtle edge cases described above.
+    See <a href="https://github.com/whatwg/html/issues/4926">whatwg/html#4926</a> and the
+    <a href="https://github.com/antosart/policy-container-explained">Policy Container explainer</a>.
   </section>
 </section>
 

--- a/index.src.html
+++ b/index.src.html
@@ -665,7 +665,7 @@ spec: html; type: element; text:script
       that gets created later as a result of the "<code>javascript:</code>" navigation is <a spec=html
       lt="create and initialize a Document object">initialized</a> with this <a for="/">referrer policy</a>.
       This means:
-        - For <a>nested browsing contexts</a> whose <a>active document</a> is a <a>an <code>iframe</code>
+        - For <a>nested browsing contexts</a> whose <a>active document</a> is <a>an <code>iframe</code>
           <code>srcdoc</code> document</a> that experiences a "<code>javascript:</code>" navigation, the
           resulting {{Document}} inherits its <a for="Document">referrer policy</a> in the way described by
           the first point above in this section.

--- a/index.src.html
+++ b/index.src.html
@@ -648,7 +648,7 @@ spec: html; type: element; text:script
     <em>This section is not normative.</em>
 
     {{Document}}s don't typically inherit their <a for="Document">referrer policy</a> from other
-    {{Document}}s, however there are two exceptions:
+    {{Document}}s. However, there are two exceptions:
     - Requests that do not provide their own <a for="request">referrer policy</a> and are initiated
       from <a>an <code>iframe</code> <code>srcdoc</code> document</a> that does not set its own
       <a for="Document">referrer policy</a> (via a <{meta}> tag) will use the


### PR DESCRIPTION
This PR replaces the "Nested browsing context" section with a more general "Referrer Policy Inheritance" section that outlines what I see as the only two places where a referrer policy is ever effectively inherited:
 - For requests coming from an iframe srcdoc document, and...
 - During `javascript:` navigations

This section was previously wrong because it mentions that we only inherit the referrer policy for documents not created by a response, like srcdoc documents, however srcdoc documents are actually created from a (locally-created) response, so the previous text wasn't quite right. It also leaves out `javascript:` navigations which use locally-created responses as well when the JS evaluates to a string.

This section also used to mention "blob:" URLs, however from looking around in HTML as well as https://fetch.spec.whatwg.org/#concept-scheme-fetch I do not see any special referrer policy treatment in the "blob:" URL case ... maybe @annevk would know.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-referrer-policy/pull/148.html" title="Last updated on Jan 22, 2021, 6:48 PM UTC (a03517d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-referrer-policy/148/828435e...a03517d.html" title="Last updated on Jan 22, 2021, 6:48 PM UTC (a03517d)">Diff</a>