### PR TITLE
Use API base URL when determining referrer

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -828,8 +828,8 @@ spec: html; type: interface; text: Window
               </ol>
             </li>
 
-            <li>Otherwise, let |referrerSource| be |environment|'s <a for=environment>creation
-            URL</a>.</li>
+            <li>Otherwise, let |referrerSource| be |environment|'s
+              <a for="environment settings object">API base URL</a>.</li>
           </ol>
         </dd>
 


### PR DESCRIPTION
Based on an investigation as to why Servo
doesn't use the correct URL per the spec [1]
I thought that HTML was incorrectly setting
the creation URL [2].

However, after writing a WPT test [3] it turns
out that the creation URL is correctly set in
HTML, but incorrectly used in Referrer Policy.
Browsers don't use the creation URL to
determine the referrer policy, per another
WPT test [4].

Instead of the creation URL, browsers use the
url of the worker, which is the same as the
API base URL [5].

[1]: https://github.com/servo/servo/pull/41458
[2]: https://github.com/whatwg/html/pull/12038
[3]: https://github.com/web-platform-tests/wpt/pull/56921
[4]: https://wpt.fyi/results/fetch/api/basic/request-referrer-redirected-worker.html?label=master&label=experimental&aligned
[5]: https://html.spec.whatwg.org/multipage/workers.html#script-settings-for-workers:api-base-url


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/TimvdLippe/webappsec-referrer-policy/pull/177.html" title="Last updated on Dec 25, 2025, 10:22 AM UTC (b60f97a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-referrer-policy/177/2adab47...TimvdLippe:b60f97a.html" title="Last updated on Dec 25, 2025, 10:22 AM UTC (b60f97a)">Diff</a>