### PR TITLE
Fix policy container references in build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,10 +2,10 @@ name: Build
 on:
   pull_request:
     branches:
-    - master
+    - main
   push:
     branches:
-    - master
+    - main
 jobs:
   build:
     name: Build
@@ -15,7 +15,7 @@ jobs:
     - name: Build
       run: make ci
     - name: Deploy
-      if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+      if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
       uses: peaceiris/actions-gh-pages@v3
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/index.src.html
+++ b/index.src.html
@@ -648,7 +648,7 @@ spec: html; type: element; text:script
     <em>This section is not normative.</em>
 
     Referrer policy is inherited following the inheritance mechanism of
-    <a>policy containers</a>, as defined by HTML.
+    <a for="/">policy containers</a>, as defined by HTML.
   </section>
 </section>
 
@@ -678,9 +678,9 @@ spec: html; type: element; text:script
 
   The HTML Standard determines the <a for="/">referrer policy</a> of any response
   received during <a>navigation</a> or while <a>running a worker</a>, and uses
-  the result to set the resulting {{Document}}'s <a for=document>policy
+  the result to set the resulting {{Document}}'s <a for=Document>policy
   container</a>'s or {{WorkerGlobalScope}}'s <a for=WorkerGlobalScope>policy
-  container</a>'s <a for="policy container">referrer policy<a>.
+  container</a>'s <a for="policy container">referrer policy</a>.
 </section>
 
 <section>
@@ -701,7 +701,7 @@ spec: html; type: element; text:script
 
        Issue: This requires that CSS style sheets process `Referrer-Policy`
        headers, and store a <dfn for="CSSStyleSheet">referrer policy</dfn>
-       in the same way that <a for="Document" lt="referrer policy">Documents
+       in the same way that <a for="policy container" lt="referrer policy">Documents
        do</a>.
     </li>
 
@@ -712,7 +712,8 @@ spec: html; type: element; text:script
       <a>node document</a>'s <a for="Document">URL</a>, and the
       <a for="request">referrer policy</a> to its
       <a for="CSSStyleSheet">owner node</a>'s
-      <a>node document</a>'s <a for="Document">referrer policy</a>.
+      <a>node document</a>'s <a for="Document">policy container</a>'s
+      <a for="policy container">referrer policy</a>.
     </li>
 
     <li>
@@ -726,7 +727,8 @@ spec: html; type: element; text:script
        document</a>'s <a for="Document">URL</a>, and the
        <a for="request">referrer policy</a> to the block's
        <a for="CSSStyleDeclaration">owner node</a>'s <a>node document</a>'s
-       <a for="Document">referrer policy</a>.
+       <a for="Document">policy container</a>'s
+       <a for="policy container">referrer policy</a>.
     </li>
   </ol>
 


### PR DESCRIPTION
Fixes #154


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/antosart/webappsec-referrer-policy/pull/157.html" title="Last updated on Nov 10, 2021, 7:45 AM UTC (31fca19)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-referrer-policy/157/a5fc841...antosart:31fca19.html" title="Last updated on Nov 10, 2021, 7:45 AM UTC (31fca19)">Diff</a>