### PR TITLE
Added IANA considerations section for HTTP header

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -1078,6 +1078,29 @@ spec: html; type: interface; text:Window
 
 </section>
 
+<section>
+  <h2 id="iana">IANA Considerations</h2>
+
+  The HTTP Field Name Registry is to be updated with the following
+  registration: [[!RFC9110]]
+
+  <dl>
+    <dt>Field name</dt>
+    <dd>Referrer-Policy</dd>
+
+    <dt>Status</dt>
+    <dd>permanent</dd>
+
+    <dt>Specification document(s)</dt>
+    <dd>This specification (See [[#referrer-policy-header]])</dd>
+
+    <dt>Comments</dt>
+    <dd>
+      The header name does not share the HTTP Referer header's misspelling.
+    </dd>
+  </dl>
+</section>
+
 <!--
    ███     ██████  ██    ██ ██    ██  ███████  ██      ██ ██       ████████ ████████   ██████   ████████ ██     ██ ████████ ██    ██ ████████  ██████
   ██ ██   ██    ██ ██   ██  ███   ██ ██     ██ ██  ██  ██ ██       ██       ██     ██ ██    ██  ██       ███   ███ ██       ███   ██    ██    ██    ██


### PR DESCRIPTION
This change adds an IANA Considerations section, with the intent to register the Referrer-Policy HTTP header. This should move #168 along.

-@stiiin


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/stiiin/webappsec-referrer-policy/pull/171.html" title="Last updated on Aug 24, 2024, 5:06 PM UTC (0d40542)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-referrer-policy/171/c7db4d9...stiiin:0d40542.html" title="Last updated on Aug 24, 2024, 5:06 PM UTC (0d40542)">Diff</a>