### PR TITLE
Fix 'Strip url for use as referrer' to account for trailing slash

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -987,7 +987,7 @@ spec: html; type: element; text:script
 
       <ol>
         <li>
-          Set <var>url</var>'s <a for=url>path</a> to « ».
+          Set <var>url</var>'s <a for=url>path</a> to « the empty string ».
         </li>
         <li>
           Set <var>url</var>'s <a for=url>query</a> to <code>null</code>.


### PR DESCRIPTION
As Anne pointed out in https://github.com/w3c/webappsec-referrer-policy/pull/162#issuecomment-1135497605, the `String url for use as referrer` algorithm should set the path to `« the empty string »` so that the URL serializes with a trailing slash.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-referrer-policy/pull/163.html" title="Last updated on May 24, 2022, 1:01 PM UTC (b8d0b64)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-referrer-policy/163/2abd67a...b8d0b64.html" title="Last updated on May 24, 2022, 1:01 PM UTC (b8d0b64)">Diff</a>