### PR TITLE
Update from api.csswg.org/bikeshed to spec-generator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,11 +15,12 @@ clean:
 	rm index.html
 
 index.html: index.src.html
-	@ (HTTP_STATUS=$$(curl https://api.csswg.org/bikeshed/ \
+	@ (HTTP_STATUS=$$(curl https://www.w3.org/publications/spec-generator/ \
 	                       --output index.html \
 	                       --write-out "%{http_code}" \
 	                       --header "Accept: text/plain, text/html" \
-			       -F die-on=warning \
+	                       -F type=bikeshed-spec \
+	                       -F die-on=warning \
 	                       -F file=@index.src.html) && \
 	[[ "$$HTTP_STATUS" -eq "200" ]]) || ( \
 		echo ""; cat index.html; echo ""; \


### PR DESCRIPTION
This updates the Makefile to reference spec-generator instead of the discontinued CSSWG Bikeshed service.

I've verified that `make index.html` runs successfully with output similar to the current ED; the only differences seem likely related to running with a newer Bikeshed version.