### PR TITLE
Adapt to referrer policy being in policy container

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -647,38 +647,8 @@ spec: html; type: element; text:script
 
     <em>This section is not normative.</em>
 
-    {{Document}}s don't typically inherit their <a for="Document">referrer policy</a> from other
-    {{Document}}s. However, there are currently three cases where this happens:
-    - Requests that do not provide their own <a for="request">referrer policy</a> and are initiated
-      from <a>an <code>iframe</code> <code>srcdoc</code> document</a> that does not set its own
-      <a for="Document">referrer policy</a> (via a <{meta}> tag) will use the
-      <a for="Document">referrer policy</a> of its first ancestor <a spec=html>container document</a>
-      that is not <a>an <code>iframe</code> <code>srcdoc</code> document</a>. This is specified per
-      the definition of an <a for="environment settings object" lt="referrer policy">environment
-      settings object referrer policy</a>, thus effectively creating a form of <a for="/">referrer
-      policy</a> inheritance.
-    - If when a "<code>javascript:</code>" URL is <a spec=html
-      lt="execute a javascript: URL request">executed</a>, the result of its evaluation is a string,
-      then we populate a locally-created <a for="/">response</a> whose <code><a>Referrer-Policy</a></code>
-      header is the navigating <a>browsing context</a>'s <a>active document</a>'s <a>relevant settings
-      object</a>'s <a for="environment settings object">referrer policy</a>. The {{Document}}
-      that gets created later as a result of the "<code>javascript:</code>" navigation is <a spec=html
-      lt="create and initialize a Document object">initialized</a> with this <a for="/">referrer policy</a>.
-      This means:
-        - For <a>nested browsing contexts</a> whose <a>active document</a> is <a>an <code>iframe</code>
-          <code>srcdoc</code> document</a> that experiences a "<code>javascript:</code>" navigation, the
-          resulting {{Document}} inherits its <a for="Document">referrer policy</a> in the way described by
-          the first point above in this section.
-        - For all other <a>browsing contexts</a>, the new {{Document}}'s <a for="Document">referrer
-          policy</a> is inherited from the {{Document}} preceding the "<code>javascript:</code>" navigation.
-    - Upon <a spec=html lt="create a new browsing context">creation</a> of a new <a>browsing context</a>,
-      the initial <code><a spec=html>about:blank</a></code> {{Document}} will inherit its
-      <a for="Document">referrer policy</a> from its creator {{Document}} if the creator is non-null.
-
-    Note: When a Policy Container is fully defined, the inheritance of <a for="/">referrer policies</a> or
-    lack thereof will be more consistent and clear, as opposed to relying on subtle edge cases described above.
-    See <a href="https://github.com/whatwg/html/issues/4926">whatwg/html#4926</a> and the
-    <a href="https://github.com/antosart/policy-container-explained">Policy Container explainer</a>.
+    Referrer policy is inherited following the inheritance mechanism of
+    <a>policy containers</a>, as defined by HTML.
   </section>
 </section>
 
@@ -708,10 +678,9 @@ spec: html; type: element; text:script
 
   The HTML Standard determines the <a for="/">referrer policy</a> of any response
   received during <a>navigation</a> or while <a>running a worker</a>, and uses
-  the result to set the resulting {{Document}} or {{WorkerGlobalScope}}'s
-  referrer policy. This is later used by the corresponding <a>environment
-  settings object</a>, which serves as a <a for=request lt=client>request client</a> for <a
-  for=/ lt="fetch">fetches</a> it initiates.
+  the result to set the resulting {{Document}}'s <a for=document>policy
+  container</a>'s or {{WorkerGlobalScope}}'s <a for=WorkerGlobalScope>policy
+  container</a>'s <a for="policy container">referrer policy<a>.
 </section>
 
 <section>


### PR DESCRIPTION
This is a companion change to https://github.com/whatwg/html/pull/6677, which moves referrer policy into the policy container.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on May 12, 2021, 8:08 AM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [CSS Spec Preprocessor](https://api.csswg.org/bikeshed/) - CSS Spec Preprocessor is the web service used to build Bikeshed specs.

:link: [Related URL](https://api.csswg.org/bikeshed/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fantosart%2Fwebappsec-referrer-policy%2F73df7303f60edb9ce6cbe2c0907c66f326b74f95%2Findex.src.html&force=1&md-warning=not%20ready)



_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/webappsec-referrer-policy%23152.)._
</details>
