### PR TITLE
Handle the null fetch client case

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -803,6 +803,8 @@ spec: html; type: interface; text:Window
         <dt>"<code>client</code>"</dt>
         <dd>
           <ol>
+            <li>If |environment| is null, then return <code>no referrer</code>.</li>
+
             <li>
               If |environment|'s <a for="environment settings object">global
               object</a> is a {{Window}} object, then

--- a/index.src.html
+++ b/index.src.html
@@ -109,10 +109,11 @@ spec: RFC2616; urlPrefix: https://tools.ietf.org/html/rfc7231
 </pre>
 
 <pre class="link-defaults">
-spec: html; type: element; text: link;
-spec: html; type: element; text: a;
-spec: html; type: element; text:script
-spec: html; type: interface; text:Window
+spec: html; type: element; text: link
+spec: html; type: element; text: a
+spec: html; type: element; text: script
+spec: html; type: element; text: meta
+spec: html; type: interface; text: Window
 </pre>
 
 <!--


### PR DESCRIPTION
If referrer is left as "client" (the default) and there's no fetch client, the spec is currently broken. Instead, have it return no referrer.

The most prominent null client case is browser UI navigations, although there are possibly others where the browser creates a new window independently.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-referrer-policy/pull/175.html" title="Last updated on Jun 6, 2025, 1:19 AM UTC (54179c1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-referrer-policy/175/88f8f25...54179c1.html" title="Last updated on Jun 6, 2025, 1:19 AM UTC (54179c1)">Diff</a>