### PR TITLE
Fix 'Strip url for use as referrer'

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -987,7 +987,7 @@ spec: html; type: element; text:script
 
       <ol>
         <li>
-          Set <var>url</var>'s <a for=url>path</a> to « the empty string ».
+          Set <var>url</var>'s <a for=url>path</a> to « ».
         </li>
         <li>
           Set <var>url</var>'s <a for=url>query</a> to <code>null</code>.

--- a/index.src.html
+++ b/index.src.html
@@ -56,7 +56,6 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/multipage/
       text: browsing context
     urlPrefix: infrastructure.html
       text: ascii case-insensitive match; url: ascii-case-insensitive
-      text: fragment; url: concept-url-fragment
       text: document base url
       text: plugin
       text: reflect

--- a/index.src.html
+++ b/index.src.html
@@ -974,13 +974,13 @@ spec: html; type: element; text:script
       return <code>no referrer</code>.
     </li>
     <li>
-      Set <var>url</var>'s <a>username</a> to the empty string.
+      Set <var>url</var>'s <a for=url>username</a> to the empty string.
     </li>
     <li>
-      Set <var>url</var>'s <a>password</a> to <code>null</code>.
+      Set <var>url</var>'s <a for=url>password</a> to the empty string.
     </li>
     <li>
-      Set <var>url</var>'s <a>fragment</a> to <code>null</code>.
+      Set <var>url</var>'s <a for=url>fragment</a> to <code>null</code>.
     </li>
     <li>
       If the <code><a>origin-only flag</a></code> is <code>true</code>,
@@ -988,7 +988,7 @@ spec: html; type: element; text:script
 
       <ol>
         <li>
-          Set <var>url</var>'s <a for=url>path</a> to <code>null</code>.
+          Set <var>url</var>'s <a for=url>path</a> to « the empty string ».
         </li>
         <li>
           Set <var>url</var>'s <a for=url>query</a> to <code>null</code>.


### PR DESCRIPTION
This closes #153.

 - Set url's "password" to an empty string instead of null, since null is not an allowable type per the URL Standard
 - Same with "path"
 - Adds `for=url` on several `<a>` in this algorithm, since "fragment" was linking to HTML's infrastructure page


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-referrer-policy/pull/162.html" title="Last updated on May 24, 2022, 12:26 AM UTC (3321fcd)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-referrer-policy/162/a02b69a...3321fcd.html" title="Last updated on May 24, 2022, 12:26 AM UTC (3321fcd)">Diff</a>