### PR TITLE
Editorial: Fix HTML markup conformance error

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -897,12 +897,11 @@ spec: html; type: element; text:script
       <a for="url">host</a>, replace it with an empty string, etc.
     </li>
     <li>
-      Execute the statements corresponding to the value of <var>policy</var>:
-
-      <dl class="switch">
+      Execute the statements corresponding to the value of <var>policy</var>:<br>
         Note: If <var>request</var>'s <a for=request>referrer policy</a> is
         the empty string, Fetch will not call into this algorithm.
 
+      <dl class="switch">
         <dt><a>"<code>no-referrer</code>"</a></dt>
         <dd>Return <code>no referrer</code></dd>
 


### PR DESCRIPTION
This fixes a problem in the source that causes non-conforming output (a `dl` element can’t have text nodes).


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-referrer-policy/pull/151.html" title="Last updated on Mar 12, 2021, 9:23 AM UTC (7685651)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-referrer-policy/151/8b762ea...7685651.html" title="Last updated on Mar 12, 2021, 9:23 AM UTC (7685651)">Diff</a>