### PR TITLE
Update a step number referenced in the fetch spec

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -653,7 +653,7 @@ spec: html; type: interface; text:Window
 
   The Fetch specification calls out to
   [[#set-requests-referrer-policy-on-redirect]]
-  before [[fetch#http-redirect-fetch|Step 13 of the HTTP-redirect fetch]], so
+  before [[fetch#http-redirect-fetch|Step 19 of the HTTP-redirect fetch]], so
   that a request's referrer policy can be updated before following a redirect.
 
   The Fetch specification calls out to [[#determine-requests-referrer]]


### PR DESCRIPTION
The step number in the fetch spec related to #set-requests-referrer-policy-on-redirect has drifted from 13 to 19:

https://fetch.spec.whatwg.org/#concept-http-redirect-fetch


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/shanehandley/webappsec-referrer-policy/pull/173.html" title="Last updated on Nov 2, 2024, 3:03 AM UTC (8db5456)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-referrer-policy/173/1b0d34d...shanehandley:8db5456.html" title="Last updated on Nov 2, 2024, 3:03 AM UTC (8db5456)">Diff</a>